### PR TITLE
refactor: sdk parameter integration examples

### DIFF
--- a/src/components/markdown/DemoIntegrations.js
+++ b/src/components/markdown/DemoIntegrations.js
@@ -1,0 +1,156 @@
+import React, { useMemo } from 'react'
+import kebabCase from 'lodash/kebabCase'
+
+import { Figcaption, Microlink, MultiCodeEditor } from 'components/markdown'
+
+const DEFAULT_URL_NAME = 'microlink.io'
+const DEFAULTS = {
+  url: 'https://microlink.io'
+}
+
+const chainItems = (items, quotes, object, wrapKey = false) =>
+  items
+    .map(key => {
+      const value = !object ? key : object[key]
+      const isString = typeof value === 'string'
+      const valueQuotes = isString ? quotes : ''
+      const wrappedValue = `${valueQuotes}${value}${valueQuotes}`
+
+      if (!object) {
+        return wrappedValue
+      }
+
+      const k = !wrapKey ? key : `${quotes}${key}${quotes}`
+
+      return `${k}: ${wrappedValue}`
+    })
+    .join(', ')
+
+const formatParam = (param, useRealJson = false) => {
+  const quotes = !useRealJson ? "'" : '"'
+
+  if (Array.isArray(param)) {
+    return `[${chainItems(param, quotes)}]`
+  }
+
+  if (typeof param === 'object') {
+    return `{ ${chainItems(Object.keys(param), quotes, param, useRealJson)} }`
+  }
+
+  return param
+}
+
+const DemoIntegrations = ({ caption, parameters = {}, showCard = true, urlName = DEFAULT_URL_NAME }) => {
+  const params = useMemo(() => ({ ...DEFAULTS, ...parameters }), [parameters])
+  const paramKeys = useMemo(() => Object.keys(params), [params])
+  const withoutUrl = useMemo(() => paramKeys.filter(k => k !== 'url'), [
+    paramKeys
+  ])
+
+  const react = useMemo(
+    () =>
+      paramKeys
+        .map(key => {
+          const param = params[key]
+
+          if (param === true) {
+            return key
+          }
+
+          const isString = typeof param === 'string'
+          const open = isString ? "'" : '{'
+          const close = isString ? "'" : '}'
+
+          return `${key}=${open}${formatParam(param)}${close}`
+        })
+        .join(' '),
+    [params, paramKeys]
+  )
+
+  const vue = useMemo(
+    () =>
+      paramKeys
+        .map(key => {
+          const param = params[key]
+          const prefix = typeof param === 'string' ? '' : ':'
+          const attr = `${prefix}${kebabCase(key)}`
+
+          return `${attr}="${formatParam(param)}"`
+        })
+        .join(' '),
+    [params, paramKeys]
+  )
+
+  const jsObject = useMemo(
+    () =>
+      withoutUrl
+        .map(key => {
+          const param = params[key]
+          const isString = typeof param === 'string'
+          const quotes = isString ? "'" : ''
+
+          return `${key}: ${quotes}${formatParam(param)}${quotes}`
+        })
+        .join(', '),
+    [params, withoutUrl]
+  )
+
+  const angular = useMemo(
+    () => (jsObject.length ? ` [options]="{ ${jsObject} }"` : ''),
+    [jsObject]
+  )
+
+  const jekyll = useMemo(() => {
+    const jParams = withoutUrl
+      .map(key => {
+        const param = params[key]
+        const attr = `data-${kebabCase(key)}`
+        const quotes = typeof param === 'object' ? "'" : '"'
+
+        return `${attr}=${quotes}${formatParam(param, true)}${quotes}`
+      })
+      .join(' ')
+
+    return jParams.length ? ` ${jParams}` : ''
+  }, [params, withoutUrl])
+
+  const vanilla = useMemo(() => (jsObject.length ? `, { ${jsObject} }` : ''), [
+    jsObject
+  ])
+
+  return (
+    <>
+      <MultiCodeEditor
+        languages={{
+          React: `import Microlink from '@microlink/react' 
+      
+export default () => (
+  <Microlink ${react} />
+)
+    `,
+          Vue: `<template>
+  <Microlink ${vue} />
+</template>
+    `,
+          Angular: `<microlink url="${params.url}"${angular}></microlink>
+          `,
+          Jekyll: `[](${params.url}){:.card-preview${jekyll}}`,
+          Vanilla: `<a href="${params.url}">${urlName}</a>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function (event) {
+    microlink('a'${vanilla})
+  })
+</script>
+    `
+        }}
+      />
+
+      {caption && <Figcaption children={caption} />}
+
+      {showCard && <Microlink {...params} />}
+    </>
+  )
+}
+
+export default DemoIntegrations

