### PR TITLE
docs(function): add OutgoingRequestError

### DIFF
--- a/src/content/docs/api/parameters/function.md
+++ b/src/content/docs/api/parameters/function.md
@@ -136,12 +136,13 @@ The profiling phases are:
 
 The function parameter is available on both free and pro plans with different resource limits:
 
-|             | Free       | Pro              |
-| ----------- | ---------- | ---------------- |
-| Timeout     | 5 seconds  | Up to 28 seconds |
-| Memory      | 16 MB      | 32 MB            |
-| Code size   | 1024 bytes | Unlimited        |
-| Concurrency | 1 per IP   | Unlimited        |
+|                      | Free       | Pro              |
+| -------------------- | ---------- | ---------------- |
+| Timeout              | 5 seconds  | Up to 28 seconds |
+| Memory               | 16 MB      | 32 MB            |
+| Code size            | 1024 bytes | Unlimited        |
+| Concurrency          | 1 per IP   | Unlimited        |
+| Outgoing requests    | Same-origin only | Unrestricted |
 
 When a limit is exceeded, the function returns `isFulfilled: false` with a descriptive error instead of failing the entire request:
 
@@ -163,13 +164,14 @@ When a limit is exceeded, the function returns `isFulfilled: false` with a descr
 
 The resource error types are:
 
-| Error              | Trigger                                                         |
-| ------------------ | --------------------------------------------------------------- |
-| `TimeoutError`     | Function wall-clock time exceeded the plan limit                |
-| `CpuTimeError`     | Function CPU time exceeded the plan limit                       |
-| `MemoryError`      | Function memory usage exceeded the plan limit                   |
-| `CodeSizeError`    | Function code exceeds the 1024 bytes free plan limit            |
-| `ConcurrencyError` | Too many concurrent function executions for the free plan (1 per IP) |
+| Error                  | Trigger                                                              |
+| ---------------------- | -------------------------------------------------------------------- |
+| `TimeoutError`         | Function wall-clock time exceeded the plan limit                     |
+| `CpuTimeError`         | Function CPU time exceeded the plan limit                            |
+| `MemoryError`          | Function memory usage exceeded the plan limit                        |
+| `CodeSizeError`        | Function code exceeds the 1024 bytes free plan limit                 |
+| `ConcurrencyError`     | Too many concurrent function executions for the free plan (1 per IP) |
+| `OutgoingRequestError` | Function made a cross-origin network request on the free plan        |
 
 Each error message is plan-aware and tells you the exact limit that was hit.
 

--- a/src/content/docs/guides/function/troubleshooting.md
+++ b/src/content/docs/guides/function/troubleshooting.md
@@ -35,6 +35,7 @@ When a function exceeds its plan limits, the API returns a descriptive error ins
 | `MemoryError`      | Function memory usage exceeded the plan limit                   |
 | `CodeSizeError`    | Function code exceeds the 1024 bytes free plan limit            |
 | `ConcurrencyError` | Too many concurrent function executions for the free plan (1 per IP) |
+| `OutgoingRequestError` | Function made a cross-origin network request on the free plan        |
 
 Each error message is plan-aware:
 
@@ -84,6 +85,12 @@ Each error message is plan-aware:
 
 1. Wait for the current function execution to finish before sending another request.
 2. Upgrade to pro for unlimited concurrency.
+
+**OutgoingRequestError** — the function made a cross-origin network request on the free plan:
+
+1. Remove any `fetch`, `XMLHttpRequest`, or WebSocket calls to external domains.
+2. Same-origin requests (relative URLs or same host as the target URL) are always allowed.
+3. Upgrade to pro for unrestricted outgoing requests.
 
 ## General debugging
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security logic modifications.
> 
> **Overview**
> Documents a new **free-plan restriction** on user `function` code: **outgoing requests** are **same-origin only**, with **unrestricted** access on **pro**.
> 
> The API reference adds an **Outgoing requests** row to the plan limits table and documents **`OutgoingRequestError`** when a function makes a **cross-origin** network call on free. The troubleshooting guide lists the same error and explains fixes (avoid external `fetch` / XHR / WebSockets, allow same-origin, upgrade to pro). Minor table column alignment updates accompany the new rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d59f278bcfe3bd8a78188d89c1b120772d9531a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation to clarify outgoing request constraints between plans: free plan restricts to same-origin requests only, pro plan allows unrestricted requests.
  * Added documentation for cross-origin request errors with troubleshooting steps and upgrade guidance for unrestricted outgoing request access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->