### PR TITLE
fix: blink cursor for terminal

### DIFF
--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -170,7 +170,7 @@
   "src/content/docs/guides/search/autocomplete.md": "2026-05-28T00:00:00.000Z",
   "src/content/docs/guides/search/content-expansion.md": "2026-05-28T00:00:00.000Z",
   "src/content/docs/guides/search/images.md": "2026-05-28T00:00:00.000Z",
-  "src/content/docs/guides/search/index.md": "2026-05-28T00:00:00.000Z",
+  "src/content/docs/guides/search/index.md": "2026-05-31T00:00:00.000Z",
   "src/content/docs/guides/search/maps.md": "2026-05-28T00:00:00.000Z",
   "src/content/docs/guides/search/news.md": "2026-05-28T00:00:00.000Z",
   "src/content/docs/guides/search/patents.md": "2026-05-28T00:00:00.000Z",

--- a/src/components/elements/CodeEditor/CodeEditor.js
+++ b/src/components/elements/CodeEditor/CodeEditor.js
@@ -1,7 +1,7 @@
 import { cx, radii, theme, fontSizes, lineHeights, fonts, space } from 'theme'
 import { hideScrollbar, wordBreak } from 'helpers/style'
 import React, { useState, useEffect } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { getLines } from 'helpers/get-lines'
 import { childrenTextAll } from 'helpers/children-text-all'
 import { prettier } from 'helpers/prettier'
@@ -100,8 +100,16 @@ const CustomCodeBlock = styled.pre`
   background: ${props => (props.$theme === 'dark' ? cx('black') : cx('white'))};
   color: ${props => (props.$theme === 'dark' ? cx('white') : cx('black'))};
 
+  ${props =>
+    props.$blinkCursor &&
+    css`
+      display: inline;
+      margin: 0;
+      vertical-align: top;
+    `}
+
   code {
-    display: block;
+    display: ${props => (props.$blinkCursor ? 'inline' : 'block')};
     white-space: pre;
     overflow-x: auto;
     padding-left: ${props => (props.$showLineNumbers ? '3rem' : '0')};
@@ -113,8 +121,8 @@ const CustomCodeBlock = styled.pre`
   }
 
   .code-line {
-    display: inline-block;
-    width: 100%;
+    display: ${props => (props.$blinkCursor ? 'inline' : 'inline-block')};
+    width: ${props => (props.$blinkCursor ? 'auto' : '100%')};
     margin-bottom: ${space[1]};
   }
 