--- a/src/components/markdown/index.js
+++ b/src/components/markdown/index.js
@@ -20,6 +20,8 @@ import {
   Button
 } from 'components/elements'
 
+import DemoIntegrations from './DemoIntegrations'
+
 import MicrolinkBase from '../patterns/Microlink/Microlink'
 
 import { textGradient } from '../../theme'
@@ -357,6 +359,7 @@ const ScopedComponents = {
   Code,
   CodeInline,
   Container,
+  DemoIntegrations,
   Figcaption,
   H1,
   H2,

--- a/src/pages/docs/sdk/getting-started/considerations.md
+++ b/src/pages/docs/sdk/getting-started/considerations.md
@@ -2,7 +2,7 @@
 title: 'Considerations'
 ---
 
-The **Microlink SDK** is the way to consume [Microlink API](/docs/api) directly from your UI.
+The **Microlink SDK** is the way to consume [Microlink API](/docs/api/getting-started/overview) directly from your UI.
 
 Based on that premise, **Microlink SDK** has been designed with three things in mind:
 
@@ -12,7 +12,7 @@ Based on that premise, **Microlink SDK** has been designed with three things in 
 
 ## Pollyfills
 
-Since the **Microlink SDK** consumes the [Microlink API](/docs/api) and turns the raw data into a beautiful preview, it needs to perform an internal request to obtain it from the target URL.
+Since the **Microlink SDK** consumes the [Microlink API](/docs/api/getting-started/overview) and turns the raw data into a beautiful preview, it needs to perform an internal request to obtain it from the target URL.
 
 To do that, our integrations use the standard [Fetch API](https://developer.mozilla.org/es/docs/Web/API/Fetch_API). However, **Microlink SDK** doesn't add it as part of the bundle: It will take it from `window`.
 

--- a/src/pages/docs/sdk/getting-started/overview.md
+++ b/src/pages/docs/sdk/getting-started/overview.md
@@ -12,7 +12,7 @@ into a beautiful preview
 
 <Microlink url='https://instagram.com/p/BvDTdWdnzkj/' />
 
-**Microlink SDK** can detect video, audio or image automagically. Also, it supports some customizable things, like [size](size).
+**Microlink SDK** can detect video, audio or image automagically. Also, it supports some customizable things, like [size](/docs/sdk/parameters/size/).
 
 <Microlink url='https://instagram.com/p/BvDTdWdnzkj/' media='video' size='large' />
 

--- a/src/pages/docs/sdk/parameters/api-key.md
+++ b/src/pages/docs/sdk/parameters/api-key.md
@@ -6,27 +6,11 @@ Type: <Type children='<string>'/>
 
 The API Key associated with your plan for [authenticating](/docs/api/basics/authentication) your requests.
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://microlink.io'
-    apiKey='MyApiKey'
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { apiKey: 'MyApiKey' })
-  })
-</script>
-`, Jekyll: `
-[](https://microlink.io){:.card-preview data-apiKey='MyApiKey'}
-`}} 
+<DemoIntegrations
+  parameters={{apiKey: 'MyApiKey'}}
+  caption="The free daily quota will be used if you don't provide a registered API key."
+  showCard={false}
 />
-
-<Figcaption children="The free daily quota will be used if you don't provide a previously API key registered."  />
 
 When you do not attach an API Key, you are going to use the free quota until you reach the daily rate limit.
 

--- a/src/pages/docs/sdk/parameters/contrast.md
+++ b/src/pages/docs/sdk/parameters/contrast.md
@@ -7,27 +7,6 @@ Default: <Type children='false'/>
 
 When enabled, it will generate a high contrast card based on predominant colors detected in the feature image from the target URL.
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://instagram.com/p/BsMKPL2nDgX/'
-    contrast
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { contrast: true })
-  })
-</script>
-`, Jekyll: `
-[](https://instagram.com/p/BsMKPL2nDgX/){:.card-preview data-contrast='true'}
-`}} 
-/>
+<DemoIntegrations parameters={{url: '{{demolinks.instagram.url}}', contrast: true}} caption="The contrast mode has better accessibility ratio." urlName="instagram.com" />
 
