### PR TITLE
Update `ContentFeature` pattern component

### DIFF
--- a/src/components/patterns/ContentFeature.js
+++ b/src/components/patterns/ContentFeature.js
@@ -15,7 +15,7 @@ CustomImage.defaultProps = {
 
 export default ({ image, children, title, flexDirection = 'left' }) => (
   <Flex
-    alignContent={'center'}
+    alignItems={'center'}
     flexDirection={[
       'column',
       '',


### PR DESCRIPTION
> The last version of rebass/styled-system renamed align into alignContent for Flexbox props

_Almost_ @Kikobeats, `align` === `alignItems`, that's why it wasn't centring 😅 