### PR TITLE
chore: mobile tweaks

### DIFF
--- a/src/components/pages/search/Sections.js
+++ b/src/components/pages/search/Sections.js
@@ -50,7 +50,7 @@ export const SectionCaption = ({
           m: 0,
           color,
           fontWeight: 'bold',
-          fontSize: [0, 0, 0, 0],
+          fontSize: ['10px', '10px', '12px', '12px'],
           textTransform: 'uppercase',
           letterSpacing: 2,
           lineHeight: 0
@@ -88,7 +88,7 @@ export const BulletList = ({ children }) => (
     as='ul'
     css={theme({
       m: 0,
-      mt: [3, 3, 4, 4],
+      mt: 4,
       p: 0,
       listStyle: 'none'
     })}
@@ -301,6 +301,7 @@ export const TutorialStep = ({ step }) => (
       <Text
         as='h3'
         css={theme({
+          pb: [3, 3, 0, 0],
           m: 0,
           color: 'black',
           fontWeight: 'bold',

--- a/src/components/pages/search/VerticalTablist.js
+++ b/src/components/pages/search/VerticalTablist.js
@@ -25,7 +25,7 @@ const VerticalTablist = ({
           flexWrap: 'nowrap',
           alignItems: 'stretch',
           justifyContent: ['flex-start', 'flex-start', 'center', 'center'],
-          gap: [1, 1, 2, 2],
+          gap: 2,
           width: '100%',
           overflowX: 'auto',
           overflowY: 'hidden',

--- a/src/components/pages/search/index.js
+++ b/src/components/pages/search/index.js
@@ -267,7 +267,7 @@ export const VerticalExampleShell = styled(Box).withConfig({
 })`
   ${theme({
     mt: [4, 4, 5, 5],
-    overflow: 'hidden',
+    overflow: ['visible', 'visible', 'visible', 'hidden'],
     minWidth: 0
   })};
   position: relative;
@@ -287,7 +287,7 @@ export const VerticalExampleGrid = styled(Box)`
     width: '100%',
     maxWidth: VERTICAL_EXAMPLE_GRID_MAX_WIDTH,
     mx: 'auto',
-    height: '100%'
+    height: ['auto', 'auto', 'auto', '100%']
   })};
 `
 
@@ -548,7 +548,7 @@ export const BulletItem = styled(Flex).attrs({ as: 'li' })`
   })};
 
   &:not(:first-of-type) {
-    ${theme({ mt: [2, 2, 3, 3] })};
+    ${theme({ mt: 3 })};
   }
 `
 
@@ -558,7 +558,7 @@ export const TutorialStepContainer = styled(Box).attrs({ as: 'section' })`
     display: 'grid',
     gridTemplateColumns: ['1fr', '1fr', '72px 1fr', '72px 1fr'],
     columnGap: [0, 0, 4, 4],
-    pb: [4, 4, 5, 5]
+    pb: 5
   })};
 
   &:last-child {

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -83,7 +83,11 @@ const MOBILE_SECTION_BLEED = {
   mx: [-3, -3, 0, 0]
 }
 
-const VERTICAL_RESPONSE_HEIGHT = '100%'
+const HERO_HEADING_FONT_SIZE = ['36px', '36px', 5, 5]
+const SECTION_HEADING_FONT_SIZE = ['36px', '42px', 4, 4]
+const SECTION_HEADING_FONT_SIZE_MEDIUM = ['36px', '42px', '36px', '36px']
+const SECTION_HEADING_FONT_SIZE_LARGE = ['36px', '42px', '42px', '42px']
+const PRICE_DISPLAY_FONT_SIZE = ['36px', '42px', 5, 5]
 
 const VERTICAL_OUTPUT_TABS = [
   { id: 'json', label: 'JSON' },
@@ -287,7 +291,7 @@ const GooglePage = () => {
                 fontWeight: 'bold',
                 letterSpacing: 1,
                 lineHeight: [1, 1, 0, 0],
-                fontSize: [4, 4, 5, 5],
+                fontSize: HERO_HEADING_FONT_SIZE,
                 textAlign: 'center'
               })}
             >