-<Figcaption children="The contrast mode has better accessibility ratio."  />
-
-<Microlink url='https://instagram.com/p/BsMKPL2nDgX/' contrast />
-<Microlink url='https://instagram.com/p/BsMKPL2nDgX/' contrast size='large' />
+<Microlink url='{{demolinks.instagram.url}}' contrast size='large' />

--- a/src/pages/docs/sdk/parameters/direction.md
+++ b/src/pages/docs/sdk/parameters/direction.md
@@ -8,52 +8,10 @@ Values: <TypeContainer><Type children="'ltr'"/> | <Type children="'rtl'"/></Type
 
 Sets the direction of the card.
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://microlink.io'
-    media='logo'
-    direction='ltr'
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'logo', direction:'ltr' })
-  })
-</script>
-`, Jekyll: `
-[](https://microlink.io){:.card-preview data-media='logo' data-direction='ltr'}
-`}} 
-/>
+<DemoIntegrations parameters={{direction: 'ltr'}} />
 
-<Microlink url='https://microlink.io' media='logo' />
+<Figcaption children="The default direction is ltr."  />
 
-<Figcaption children="The default direction is rtl."  />
+Alternatively you can set <Type children="'rtl'"/>, that means *right-to-left*
 
-Alternatively you can set <Type children="'rtl'"/> that means *right-to-left*
-
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://microlink.io'
-    media='logo'
-    direction='rlt'
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'logo', direction:'rlt' })
-  })
-</script>
-`, Jekyll: `
-[](https://microlink.io){:.card-preview data-media='logo' data-direction='rlt'}
-`}} 
-/>
-
-<Microlink url='https://microlink.io' direction='rtl' media='logo' />
+<DemoIntegrations parameters={{direction: 'rtl'}} />

--- a/src/pages/docs/sdk/parameters/lazy.md
+++ b/src/pages/docs/sdk/parameters/lazy.md
@@ -7,48 +7,8 @@ Default: <Type children='true'/>
 
 When <Type children='true'/>, card content will be loaded lazily under the user's scroll behavior, using [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://microlink.io'
-    lazy
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { lazy: true })
-  })
-</script>
-`, Jekyll: `
-[](https://microlink.io){:.card-preview data-lazy='true'}
-`}} 
-/>
-
-<Figcaption children='Using `lazy` allows to load content on-demand, avoiding unnecessary API calls' />
+<DemoIntegrations caption="Using `lazy` allows to load content on-demand, avoiding unnecessary API calls" parameters={{lazy: true}} />
 
 Additionally, you can pass your own [IntersectionObserver options](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Intersection_observer_options) to customize when the card content should be fetched.
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://microlink.io'
-    lazy={{ threshold: 0.5 }}
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { threshold: 0.5 })
-  })
-</script>
-`, Jekyll: `
-[](https://microlink.io){:.card-preview data-lazy="{ 'threshold': 0.5 }"}
-`}} 
-/>
-
-<Figcaption children='The card content will be fetched when 50% of the card reaches the viewport.' />
+<DemoIntegrations caption="The card content will be fetched when 50% of the card reaches the viewport." parameters={{lazy: { threshold: 0.5 }}} />

--- a/src/pages/docs/sdk/parameters/media/auto-play.md
+++ b/src/pages/docs/sdk/parameters/media/auto-play.md
@@ -7,52 +7,9 @@ Default: <Type children='true'/>
 
 Determine if the media will automatically start playing as soon as it can do so without stopping.
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://instagram.com/p/BXHj-DllyYU'
-    media='video'
-    autoPlay
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'video', autoPlay: true })
-  })
-</script>
-`, Jekyll: `
-[](https://instagram.com/p/BXHj-DllyYU){:.card-preview data-media='video' data-auto-play='true'}
-`}} 
-/>
-
-<Microlink url='https://instagram.com/p/BXHj-DllyYU/' media='video' autoPlay />
-
-<Figcaption children='To control the media just hover with your cursor.' />
+<DemoIntegrations parameters={{url: '{{demolinks.instagram.url}}', media: 'video', autoPlay: true}} caption="To control the media just hover with your cursor." urlName="instagram.com" />
 
 The default behavior is to start the media playing; You can change that by passing `autoPlay: false`.
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://instagram.com/p/BXHj-DllyYU'
-    media='video'
-    autoPlay={false}
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'video', autoPlay: false })
-  })
-</script>
-`, Jekyll: `
-[](https://instagram.com/p/BXHj-DllyYU){:.card-preview data-media='video' data-auto-play='false'}
-`}} 
-/>
+<DemoIntegrations parameters={{url: '{{demolinks.instagram.url}}', media: 'video', autoPlay: false}} urlName="instagram.com" />
 
