### PR TITLE
docs: ad EINVALDATA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,6 @@ jobs:
         with:
           version: latest
       - name: Install
-        run: pnpm install --ignore-scripts
+        run: pnpm install --dangerously-allow-all-builds
       - name: Test
         run: pnpm test

--- a/src/content/docs/api/basics/error-codes.md
+++ b/src/content/docs/api/basics/error-codes.md
@@ -163,6 +163,32 @@ The [function](/docs/api/parameters/function) parameter contains invalid JavaScr
 - Uses proper function formatting (arrow function or regular function)
 - Doesn't contain syntax errors like missing brackets or semicolons
 
+## EINVALDATA
+
+**Message**
+
+The `data.<field>` has an invalid value (`<value>`). rule must be an object (or array of objects) with extraction options.
+
+Example:
+
+The `data.innerHTML` has an invalid value (empty). rule must be an object (or array of objects) with extraction options.
+
+**Solution**
+
+Use object rules for [data](/docs/api/parameters/data) extraction instead of primitive values.
+
+Valid:
+
+- `data.title.selector=h1`
+- `data.price.selector=.price&data.price.attr=text`
+- `data.links.selectorAll=a&data.links.attr=href`
+
+Invalid:
+
+- `data.innerHTML=`
+- `data.foo=html`
+- `data.bar=false`
+
 ## EINVALSTTL
 
 **Message**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI now runs dependency build/lifecycle scripts via `pnpm install --dangerously-allow-all-builds`, which can change test behavior and slightly increases supply-chain risk. The rest is documentation-only.
> 
> **Overview**
> Updates the GitHub Actions test workflow to install dependencies with `pnpm install --dangerously-allow-all-builds` instead of `--ignore-scripts`, enabling package build/lifecycle scripts during CI.
> 
> Adds documentation for the new `EINVALDATA` API error code, including message format and examples of valid vs invalid `data` extraction rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a1fd6e863553f000cb804c9eb1d7e77f3f741b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->