@@ -504,8 +508,8 @@ const GooglePage = () => {
                   css={theme({
                     alignSelf: 'stretch',
                     minHeight: 0,
-                    height: VERTICAL_RESPONSE_HEIGHT,
-                    maxHeight: '100%',
+                    height: ['auto', 'auto', 'auto', '100%'],
+                    maxHeight: ['none', 'none', 'none', '100%'],
                     flexDirection: 'column',
                     gap: 3,
                     overflow: 'hidden'
@@ -515,7 +519,7 @@ const GooglePage = () => {
                     css={theme({
                       border: 1,
                       borderColor: 'black10',
-                      height: ['160px', '160px', '180px', '190px'],
+                      height: ['auto', 'auto', 'auto', '190px'],
                       flexShrink: 0
                     })}
                   >
@@ -524,9 +528,9 @@ const GooglePage = () => {
                       aria-label={codeExampleLabel}
                       css={theme({
                         flexDirection: 'column',
-                        flex: 1,
+                        flex: ['none', 'none', 'none', 1],
                         minHeight: 0,
-                        height: '100%',
+                        height: ['auto', 'auto', 'auto', '100%'],
                         py: 3
                       })}
                     >
@@ -540,9 +544,9 @@ const GooglePage = () => {
                         aria-label={codeExampleLabel}
                         css={theme({
                           width: '100%',
-                          height: '100%',
+                          height: ['auto', 'auto', 'auto', '100%'],
                           minHeight: 0,
-                          flex: 1,
+                          flex: ['none', 'none', 'none', 1],
                           border: 0,
                           borderRadius: 0,
                           pt: 1
@@ -557,8 +561,8 @@ const GooglePage = () => {
                     css={theme({
                       border: 1,
                       borderColor: 'black10',
-                      flex: 1,
-                      minHeight: 0,
+                      flex: ['none', 'none', 'none', 1],
+                      minHeight: ['320px', '320px', '320px', 0],
                       overflow: 'hidden'
                     })}
                   >
@@ -608,9 +612,10 @@ const GooglePage = () => {
                         css={theme({
                           flexDirection: 'column',
                           flex: 1,
-                          minHeight: 0,
-                          height: 0,
-                          overflow: 'hidden',
+                          minHeight: ['280px', '280px', '280px', 0],
+                          height: ['auto', 'auto', 'auto', 0],
+                          maxHeight: ['480px', '480px', '480px', 'none'],
+                          overflow: ['auto', 'auto', 'auto', 'hidden'],
                           py: [2, 2, 3, 3]
                         })}
                       >
@@ -624,10 +629,15 @@ const GooglePage = () => {
                           aria-label={jsonOutputLabel}
                           css={theme({
                             width: '100%',
-                            height: '100%',
-                            minHeight: 0,
-                            flex: 1,
-                            overflowY: 'auto',
+                            height: ['auto', 'auto', 'auto', '100%'],
+                            minHeight: ['240px', '240px', '240px', 0],
+                            flex: ['none', 'none', 'none', 1],
+                            overflowY: [
+                              'visible',
+                              'visible',
+                              'visible',
+                              'auto'
+                            ],
                             overflowX: 'hidden',
                             border: 0,
                             borderRadius: 0,
@@ -646,8 +656,9 @@ const GooglePage = () => {
                         aria-labelledby='vertical-output-tab-preview'
                         css={theme({
                           flexDirection: 'column',
-                          height: 0,
-                          minHeight: 0,
+                          height: ['auto', 'auto', 'auto', 0],
+                          minHeight: ['280px', '280px', '280px', 0],
+                          maxHeight: ['480px', '480px', '480px', 'none'],
                           flex: 1,
                           minWidth: 0,
                           overflowY: 'auto',
@@ -672,7 +683,7 @@ const GooglePage = () => {
             </VerticalExampleShell>
           </Box>
 
-          <Box id='features' as='section' css={theme({ pt: 6 })}>
+          <Box id='features' as='section' css={theme({ pt: [5, 5, 6, 6] })}>
             <Box
               as='ul'
               css={theme({
@@ -726,7 +737,11 @@ const GooglePage = () => {
         </Box>
       </Container>
 
-      <Box as='section' id='retrieval-workflows' css={theme({ py: 6 })}>
+      <Box
+        as='section'
+        id='retrieval-workflows'
+        css={theme({ py: [5, 5, 6, 6] })}
+      >
         <Container
           css={theme({
             maxWidth: [
@@ -773,7 +788,7 @@ const GooglePage = () => {
                   fontWeight: 'bold',
                   letterSpacing: 1,
                   lineHeight: [1, 1, 0, 0],
-                  fontSize: [3, 4, 4, 4],
+                  fontSize: SECTION_HEADING_FONT_SIZE,
                   textAlign: 'left'
                 })}
               >
@@ -844,7 +859,7 @@ const GooglePage = () => {
         id='pricing'
         css={theme({
           bg: 'orange0',
-          py: 6,
+          py: [5, 5, 6, 6],
           borderTop: 1,
           borderBottom: 1,
           borderColor: 'orange5',
@@ -878,9 +893,7 @@ const GooglePage = () => {
                 minWidth: 0
               })}
             >
-              <SectionCaption color={colors.orange7}>
-                Simple, predictable pricing
-              </SectionCaption>
+              <SectionCaption color={colors.orange7}>Pricing</SectionCaption>
               <Text
                 as='h2'
                 css={theme({
@@ -889,7 +902,7 @@ const GooglePage = () => {
                   fontWeight: 'bold',
                   letterSpacing: 1,
                   lineHeight: [1, 1, 0, 0],
-                  fontSize: [3, 4, 4, 4],
+                  fontSize: SECTION_HEADING_FONT_SIZE,
                   textAlign: 'left'
                 })}
               >
@@ -934,7 +947,7 @@ const GooglePage = () => {
                 <Text
                   css={theme({
                     color: 'black',
-                    fontSize: [4, 4, 5, 5],
+                    fontSize: PRICE_DISPLAY_FONT_SIZE,
                     fontWeight: 'bold',
                     lineHeight: 0,
                     mb: 2
@@ -997,7 +1010,11 @@ const GooglePage = () => {
         </Container>
       </Box>
 
-      <Box as='section' id='google-api-integration' css={theme({ py: 6 })}>
+      <Box
+        as='section'
+        id='google-api-integration'
+        css={theme({ py: [5, 5, 6, 6] })}
+      >
         <Container
           css={theme({
             p: 0,
@@ -1036,7 +1053,7 @@ const GooglePage = () => {
                   fontWeight: 'bold',
                   letterSpacing: 1,
                   lineHeight: [1, 1, 0, 0],
-                  fontSize: [3, 3, '36px', '36px'],
+                  fontSize: SECTION_HEADING_FONT_SIZE_MEDIUM,
                   textAlign: 'left'
                 })}
               >
@@ -1110,7 +1127,7 @@ const GooglePage = () => {
           borderTop: 1,
           borderBottom: 1,
           borderColor: 'blue5',
-          py: 6,
+          py: [5, 5, 6, 6],
           ...MOBILE_SECTION_BLEED
         })}
       >
@@ -1158,16 +1175,14 @@ const GooglePage = () => {
                   color: 'black',
                   fontWeight: 'bold',
                   letterSpacing: 1,
-                  lineHeight: 1,
-                  fontSize: [4, 4, '42px', '42px'],
+                  lineHeight: [1, 1, 0, 0],
+                  fontSize: SECTION_HEADING_FONT_SIZE_LARGE,
                   textAlign: 'left'
                 })}
               >
                 Plug <span css={theme({ color: 'blue6' })}>Microlink</span>
                 <br />
-                <span css={theme({ whiteSpace: 'nowrap' })}>
-                  into your workflow
-                </span>
+                into your workflow
               </Text>
               <Text
                 as='p'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only CSS and copy on the search marketing page; no API or business-logic changes.
> 
> **Overview**
> This PR refines the **search landing page** for smaller viewports while keeping the wide desktop layout largely intact.
> 
> **Playground / vertical example:** On mobile and tablet, the example grid and panels stop forcing `100%` height and hidden overflow. Code and JSON/preview areas use **auto** height with explicit **min/max** heights and scrollable overflow so content isn’t clipped; desktop still uses the fixed split layout.
> 
> **Typography & spacing:** Hero and section headings get shared breakpoint-based font-size tokens (e.g. `36px` / `42px` on small screens). Section vertical padding is slightly tighter on the first two breakpoints (`py`/`pt` `5` vs `6`). Shared components tighten spacing (bullet lists, tutorial steps, tab gaps, section caption sizes).
> 
> **Copy tweaks:** Pricing caption shortens to “Pricing”; final CTA heading drops `nowrap` on “into your workflow”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35d9b938bce2f510b9d3cd4cb8bb104f55602945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined responsive typography and layout adjustments across the search page
  * Improved spacing and padding behavior for better visual hierarchy
  * Optimized responsive panel sizing and overflow handling
  * Updated pricing section copy for clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microlinkhq/www/pull/2059?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->