### PR TITLE
fix(doc): align active with border

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Concise rules for building accessible, fast, delightful UIs. Use MUST/SHOULD/NEV
 - NEVER: Use raw token interpolation (for example `font-size: ${fontSizes[0]}`) when the same style can be expressed via `theme({...})`.
 - NEVER: Split tokenized style values across raw CSS and multiple `theme(...)` calls when one `theme({...})` object can express them.
 - NEVER: Add media queries only to change styled-system token values that can be expressed as responsive arrays/objects in `theme({...})`.
+- MUST: When a `styled(Flex)` (or other display primitive) needs to hide below the first breakpoint and restore layout above it, use `display: ['none', 'inherit']` (or `d: [...]`) instead of repeating `flex` or hand-writing `@media` blocks that only change `display`. `inherit` copies the **parent element’s** `display` at larger breakpoints—so the parent must be a flex container (`display: flex`) when the child must resolve to `flex`; otherwise use `display: ['none', 'flex']` explicitly. Avoid duplicating the primitive’s `display` keyword in the array when `inherit` is correct.
 - SHOULD: Keep raw CSS only for unsupported/states-only patterns (for example keyframes, browser-specific values, or dynamic runtime computed styles).
 
 ## Interactions

--- a/src/components/patterns/DocTabs/DocTabs.js
+++ b/src/components/patterns/DocTabs/DocTabs.js
@@ -1,21 +1,24 @@
 import { Link } from 'components/elements/Link'
 import Flex from 'components/elements/Flex'
 import Text from 'components/elements/Text'
+import { theme, transition } from 'theme'
 import Box from 'components/elements/Box'
 import styled from 'styled-components'
-import { theme } from 'theme'
 import React from 'react'
 
 import { DOC_TABS } from 'components/patterns/Aside/constants'
 
 const TabButton = styled(Link)`
+  transition: color ${transition.medium}, border-color ${transition.medium};
+
   ${theme({
     px: 3,
     py: 3,
     textDecoration: 'none',
     cursor: 'pointer',
     fontWeight: 500,
-    transition: 'all 0.2s ease'
+    borderBottom: 2,
+    borderBottomColor: 'transparent'
   })}
 
   &:hover {
@@ -24,8 +27,7 @@ const TabButton = styled(Link)`
 
   &.active {
     ${theme({
-      borderBottom: 2,
-      borderColor: 'black',
+      borderBottomColor: 'black',
       fontWeight: 600
     })}
   }

--- a/src/components/patterns/Layout.js
+++ b/src/components/patterns/Layout.js
@@ -65,6 +65,8 @@ const Root = styled(Flex)`
 
 const Main = styled(Box)`
   ${themeProp({
+    display: 'flex',
+    flexDirection: 'column',
     pt: TOOLBAR_HEIGHTS,
     mt: [0, 0, 4],
     px: [3, 3, 0],

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -43,15 +43,16 @@ const DocsHeaderBackdrop = styled(Box)`
   })}
 `
 
-const DocsNavbar = styled(Box)`
+const DocsNavbar = styled(Flex)`
   ${theme({
     position: 'fixed',
     top: TOOLBAR_PRIMARY_HEIGHT,
     left: 0,
     right: 0,
     zIndex: 100,
-    background: 'transparent',
-    display: ['none', 'block']
+    alignItems: 'flex-end',
+    height: DOCS_NAVBAR_HEIGHT,
+    display: ['none', 'inherit']
   })}
 `
 
@@ -59,7 +60,8 @@ const DocsNavbarContainer = styled(Container)`
   ${theme({
     px: 0,
     pt: 0,
-    maxWidth: layout.large
+    maxWidth: layout.large,
+    width: '100%'
   })}
 `
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk styling/layout tweaks limited to docs navigation and main layout container; primary risk is minor responsive layout regressions at breakpoints.
> 
> **Overview**
> Updates `DocTabs` styling to use explicit `color`/`border-color` transitions and a consistent `borderBottomColor` approach so the active tab border aligns correctly.
> 
> Refactors the docs navbar to be a `Flex` container that hides on mobile and restores layout via `display: ['none', 'inherit']`, adds required flex layout to `Layout`’s `Main`, and ensures the navbar container spans full width.
> 
> Documents the new responsive `display: ['none','inherit']` guideline in `AGENTS.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4a980ffd5fb72e0ba091620671cac1cc724678b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->