-<Microlink url='https://instagram.com/p/BXHj-DllyYU/' media='video' autoPlay={false} />

--- a/src/pages/docs/sdk/parameters/media/controls.md
+++ b/src/pages/docs/sdk/parameters/media/controls.md
@@ -9,52 +9,8 @@ Display UI controls for the card's media.
 
 with `controls` enabled:
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://instagram.com/p/BXHj-DllyYU/'
-    media='video'
-    autoPlay={false}
-    controls
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'video', autoPlay: false, controls: true })
-  })
-</script>
-`, Jekyll: `
-[](https://instagram.com/p/BXHj-DllyYU){:.card-preview data-media='video' data-autoPlay='false' data-controls='true'}
-`}} 
-/>
-
-<Microlink url='https://instagram.com/p/BXHj-DllyYU/' media='video' autoPlay={false} controls />
+<DemoIntegrations parameters={{url: '{{demolinks.instagram.url}}', media: 'video', controls: true}} urlName="instagram.com" />
 
 with `controls` disabled:
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://instagram.com/p/BXHj-DllyYU/'
-    media='video'
-    autoPlay={false}
-    controls={false}
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'video', autoPlay: false, controls: false })
-  })
-</script>
-`, Jekyll: `
-[](https://instagram.com/p/BXHj-DllyYU){:.card-preview data-media='video' data-autoPlay='false' data-controls='false'}
-`}} 
-/>
-
-<Microlink url='https://instagram.com/p/BXHj-DllyYU/' media='video' autoPlay={false} controls={false} />
+<DemoIntegrations parameters={{url: '{{demolinks.instagram.url}}', media: 'video', controls: false}} urlName="instagram.com" />

