### PR TITLE
chore: remove gatsby-plugin-loadable-components-ssr

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -43,7 +43,6 @@ module.exports = {
     cdnUrl: CDN_URL
   },
   plugins: [
-    'gatsby-plugin-loadable-components-ssr',
     'gatsby-plugin-styled-components',
     'gatsby-plugin-react-helmet',
     'gatsby-plugin-catch-links',

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "gatsby-plugin-canonical-urls": "~3.7.1",
     "gatsby-plugin-catch-links": "~3.7.1",
     "gatsby-plugin-google-analytics": "~3.7.1",
-    "gatsby-plugin-loadable-components-ssr": "~3.1.0",
     "gatsby-plugin-react-helmet": "~4.7.1",
     "gatsby-plugin-remove-trailing-slashes": "~3.7.1",
     "gatsby-plugin-sass": "~4.7.1",


### PR DESCRIPTION
unfortunately the build is reporting problems:

```
jsonp chunk loading:27 Uncaught (in promise) ChunkLoadError: Loading chunk 234 failed.
(error: https://microlink.io/58917679-07ddb7596531004249f9.js)
    at Object.f.f.j (jsonp chunk loading:27)
    at ensure chunk:6
    at Array.reduce (<anonymous>)
    at Function.f.e (ensure chunk:5)
    at Object.component---src-pages-index-js (async-requires.js:10)
    at t.loadComponent (loader.js:499)
    at loader.js:247
```