### PR TITLE
Fixed typo

### DIFF
--- a/src/pages/docs/mql/getting-started/installation.md
+++ b/src/pages/docs/mql/getting-started/installation.md
@@ -27,7 +27,7 @@ console.log(`The avatar URL is '${data.avatar.url}' (${data.avatar.size_pretty})
 It's ready to be consumed as **ESM**:
 
 ```js
-import mql from 'microlink/mql'
+import mql from '@microlink/mql'
 
 const { data } = await mql('https://kikobeats.com', {
   data: {


### PR DESCRIPTION
In ESM import module example code, `import mql from '@microlink/mql'` is written as `import mql from 'microlink/mql'`