### PR TITLE
refactor(embed): tweaks

### DIFF
--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -479,7 +479,7 @@
   "src/pages/docs/sdk/parameters/size.md": "2020-02-05T16:24:58.000Z",
   "src/pages/docs/sdk/parameters/url.md": "2020-03-29T11:24:22.000Z",
   "src/pages/dpa.md": "2025-07-01T19:16:55.000Z",
-  "src/pages/embed.js": "2026-05-21T11:22:09.000Z",
+  "src/pages/embed.js": "2026-05-26T11:18:07.000Z",
   "src/pages/embed/examples.js": "2019-06-09T18:57:52.000Z",
   "src/pages/embed/index.js": "2019-06-09T18:57:52.000Z",
   "src/pages/embed/template.js": "2019-06-09T18:57:52.000Z",

--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -523,7 +523,7 @@
   "src/pages/subprocessors.md": "2025-07-01T19:16:55.000Z",
   "src/pages/terms.js": "2018-08-20T15:55:21.000Z",
   "src/pages/tools.js": "2026-05-15T14:30:09.000Z",
-  "src/pages/tools/embed-url.js": "2026-05-26T10:14:32.000Z",
+  "src/pages/tools/embed-url.js": "2026-05-26T11:04:42.000Z",
   "src/pages/tools/sharing-debugger.js": "2026-03-18T14:10:19.000Z",
   "src/pages/tools/url-to-markdown.js": "2026-04-29T09:02:20.000Z",
   "src/pages/tools/website-screenshot.js": "2026-04-29T08:52:10.000Z",

--- a/src/pages/embed.js
+++ b/src/pages/embed.js
@@ -720,9 +720,13 @@ const ProvidersSlider = styled(BackgroundSliderContainer)`
 `
 
 const ProviderSliderRow = styled(Flex)`
-  ${theme({ alignItems: 'center', gap: [3, 3, 4, 4], pr: [3, 3, 4, 4] })};
-  display: inline-flex;
-  flex-wrap: nowrap;
+  ${theme({
+    alignItems: 'center',
+    gap: [3, 3, 4, 4],
+    pr: [3, 3, 4, 4],
+    display: 'inline-flex',
+    flexWrap: 'nowrap'
+  })};
 `
 
 const ProviderChip = styled(Flex)`
@@ -736,13 +740,14 @@ const ProviderChip = styled(Flex)`
     fontWeight: 'bold',
     color: 'black80',
     alignItems: 'center',
-    gap: 2
+    gap: 2,
+    border: 1,
+    borderColor: 'black10',
+    whiteSpace: 'nowrap',
+    flex: '0 0 auto',
+    letterSpacing: 0,
+    lineHeight: 1
   })};
