### PR TITLE
Fix typo

### DIFF
--- a/src/pages/meta.js
+++ b/src/pages/meta.js
@@ -695,7 +695,7 @@ const MetaPage = () => {
                       textAlign='left'
                       titleize={false}
                     >
-                      less responsability.
+                      less responsibility.
                     </Subhead>
                   </>
                 }


### PR DESCRIPTION
`responsability` → `responsibility`