### PR TITLE
chore: update customers landings ui

### DIFF
--- a/src/pages/customers/index.js
+++ b/src/pages/customers/index.js
@@ -23,10 +23,10 @@ import Layout from 'components/patterns/Layout'
 import { cdnUrl } from 'helpers/cdn-url'
 
 const ACCENT = {
-  text: 'orange7',
-  bgSoft: 'orange0',
-  bgEdge: 'orange1',
-  highlight: 'orange5'
+  text: 'blue7',
+  bgSoft: 'blue0',
+  bgEdge: 'blue1',
+  highlight: 'blue5'
 }
 
 /* ─── Hero ───────────────────────────────────────────────────────────────── */

--- a/src/pages/customers/luckynote.js
+++ b/src/pages/customers/luckynote.js
@@ -30,10 +30,10 @@ import Layout from 'components/patterns/Layout'
 import { cdnUrl } from 'helpers/cdn-url'
 
 const ACCENT = {
-  text: 'orange7',
-  bgSoft: 'orange0',
-  bgEdge: 'orange1',
-  highlight: 'orange5'
+  text: 'blue7',
+  bgSoft: 'blue0',
+  bgEdge: 'blue1',
+  highlight: 'blue5'
 }
 
 /* ─── Hero ───────────────────────────────────────────────────────────────── */

--- a/src/pages/customers/mymahi.js
+++ b/src/pages/customers/mymahi.js
@@ -28,10 +28,10 @@ import {
 import Layout from 'components/patterns/Layout'
 
 const ACCENT = {
-  text: 'orange7',
-  bgSoft: 'orange0',
-  bgEdge: 'orange1',
-  highlight: 'orange5'
+  text: 'blue7',
+  bgSoft: 'blue0',
+  bgEdge: 'blue1',
+  highlight: 'blue5'
 }
 
 /* ─── Hero ───────────────────────────────────────────────────────────────── */

--- a/src/pages/customers/r-advertising.js
+++ b/src/pages/customers/r-advertising.js
@@ -30,10 +30,10 @@ import Layout from 'components/patterns/Layout'
 import { cdnUrl } from 'helpers/cdn-url'
 
 const ACCENT = {
-  text: 'orange7',
-  bgSoft: 'orange0',
-  bgEdge: 'orange1',
-  highlight: 'orange5'
+  text: 'blue7',
+  bgSoft: 'blue0',
+  bgEdge: 'blue1',
+  highlight: 'blue5'
 }
 
 /* ─── Hero ───────────────────────────────────────────────────────────────── */


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched customer landing pages from the orange accent theme to blue for a consistent, updated look. Updates text, background, and highlight styles via the `ACCENT` token.

- **Refactors**
  - Updated `ACCENT` to blue: `text: 'blue7'`, `bgSoft: 'blue0'`, `bgEdge: 'blue1'`, `highlight: 'blue5'`.
  - Applied to `customers/index`, `luckynote`, `mymahi`, and `r-advertising` pages.

<sup>Written for commit dbd7bb2e98da8daf4c00fc322925ec565599c76d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

