### PR TITLE
Fix ContentFeature flex

### DIFF
--- a/src/components/patterns/ContentFeature.js
+++ b/src/components/patterns/ContentFeature.js
@@ -15,7 +15,7 @@ CustomImage.defaultProps = {
 
 export default ({ image, children, title, flexDirection = 'left' }) => (
   <Flex
-    alignContent={'center'}
+    align='center'
     flexDirection={[
       'column',
       '',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -276,7 +276,7 @@ export default class extends Component {
         </Section>
 
         <Section bg='#FAFBFC' pb={5}>
-          <Container p={[4, 5]}>
+          <Container pt={[4, 5]}>
             <ContentFeature flexDirection='right' image='/img/link-preview.png'>
               <SectionSubhead
                 fontSize={[3, 5]}
@@ -418,7 +418,7 @@ export default class extends Component {
         </Section>
 
         <Section bg='#FAFBFC' pb={5}>
-          <Container p={[4, 5]}>
+          <Container pt={[4, 5]}>
             <ContentFeature
               flexDirection='right'
               image='/img/embed-support.png'

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -276,7 +276,7 @@ export default class extends Component {
         </Section>
 
         <Section bg='#FAFBFC' pb={5}>
-          <Container p={[2, 5]}>
+          <Container p={[4, 5]}>
             <ContentFeature flexDirection='right' image='/img/link-preview.png'>
               <SectionSubhead
                 fontSize={[3, 5]}
@@ -418,7 +418,7 @@ export default class extends Component {
         </Section>
 
         <Section bg='#FAFBFC' pb={5}>
-          <Container p={[2, 5]}>
+          <Container p={[4, 5]}>
             <ContentFeature
               flexDirection='right'
               image='/img/embed-support.png'


### PR DESCRIPTION
Fixes features showing left-aligned when the `flex-direction` flips to `column`:

![image](https://user-images.githubusercontent.com/5795227/38279899-ce7368be-37a2-11e8-94fc-f405a7f90e54.png)
