### PR TITLE
refactor(search): adjust spaces

### DIFF
--- a/src/components/icons/Feather.js
+++ b/src/components/icons/Feather.js
@@ -14,12 +14,20 @@ const FeatherIcon = ({
   animations = true,
   ...props
 }) => {
+  const dimensions = getWidth(size)
+
   return (
     <Flex
       css={theme({
+        alignItems: 'center',
         justifyContent: 'center',
-        width: getWidth(size),
-        height: '100%'
+        flexShrink: 0,
+        width: dimensions,
+        height: dimensions,
+        '& svg': {
+          width: '100%',
+          height: '100%'
+        }
       })}
       as='span'
       {...props}

--- a/src/components/pages/search/Sections.js
+++ b/src/components/pages/search/Sections.js
@@ -311,12 +311,13 @@ export const TutorialStep = ({ step }) => (
         <Text
           as='span'
           css={theme({
+            display: ['inline', 'inline', 'none', 'none'],
             color: 'black50',
             fontFamily: 'mono',
             fontSize: [0, 0, 1, 1],
             fontWeight: 'bold',
             letterSpacing: 1,
-            mr: 1
+            mr: [1, 1, 0, 0]
           })}
         >
           {step.step}.

--- a/src/components/pages/search/index.js
+++ b/src/components/pages/search/index.js
@@ -7,16 +7,17 @@ import Text from 'components/elements/Text'
 
 import { truncateLineCss } from './utils'
 
+export const SEARCH_LAYOUT_WIDE_MAX_WIDTH = `calc(${layout.large} * 1.36)`
+
 const VERTICAL_EXAMPLE_GRID_MAX_WIDTH = [
   '100%',
   '100%',
   '100%',
-  `calc(${layout.large} * 1.7)`
+  SEARCH_LAYOUT_WIDE_MAX_WIDTH
 ]
 
 export const ActionRow = styled(Flex)`
   ${theme({
-    mt: 4,
     gap: [2, 2, 3, 3],
     flexWrap: 'wrap',
     alignItems: 'center',

--- a/src/components/patterns/List/List.js
+++ b/src/components/patterns/List/List.js
@@ -16,12 +16,18 @@ const ListItem = ({
   ...props
 }) => {
   const isYes = type === 'yes'
+  const iconSize = [1, 1, 2, 2]
+
   return (
     <Flex as='li' css={theme({ alignItems, mb: isLast ? 0 : 3 })}>
       <Flex
         css={theme({
+          alignItems: 'center',
           justifyContent: 'center',
+          flexShrink: 0,
+          fontSize: [1, 1, 2, 2],
           mr: 2,
+          pt: alignItems === 'flex-start' ? '0.375em' : 0,
           width: [fontSizes[1], fontSizes[1], fontSizes[2], fontSizes[2]]
         })}
         as='span'
@@ -29,6 +35,7 @@ const ListItem = ({
         <FeatherIcon
           icon={isYes ? CheckCircle : XCircle}
           color={isYes ? 'close' : 'gray'}
+          size={iconSize}
           aria-hidden='true'
         />
       </Flex>

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -57,7 +57,8 @@ import {
   VerticalOutputTab,
   VerticalPreviewContent,
   VerticalResultList,
-  VerticalTabButton
+  VerticalTabButton,
+  SEARCH_LAYOUT_WIDE_MAX_WIDTH
 } from 'components/pages/search'
 
 import VerticalTablist from 'components/pages/search/VerticalTablist'
@@ -75,7 +76,7 @@ const HERO_LAYOUT_MAX_WIDTH = [
   '100%',
   '100%',
   '100%',
-  `calc(${layout.large} * 1.7)`
+  SEARCH_LAYOUT_WIDE_MAX_WIDTH
 ]
 
 // Counteract Layout Main px: [3, 3, 0] so tinted sections span edge-to-edge on mobile.
@@ -156,8 +157,6 @@ console.log(page.results)`
     }
   }
 ]
-
-const HERO_ACCENT_GRADIENT = `linear-gradient(90deg, ${colors.pink8}, ${colors.pink9})`
 
 const visuallyHiddenCss = theme({
   position: 'absolute',
@@ -296,19 +295,19 @@ const GooglePage = () => {
                 textAlign: 'center'
               })}
             >