@@ -147,7 +155,8 @@ export const Code = ({
   showLineNumbers,
   firstHighlightLine,
   lastHighlightLine,
-  language
+  language,
+  blinkCursor = false
 }) => {
   let highlightedHtml = highlight(children)
 
@@ -179,6 +188,7 @@ export const Code = ({
 
   return (
     <CustomCodeBlock
+      $blinkCursor={blinkCursor}
       $language={language}
       css={`
         ${String(highLightLinesSelector)} {
@@ -256,7 +266,7 @@ const CodeEditor = ({
   showLineNumbers = false,
   language: languageProp,
   title = '',
-  blinkCursor = false,
+  blinkCursor,
   autoHeight = false,
   ...props
 }) => {
@@ -284,6 +294,12 @@ const CodeEditor = ({
     highLightLinesSelector &&
     highLightLinesSelector[highLightLinesSelector.length - 1]
 
+  const showBlinkCursor =
+    blinkCursor === true ||
+    (blinkCursor !== false &&
+      ['bash', 'shell', 'sh'].includes(language) &&
+      !text.includes('\n'))
+
   return (
     <Terminal
       id={`codeditor-${hash(source)}`}
@@ -298,8 +314,9 @@ const CodeEditor = ({
       blinkCursor={false}
       {...props}
     >
-      <TerminalTextWrapper $blinkCursor={blinkCursor}>
+      <TerminalTextWrapper $blinkCursor={showBlinkCursor}>
         <Code
+          blinkCursor={showBlinkCursor}
           firstHighlightLine={firstHighlightLine}
           highlightLines={highlightLines}
           highLightLinesSelector={highLightLinesSelector}

--- a/src/components/elements/CodeEditor/CodeEditor.js
+++ b/src/components/elements/CodeEditor/CodeEditor.js
@@ -1,7 +1,7 @@
-import { cx, radii, theme, fontSizes, lineHeights, fonts, space } from 'theme'
+import { cx, radii, theme, fontSizes, lineHeights } from 'theme'
 import { hideScrollbar, wordBreak } from 'helpers/style'
 import React, { useState, useEffect } from 'react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { getLines } from 'helpers/get-lines'
 import { childrenTextAll } from 'helpers/children-text-all'
 import { prettier } from 'helpers/prettier'
@@ -102,28 +102,29 @@ const CustomCodeBlock = styled.pre`
 
   ${props =>
     props.$blinkCursor &&
-    css`
-      display: inline;
-      margin: 0;
-      vertical-align: top;
-    `}
+    theme({ display: 'inline', m: 0, verticalAlign: 'top' })}
 
   code {
-    display: ${props => (props.$blinkCursor ? 'inline' : 'block')};
-    white-space: pre;
-    overflow-x: auto;
-    padding-left: ${props => (props.$showLineNumbers ? '3rem' : '0')};
-    font-family: ${fonts.mono};
-    font-size: ${fontSizes[0]};
-    line-height: ${props =>
-      props.$language === 'bash' ? lineHeights[0] : lineHeights[4]};
+    ${props =>
+      theme({
+        display: props.$blinkCursor ? 'inline' : 'block',
+        whiteSpace: 'pre',
+        overflowX: 'auto',
+        pl: props.$showLineNumbers ? '3rem' : 0,
+        fontFamily: 'mono',
+        fontSize: 0,
+        lineHeight: props.$language === 'bash' ? 0 : 4
+      })}
     tab-size: 2;
   }
 
   .code-line {
-    display: ${props => (props.$blinkCursor ? 'inline' : 'inline-block')};
-    width: ${props => (props.$blinkCursor ? 'auto' : '100%')};
-    margin-bottom: ${space[1]};
+    ${props =>
+      theme({
+        display: props.$blinkCursor ? 'inline' : 'inline-block',
+        width: props.$blinkCursor ? 'auto' : '100%',
+        mb: 1
+      })}
   }
 
   .line-numbers {

--- a/src/components/elements/Terminal/blink-cursor.js
+++ b/src/components/elements/Terminal/blink-cursor.js
@@ -6,7 +6,7 @@ import { colors } from 'theme'
 export const blinkCursorLayoutStyle = css`
   && {
     display: inline-block;
-    width: auto;
+    width: auto !important;
     max-width: 100%;
     vertical-align: top;
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped to docs-site CodeEditor/terminal presentation CSS; no API, auth, or data paths.
> 
> **Overview**
> Fixes terminal-style **blinking cursor** rendering in `CodeEditor` by driving cursor mode from a new `showBlinkCursor` rule and aligning code block layout with inline terminal text.
> 
> **`CodeEditor`** now computes `showBlinkCursor` when `blinkCursor` is explicitly `true`, or by default for single-line `bash` / `shell` / `sh` snippets (unless `blinkCursor={false}`). That flag is passed into `Code` and `TerminalTextWrapper` instead of always mirroring the raw prop; the outer `Terminal` is forced to `blinkCursor={false}` so the animated cursor stays on the highlighted code, not the chrome.
> 
> **`Code`** / `CustomCodeBlock` switch `pre`, `code`, and `.code-line` to **inline** layout (via `theme()`) when the cursor is active so the caret sits at the end of the command line; multi-line blocks keep block layout.
> 
> **`blink-cursor.js`** sets `width: auto !important` on the blink layout wrapper so width rules from parent code styles do not squash the cursor row.
> 
> Also bumps the modified timestamp for `guides/search/index.md` in `git-timestamps-modified.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da5a4cb81b1488b5a47831256e734992aa7057e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Code blocks gained an optional blinking-cursor mode, auto-enabled for single-line shell/bash examples when requested.

* **Bug Fixes**
  * Cursor styling updated to ensure consistent width and rendering across layouts.

* **Chores**
  * Updated documentation timestamp metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->