### PR TITLE
Adjust feature section paddings

### DIFF
--- a/src/components/patterns/ContentFeature.js
+++ b/src/components/patterns/ContentFeature.js
@@ -36,7 +36,7 @@ export default ({ image, children, title, flexDirection = 'left' }) => (
         maxWidth={['100%', '', '', 'none']}
       />
     </Box>
-    <Box px={4} textAlign={['center', '', '', 'left']}>
+    <Box flex={['', '', '', '1']} px={4} textAlign={['center', '', '', 'left']}>
       <Measure>{children}</Measure>
     </Box>
   </Flex>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -276,7 +276,7 @@ export default class extends Component {
         </Section>
 
         <Section bg='#FAFBFC' pb={5}>
-          <Container p={[4, 5]}>
+          <Container pt={[4, 5]}>
             <ContentFeature flexDirection='right' image='/img/link-preview.png'>
               <SectionSubhead
                 fontSize={[3, 5]}
@@ -418,7 +418,7 @@ export default class extends Component {
         </Section>
 
         <Section bg='#FAFBFC' pb={5}>
-          <Container p={[4, 5]}>
+          <Container pt={[4, 5]}>
             <ContentFeature
               flexDirection='right'
               image='/img/embed-support.png'

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -276,7 +276,7 @@ export default class extends Component {
         </Section>
 
         <Section bg='#FAFBFC' pb={5}>
-          <Container p={[2, 5]}>
+          <Container p={[4, 5]}>
             <ContentFeature flexDirection='right' image='/img/link-preview.png'>
               <SectionSubhead
                 fontSize={[3, 5]}
@@ -418,7 +418,7 @@ export default class extends Component {
         </Section>
 
         <Section bg='#FAFBFC' pb={5}>
-          <Container p={[2, 5]}>
+          <Container p={[4, 5]}>
             <ContentFeature
               flexDirection='right'
               image='/img/embed-support.png'


### PR DESCRIPTION
The paddings don't _match_ on the feature sections, causing this visual misalignment:

![image](https://user-images.githubusercontent.com/5795227/38279169-5c894e9c-379f-11e8-87be-e7a0c21e5502.png)

It's more noticeable on certain breakpoints than others.