-              Search intelligence API <br />
-              <Box
+              Give your AI agent <br />
+              <Text
                 as='span'
+                variant='gradient'
                 css={theme({
-                  color: 'pink8',
-                  backgroundImage: HERO_ACCENT_GRADIENT,
-                  backgroundClip: 'text',
-                  WebkitBackgroundClip: 'text',
-                  WebkitTextFillColor: 'transparent'
+                  fontSize: 'inherit',
+                  fontWeight: 'inherit',
+                  letterSpacing: 'inherit',
+                  lineHeight: 'inherit'
                 })}
               >
-                for AI agents
-              </Box>
+                eyes on the web
+              </Text>
             </Text>
             <Text
               as='p'
@@ -323,8 +322,8 @@ const GooglePage = () => {
                 textAlign: 'center'
               })}
             >
-              One client for Search, News, Maps, Shopping, Scholar, and more.
-              Structured output your agents can consume without parsing HTML.
+              Structured search results in ~1s. One client, normalized JSON for
+              tools, prompts, and RAG pipelines.
             </Text>
           </Box>
 
@@ -332,7 +331,7 @@ const GooglePage = () => {
             id='playground'
             as='section'
             aria-label='Search surface playground'
-            css={theme({ mt: [4, 4, 5, 5] })}
+            css={theme({ mt: 4 })}
           >
             <Text aria-live='polite' aria-atomic='true' css={visuallyHiddenCss}>
               {playgroundStatus}
@@ -436,12 +435,11 @@ const GooglePage = () => {
                     </Flex>
                   </Box>
 
-                  <Box
+                  <Flex
                     css={theme({
                       px: [3, 3, 4, 4],
                       minWidth: 0,
                       flex: 'none',
-                      display: 'flex',
                       flexDirection: 'column',
                       justifyContent: 'flex-start',
                       minHeight: 0
@@ -503,16 +501,15 @@ const GooglePage = () => {
                         )
                       })}
                     </VerticalResultList>
-                  </Box>
+                  </Flex>
                 </VerticalExamplePanel>
 
-                <Box
+                <Flex
                   css={theme({
                     alignSelf: 'stretch',
                     minHeight: 0,
                     height: VERTICAL_RESPONSE_HEIGHT,
                     maxHeight: '100%',
-                    display: 'flex',
                     flexDirection: 'column',
                     gap: 3,
                     overflow: 'hidden'
@@ -526,11 +523,10 @@ const GooglePage = () => {
                       flexShrink: 0
                     })}
                   >
-                    <Box
+                    <Flex
                       id='vertical-output-panel-code'
                       aria-label={codeExampleLabel}
                       css={theme({
-                        display: 'flex',
                         flexDirection: 'column',
                         flex: 1,
                         minHeight: 0,
@@ -558,7 +554,7 @@ const GooglePage = () => {
                       >
                         {activeVerticalExample.code}
                       </CodeEditor>
-                    </Box>
+                    </Flex>
                   </VerticalExamplePanel>
 
                   <VerticalExamplePanel
@@ -609,12 +605,11 @@ const GooglePage = () => {
                     </Flex>
 
                     {activeOutputTab === 'json' && (
-                      <Box
+                      <Flex
                         id='vertical-output-panel-json'
                         role='tabpanel'
                         aria-labelledby='vertical-output-tab-json'
                         css={theme({
-                          display: 'flex',
                           flexDirection: 'column',
                           flex: 1,
                           minHeight: 0,
@@ -645,17 +640,15 @@ const GooglePage = () => {
                         >
                           {JSON.stringify(activeVerticalPayload, null, 2)}
                         </CodeEditor>
-                      </Box>
+                      </Flex>
                     )}
 
                     {activeOutputTab === 'preview' && (
-                      <Box
+                      <Flex
                         id='vertical-output-panel-preview'
                         role='tabpanel'
                         aria-labelledby='vertical-output-tab-preview'
                         css={theme({
-                          bg: 'white',
-                          display: 'flex',
                           flexDirection: 'column',
                           height: 0,
                           minHeight: 0,
@@ -669,29 +662,27 @@ const GooglePage = () => {
                           <Box
                             css={theme({
                               px: [3, 3, 4, 4],
-                              bg: 'white',
                               overflow: 'hidden'
                             })}
                           >
                             <HeroResultCard result={activeVerticalPreview} />
                           </Box>
                         </VerticalPreviewContent>
-                      </Box>
+                      </Flex>
                     )}
                   </VerticalExamplePanel>
-                </Box>
+                </Flex>
               </VerticalExampleGrid>
             </VerticalExampleShell>
           </Box>
 
-          <Box id='features' as='section' css={theme({ pt: [4, 4, 5, 5] })}>
+          <Box id='features' as='section' css={theme({ pt: 6 })}>
             <Box
               as='ul'
               css={theme({
                 listStyle: 'none',
                 p: 0,
                 m: 0,
-                mt: 4,
                 width: 'max-content',
                 maxWidth: '100%',
                 mx: 'auto'
@@ -713,11 +704,13 @@ const GooglePage = () => {
           <Flex id='cta' css={theme({ justifyContent: 'center' })}>
             <ActionRow
               css={theme({
+                pt: 4,
                 flexDirection: 'row',
                 flexWrap: 'nowrap',
                 alignItems: 'center',
                 justifyContent: 'center',
-                gap: [4, 4, 0, 0]
+                gap: [4, 4, 4, 4],
+                '& > *': { flexShrink: 0 }
               })}
             >
               <Button as='a' href='/pricing'>
@@ -725,7 +718,10 @@ const GooglePage = () => {
               </Button>
               <ArrowLink
                 href={GUIDE_URL}
-                css={theme({ fontSize: [1, 1, 2, 2] })}
+                css={theme({
+                  flexShrink: 0,
+                  fontSize: [1, 1, 2, 2]
+                })}
               >
                 View docs
               </ArrowLink>
@@ -734,18 +730,14 @@ const GooglePage = () => {
         </Box>
       </Container>
 
-      <Box
-        as='section'
-        id='retrieval-workflows'
-        css={theme({ bg: 'white', py: [6, 6, 7, 7] })}
-      >
+      <Box as='section' id='retrieval-workflows' css={theme({ py: 6 })}>
         <Container
           css={theme({
             maxWidth: [
               '100%',
               '100%',
               layout.large,
-              `calc(${layout.large} * 1.7)`
+              SEARCH_LAYOUT_WIDE_MAX_WIDTH
             ],
             pt: 0,
             px: [3, 3, 0, 0]
@@ -758,7 +750,7 @@ const GooglePage = () => {
                 '100%',
                 '100%',
                 layout.large,
-                `calc(${layout.large} * 1.7)`
+                SEARCH_LAYOUT_WIDE_MAX_WIDTH
               ],
               mx: 'auto',
               minWidth: 0,
@@ -870,7 +862,7 @@ const GooglePage = () => {
               '100%',
               '100%',
               layout.large,
-              `calc(${layout.large} * 1.7)`
+              SEARCH_LAYOUT_WIDE_MAX_WIDTH
             ]
           })}
         >
@@ -1009,11 +1001,7 @@ const GooglePage = () => {
         </Container>
       </Box>
 
-      <Box
-        as='section'
-        id='google-api-integration'
-        css={theme({ bg: 'white', py: 5 })}
-      >
+      <Box as='section' id='google-api-integration' css={theme({ py: 6 })}>
         <Container
           css={theme({
             p: 0,
@@ -1021,7 +1009,7 @@ const GooglePage = () => {
               '100%',
               '100%',
               layout.large,
-              `calc(${layout.large} * 1.7)`
+              SEARCH_LAYOUT_WIDE_MAX_WIDTH
             ]
           })}
         >
@@ -1095,13 +1083,17 @@ const GooglePage = () => {
                 css={theme({
                   mt: [4, 4, 5, 5],
                   ml: [0, 0, '104px', '104px'],
+                  flexDirection: 'row',
+                  flexWrap: 'nowrap',
+                  alignItems: 'center',
                   justifyContent: [
                     'center',
                     'center',
                     'flex-start',
                     'flex-start'
                   ],
-                  gap: [4, 4, 0, 0]
+                  gap: [4, 4, 4, 4],
+                  '& > *': { flexShrink: 0 }
                 })}
               >
                 <Button as='a' href={PACKAGE_URL}>
@@ -1122,18 +1114,19 @@ const GooglePage = () => {
           borderTop: 1,
           borderBottom: 1,
           borderColor: 'blue5',
-          py: [5, 5, 6, 7],
+          py: 6,
           ...MOBILE_SECTION_BLEED
         })}
       >
         <Container
           css={theme({
             px: [3, 3, 0, 0],
+            py: 0,
             maxWidth: [
               '100%',
               '100%',
               layout.large,
-              `calc(${layout.large} * 1.7)`
+              SEARCH_LAYOUT_WIDE_MAX_WIDTH
             ]
           })}
         >
@@ -1279,12 +1272,11 @@ const GooglePage = () => {
                     )
                   }
                 ].map(product => (
-                  <Box
+                  <Flex
                     as='a'
                     key={product.label}
                     href={product.href}
                     css={theme({
-                      display: 'flex',
                       flexDirection: 'column',
                       alignItems: 'center',
                       justifyContent: 'center',
@@ -1293,7 +1285,6 @@ const GooglePage = () => {
                       minWidth: 0,
                       height: ['170px', '170px', '170px', '180px'],
                       borderRadius: 4,
-                      bg: 'white',
                       border: 0,
                       boxShadow: `0 4px 12px ${colors.black05}`,
                       textDecoration: 'none',
@@ -1330,7 +1321,7 @@ const GooglePage = () => {
                     >
                       {product.label}
                     </Text>
-                  </Box>
+                  </Flex>
                 ))}
               </Box>
             </Box>
@@ -1341,7 +1332,6 @@ const GooglePage = () => {
       <Faq
         title='Product Information'
         caption='Everything you need to know about Microlink Search, pricing, and supported search surfaces.'
-        css={theme({ mt: [5, 5, 6, 6], bg: 'white' })}
         questions={FAQ_ENTRIES.map(({ question, answers }) => ({
           question,
           answer: (
@@ -1383,8 +1373,8 @@ const GooglePage = () => {
 
 export const Head = () => (
   <Meta
-    title='Search API for SEO, Monitoring, and AI Workflows'
-    description='Microlink Search is a paid search intelligence API for querying and normalizing public results from Google Search, News, Maps, Shopping, Scholar, and more.'
+    title='Give Your AI Agent Eyes on the Web — Microlink Search API'
+    description='Structured search results in ~1s. One client, normalized JSON for AI agents, RAG pipelines, and any workflow that needs structured web data.'
     image={HERO_IMAGE}
     structured={STRUCTURED_DATA}
   />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Marketing page and presentational component tweaks only; no API or auth changes.
> 
> **Overview**
> Tightens **search landing** layout and messaging: introduces shared `SEARCH_LAYOUT_WIDE_MAX_WIDTH` (narrower than the previous `1.7×` wide breakpoint) and applies it across hero, sections, and containers. **Vertical rhythm** is simplified—more uniform `py`/`pt` spacing, less per-breakpoint variance, and CTA rows keep consistent gaps with `flexShrink: 0` on children.
> 
> **Hero copy and SEO** shift toward AI agents: headline uses `Text` `variant='gradient'` instead of inline pink gradient CSS; subcopy and `Meta` title/description match the new positioning.
> 
> **Icon/list alignment**: `FeatherIcon` gets square dimensions, centered SVG scaling, and `flexShrink: 0`; `List` items pass explicit icon size and top padding when `alignItems='flex-start'`. **Tutorial steps** show the numeric prefix only on smaller breakpoints.
> 
> Several playground panels switch from `Box` to `Flex` for layout; section backgrounds on some blocks are removed in favor of parent/layout defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 392352894554280f68d51d705ef60981e42f25fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed search page with updated messaging and improved layout experience

* **Style**
  * Enhanced responsive design across search components for better usability
  * Improved icon sizing and alignment consistency
  * Updated layout structure with normalized spacing and width behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microlinkhq/www/pull/2055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->