### PR TITLE
ci: add visual diff

### DIFF
--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -22,6 +22,7 @@ jobs:
           head: vercel
           routes: |
             - '/'
+            - '/styleguide'
           threshold: "0.005"
           microlink-api-key: ${{ secrets.MICROLINK_API_KEY }}
           s3-config: ${{ secrets.S3_CONFIG }}

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -1,0 +1,27 @@
+name: Visual diff
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+
+permissions:
+  pull-requests: write
+  deployments: read
+
+jobs:
+  visual-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: microlinkhq/difftool@master
+        with:
+          base: https://microlink.io
+          head: vercel
+          routes: |
+            - '/'
+          threshold: "0.005"
+          microlink-api-key: ${{ secrets.MICROLINK_API_KEY }}
+          s3-config: ${{ secrets.S3_CONFIG }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new PR-triggered GitHub Action that uses third-party `microlinkhq/difftool@master` with PR write permissions and secrets, which could impact CI reliability and introduces some supply-chain/permissions risk.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/visual-diff.yml`) that runs on pull request events to perform automated visual diffs.
> 
> The job uses `microlinkhq/difftool@master` to compare `https://microlink.io` against the Vercel preview for `/` and `/styleguide` with a `0.005` threshold, posting results to the PR and storing artifacts via `MICROLINK_API_KEY` and `S3_CONFIG` secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23eafe12ef650418ea8b9f67ee3f08b6c6af068a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automated visual diff checks on PRs to catch UI regressions and comment the results.

- **New Features**
  - Adds a GitHub Actions workflow using `microlinkhq/difftool` on PR open/sync/reopen/close.
  - Compares `https://microlink.io` vs `vercel` preview for `/` and `/styleguide` with a 0.5% threshold.
  - Uploads diffs to S3 (`S3_CONFIG`), auth via `MICROLINK_API_KEY`.

<sup>Written for commit 23eafe12ef650418ea8b9f67ee3f08b6c6af068a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