--- a/src/pages/docs/sdk/parameters/media/index.md
+++ b/src/pages/docs/sdk/parameters/media/index.md
@@ -8,122 +8,20 @@ Values: <TypeContainer><Type children="'audio'"/> | <Type children="'iframe'"/> 
 
 Determines the field to use as the media of the card.
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='{{demolinks.ted.url}}'
-    media={['image', 'logo']}
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: ['image', 'logo'] })
-  })
-</script>
-`, Jekyll: `
-[]({{demolinks.ted.url}}){:.card-preview data-media='image,logo'}
-`}} 
-/>
+<DemoIntegrations parameters={{url: '{{demolinks.ted.url}}', media: ['image', 'logo']}} caption="The default value is a collection of fields, meaning that the first valid value will be used as the image of the card." urlName="ted.com" />
 
-The default value is a collection of fields, meaning that the first valid value will be used as the image of the card.
+You can also pass a single value to be used instead, for example <Type children="'logo'"/>
 
-<Microlink url='{{demolinks.ted.url}}' />
-
-However, you can pass a single value to be used instead, for example <Type children="'logo'"/>
-
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='{{demolinks.ted.url}}'
-    media='logo'
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'logo' })
-  })
-</script>
-`, Jekyll: `
-[]({{demolinks.ted.url}}){:.card-preview data-media='logo'}
-`}} 
-/>
-
-<Microlink url='{{demolinks.ted.url}}' media='logo'/>
+<DemoIntegrations parameters={{url: '{{demolinks.ted.url}}', media: 'logo'}} urlName="ted.com" />
 
 The detection of <Type children="'video'"/> is also supported
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='{{demolinks.instagram.url}}'
-    media='video'
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'video' })
-  })
-</script>
-`, Jekyll: `
-[]({{demolinks.instagram.url}}){:.card-preview data-media='video'}
-`}} 
-/>
-
-<Microlink url='{{demolinks.instagram.url}}' media='video'/>
+<DemoIntegrations parameters={{url: '{{demolinks.instagram.url}}', media: 'video'}} urlName="instagram.com" />
 
 Also for <Type children="'audio'"/>
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://open.spotify.com/track/1W2919zs8SBCLTrOB1ftQT?si=4PcqgjH5RlWCvB5q4ukdnw'
-    media='audio'
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'audio' })
-  })
-</script>
-`, Jekyll: `
-[](https://open.spotify.com/track/1W2919zs8SBCLTrOB1ftQT?si=4PcqgjH5RlWCvB5q4ukdnw){:.card-preview data-media='audio'}
-`}} 
-/>
-
-<Microlink url='https://open.spotify.com/track/1W2919zs8SBCLTrOB1ftQT?si=4PcqgjH5RlWCvB5q4ukdnw' media='audio'/>
+<DemoIntegrations parameters={{url: '{{demolinks.spotify.url}}', media: 'audio'}} urlName="spotify.com" />
 
 Even <Type children="'iframe'"/>
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://instagram.com/p/BvDTdWdnzkj/'
-    media='iframe'
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'iframe' })
-  })
-</script>
-`, Jekyll: `
-[](https://instagram.com/p/BvDTdWdnzkj/){:.card-preview data-media='iframe'}
-`}} 
-/>
-
-<Microlink url='https://instagram.com/p/BvDTdWdnzkj/' media='iframe' />
+<DemoIntegrations parameters={{url: '{{demolinks.instagram.url}}', media: 'iframe'}} urlName="instagram.com" />

--- a/src/pages/docs/sdk/parameters/media/loop.md
+++ b/src/pages/docs/sdk/parameters/media/loop.md
@@ -9,52 +9,9 @@ Specifies if the media will start over again, every time it finishes.
 
 with `loop` enabled:
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://instagram.com/p/BXHj-DllyYU/'
-    media='video'
-    autoPlay={false}
-    loop
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'video', autoPlay: false, loop: true })
-  })
-</script>
-`, Jekyll: `
-[](https://instagram.com/p/BXHj-DllyYU/){:.card-preview data-media='video' data-autoPlay='false' data-loop='true'}
-`}} 
-/>
-
-<Microlink url='https://instagram.com/p/BXHj-DllyYU/' media='video' autoPlay={false} loop />
+<DemoIntegrations parameters={{url: '{{demolinks.instagram.url}}', media: 'video', autoPlay: false, loop: true }} urlName="instagram.com" />
 
 with `loop` disabled:
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://instagram.com/p/BXHj-DllyYU/'
-    media='video'
-    autoPlay={false}
-    loop={false}
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'video', autoPlay: false, loop: false })
-  })
-</script>
-`, Jekyll: `
-[](https://instagram.com/p/BXHj-DllyYU/){:.card-preview data-media='video' data-autoPlay='false' data-loop='false'}
-`}} 
-/>
+<DemoIntegrations parameters={{url: '{{demolinks.instagram.url}}', media: 'video', autoPlay: false, loop: false }} urlName="instagram.com" />
 
-<Microlink url='https://instagram.com/p/BXHj-DllyYU/' media='video' autoPlay={false} loop={false} />

--- a/src/pages/docs/sdk/parameters/media/muted.md
+++ b/src/pages/docs/sdk/parameters/media/muted.md
@@ -9,52 +9,8 @@ Specifies if the media should be muted.
 
 with `muted` enabled:
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://instagram.com/p/BvDTdWdnzkj/'
-    media='video'
-    autoPlay={false}
-    muted
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'video', autoPlay: false, muted: true })
-  })
-</script>
-`, Jekyll: `
-[](https://instagram.com/p/BvDTdWdnzkj/){:.card-preview data-media='video' data-autoPlay='false' data-muted='true'}
-`}} 
-/>
-
-<Microlink url='https://instagram.com/p/BvDTdWdnzkj/' media='video' autoPlay={false} />
+<DemoIntegrations parameters={{url: '{{demolinks.youtube.url}}', media: 'video', autoPlay: false, muted: true }} urlName="youtube.com" />
 
 with `muted` disabled:
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://instagram.com/p/BvDTdWdnzkj/'
-    media='video'
-    autoPlay={false}
-    muted={false}
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'video', autoPlay: false, muted: false })
-  })
-</script>
-`, Jekyll: `
-[](https://instagram.com/p/BvDTdWdnzkj/){:.card-preview data-media='video' data-autoPlay='false' data-muted='false'}
-`}} 
-/>
-
-<Microlink url='https://instagram.com/p/BvDTdWdnzkj/' media='video' autoPlay={false} muted={false} />
+<DemoIntegrations parameters={{url: '{{demolinks.youtube.url}}', media: 'video', autoPlay: false, muted: false }} urlName="youtube.com" />

--- a/src/pages/docs/sdk/parameters/set-data.md
+++ b/src/pages/docs/sdk/parameters/set-data.md
@@ -6,31 +6,7 @@ Type: <TypeContainer><Type children='<object>'/> | <Type children='<function>'/>
 
 Setup the content to be rendered into the card.
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://instagram.com/p/Bt6EMQhHHIr/'
-    setData={{
-      title: 'SENTRY ACTIVATED'
-    }}
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { setData: { title: 'SENTRY ACTIVATED' } })
-  })
-</script>
-`, Jekyll: `
-[](https://microlink.io){:.card-preview data-media='logo' data-set-data='{"title": "SENTRY ACTIVATED"'}
-`}} 
-/>
-
-<Figcaption children='The data provided will be merged with the original data extracted.' />
-
-<Microlink url='https://instagram.com/p/Bt6EMQhHHIr/' setData={{title: 'SENTRY ACTIVATED' }}/>
+<DemoIntegrations parameters={{url: '{{demolinks.instagram.url}}', setData: { title: 'SENTRY ACTIVATED' }}} caption="The data provided will be merged with the original data extracted." urlName="instagram.com" />
 
 When an <Type children='<object>'/> is passed to `setData`, the custom data provided will be merged with the original data.
 