-  border: ${borders[1]} ${colors.black10};
-  white-space: nowrap;
-  flex: 0 0 auto;
-  letter-spacing: 0;
-  line-height: 1;
 `
 
 const ProviderIcon = ({ icon }) => (

--- a/src/pages/embed.js
+++ b/src/pages/embed.js
@@ -15,6 +15,10 @@ import { cdnUrl } from 'helpers/cdn-url'
 import { trackEvent } from 'helpers/plausible'
 
 import Box from 'components/elements/Box'
+import {
+  BackgroundSlider,
+  BackgroundSliderContainer
+} from 'components/elements/BackgroundSlider/BackgroundSlider'
 import Caps from 'components/elements/Caps'
 import CodeEditor from 'components/elements/CodeEditor/CodeEditor'
 import Container from 'components/elements/Container'
@@ -680,15 +684,25 @@ const FEATURED_PROVIDERS = [
   { name: 'Bandcamp', icon: siBandcamp }
 ]
 
-const MARQUEE_DURATION = '60s'
+const PROVIDER_SLIDER_ROWS = 3
+const PROVIDER_SLIDER_DURATION = 80
 
-const marqueeScroll = keyframes`
-  from { transform: translate3d(0, 0, 0); }
-  to { transform: translate3d(-50%, 0, 0); }
-`
+const PROVIDER_ROWS = Array.from(
+  { length: PROVIDER_SLIDER_ROWS },
+  (_, rowIndex) =>
+    FEATURED_PROVIDERS.filter(
+      (_, index) => index % PROVIDER_SLIDER_ROWS === rowIndex
+    )
+)
 
-const ProvidersMarquee = styled(Box)`
-  ${theme({ width: '100%', overflow: 'hidden' })};
+const ProvidersSlider = styled(BackgroundSliderContainer)`
+  ${theme({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 3,
+    width: '100%',
+    overflow: 'hidden'
+  })};
   -webkit-mask-image: linear-gradient(
     to right,
     transparent 0,
@@ -705,19 +719,10 @@ const ProvidersMarquee = styled(Box)`
   );
 `
 
-const ProvidersTrack = styled(Flex)`
-  ${theme({ alignItems: 'center', gap: 2 })};
-  width: max-content;
+const ProviderSliderRow = styled(Flex)`
+  ${theme({ alignItems: 'center', gap: [3, 3, 4, 4], pr: [3, 3, 4, 4] })};
+  display: inline-flex;
   flex-wrap: nowrap;
-  animation: ${marqueeScroll} ${MARQUEE_DURATION} linear infinite;
-  will-change: transform;
-
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-    flex-wrap: wrap;
-    width: 100%;
-    justify-content: center;
-  }
 `
 
 const ProviderChip = styled(Flex)`
@@ -725,7 +730,7 @@ const ProviderChip = styled(Flex)`
     px: 3,
     py: 2,
     borderRadius: 5,
-    bg: 'white',
+    bg: 'white80',
     fontFamily: 'mono',
     fontSize: 1,
     fontWeight: 'bold',
@@ -804,18 +809,24 @@ const Providers = () => {
         Observable, Streamable, Wistia, Loom, SlideShare, Kickstarter,
         DeviantArt, Imgur, Bandcamp, and more.
       </Box>
-      <ProvidersMarquee aria-hidden='true'>
-        <ProvidersTrack>
-          {[...FEATURED_PROVIDERS, ...FEATURED_PROVIDERS].map(
-            ({ name, icon }, index) => (
-              <ProviderChip key={`${name}-${index}`}>
-                <ProviderIcon icon={icon} />
-                {name}
-              </ProviderChip>
-            )
-          )}
-        </ProvidersTrack>
-      </ProvidersMarquee>
+      <ProvidersSlider aria-hidden='true'>
+        {PROVIDER_ROWS.map((providers, rowIndex) => (
+          <BackgroundSlider
+            key={rowIndex}
+            duration={PROVIDER_SLIDER_DURATION}
+            animationDirection={rowIndex % 2 === 0 ? 'reverse' : 'normal'}
+          >
+            <ProviderSliderRow>
+              {providers.map(({ name, icon }) => (
+                <ProviderChip key={name}>
+                  <ProviderIcon icon={icon} />
+                  {name}
+                </ProviderChip>
+              ))}
+            </ProviderSliderRow>
+          </BackgroundSlider>
+        ))}
+      </ProvidersSlider>
     </Flex>
   )
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Marketing-page UI only; no API, auth, or data-path changes.
> 
> **Overview**
> The embed landing page **providers** strip is refactored from a single duplicated marquee track to **three staggered rows** built on the shared `BackgroundSlider` component, with alternating scroll direction per row and a longer animation duration.
> 
> Provider chips pick up **subtle styling tweaks** (`white80` background, theme-based border) while the section keeps the same edge-fade mask. **`data/git-timestamps-modified.json`** only bumps timestamps for `embed.js` and `tools/embed-url.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 190764f5a23e5241108ef46177c5c027e6e706e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned provider section with a row-based interactive slider: providers now display across multiple rows with alternating animation, refreshed chip styling, and improved visual layout.

* **Chores**
  * Updated internal metadata timestamps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microlinkhq/www/pull/2053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->