### PR TITLE
fix: update the url to the documentation using the correct url

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -65,12 +65,19 @@ const Questions = props => (
             The API key need to be attached to all your requests:
             <Box as='ul' pt={3} my={0}>
               <Box as='li'>
-                At <Link href='/docs/sdk/'>Microlink SDK</Link>, attach it as{' '}
+                At{' '}
+                <Link href='/docs/sdk/getting-started/overview'>
+                  Microlink SDK
+                </Link>
+                , attach it as{' '}
                 <Link href='/docs/sdk/parameters/api-key/'>apiKey</Link>.
               </Box>
               <Box as='li' pt={3}>
-                At <Link href='/docs/api/#introduction'>Microlink API</Link>,
-                attach it as{' '}
+                At{' '}
+                <Link href='/docs/api/getting-started/overview'>
+                  Microlink API
+                </Link>
+                , attach it as{' '}
                 <Link href='/docs/api/basics/authentication'>header</Link>.
               </Box>
             </Box>


### PR DESCRIPTION
Update incorrect URLs to documentation on public site