@@ -41,7 +17,7 @@ import Microlink from '@microlink/react'
 
 export default () => (
   <Microlink
-    url='https://instagram.com/p/Bt6EMQhHHIr/'
+    url='{{demolinks.instagram.url}}'
     setData={() => ({
       title: 'SENTRY ACTIVATED',
       description: 'Are humans worth it?',
@@ -55,9 +31,9 @@ export default () => (
 
 <Figcaption children='Skip internal fetch providing a function as setData.' />
 
-In that case, the function should be return all the data necessary to be mounted.
+In that case, the function should return all the data necessary to be mounted.
 
-<Microlink url='https://instagram.com/p/Bt6EMQhHHIr/' setData={() => ({
+<Microlink url='{{demolinks.instagram.url}}' setData={() => ({
   title: 'SENTRY ACTIVATED',
   description: 'Are humans worth it?',
   image: { url: 'https://i.imgur.com/1FyFxlk.jpg' },

--- a/src/pages/docs/sdk/parameters/size.md
+++ b/src/pages/docs/sdk/parameters/size.md
@@ -8,38 +8,8 @@ Values: <TypeContainer><Type children="'small'"/> | <Type children="'normal'"/> 
 
 Determines the size of the card.
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <>
-  <Microlink
-    url='https://microlink.io'
-    media='logo'
-    size='small'
-  />
-  <Microlink
-    url='https://microlink.io'
-    media='image'
-  />
-  <Microlink
-    url='https://microlink.io'
-    media='video'
-    size='large'
-  />
-  </>
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a', { media: 'logo', size: 'normal' })
-  })
-</script>
-`, Jekyll: `
-[](https://microlink.io){:.card-preview data-media='logo' data-size='normal'}
-`}} 
-/>
+<DemoIntegrations parameters={{ size: 'small', media: 'logo' }} />
 
-<Microlink url='https://microlink.io' media='logo' size='small' />
-<Microlink url='https://microlink.io' media='logo' />
-<Microlink url='https://microlink.io' media='logo' size='large' />
+<DemoIntegrations parameters={{ media: 'logo' }} />
+
+<DemoIntegrations parameters={{ size: 'large', media: 'logo' }} />

--- a/src/pages/docs/sdk/parameters/url.md
+++ b/src/pages/docs/sdk/parameters/url.md
@@ -8,29 +8,7 @@ Type: <Type children='<string>'/>
 
 The target URL for getting information based on the content.
 
-<MultiCodeEditor languages={{
-  React: `import Microlink from '@microlink/react' 
-  
-export default () => (
-  <Microlink
-    url='https://microlink.io'
-  />
-)
-`, Vanilla: `
-<script>
-  document.addEventListener('DOMContentLoaded', function (event) {
-    microlink('a')
-  })
-</script>
-`, Jekyll: `
-[](https://microlink.io){:.card-preview}
-`}} 
-/>
-
-
-<Figcaption children='`url` is the only required api parameter.' />
-
-<Microlink url='https://microlink.io' media='logo' />
+<DemoIntegrations caption="`url` is the only required api parameter." />
 
 It should be reachable by the service. For example, if you want to extract content behind a login panel, the URL provided should contain the authentication step as part of the query string.
 


### PR DESCRIPTION
+ Make adding docs for SDK parameters easier via `DemoIntegrations` component
+ Use demolinks
+ Fix broken links