### PR TITLE
style(index): fix misalignment in Principles grid on Firefox

### DIFF
--- a/src/components/patterns/Grid.js
+++ b/src/components/patterns/Grid.js
@@ -9,6 +9,7 @@ const Item = ({ title, description, ...props }) => (
     px={[3, 4]}
     style={{ listStyle: 'none' }}
     maxWidth={['100%', '21em']}
+    flex={1}
     {...props}
   >
     <Caps


### PR DESCRIPTION
Firefox 70.0.1 is rendering some cells with different widths. Adding `flex: 1` fixes it, and keeps the layout unchanged in other browsers.

## Before (notice the 'Developer First' section)
![before](https://user-images.githubusercontent.com/416456/69185942-f6251480-0b17-11ea-802a-7884f9bf687d.png)

## After
![after](https://user-images.githubusercontent.com/416456/69185948-f9200500-0b17-11ea-9b56-831e38a526bd.png)

