### PR TITLE
fix: code examples empty

### DIFF
--- a/src/components/patterns/MultiCodeEditor/MultiCodeEditorInteractive.js
+++ b/src/components/patterns/MultiCodeEditor/MultiCodeEditorInteractive.js
@@ -56,6 +56,14 @@ const Content = styled(TerminalText)`
   white-space: pre-wrap;
   word-break: break-word;
   ${theme(fontStyles)}
+
+  code {
+    ${theme({ display: 'block', whiteSpace: 'pre' })}
+  }
+
+  .code-line {
+    ${theme({ display: 'inline-block', width: '100%', mb: 1 })}
+  }
 `
 
 /**
@@ -1185,6 +1193,7 @@ function MultiCodeEditorInteractive ({
       {/* Interactive UX layer */}
       <div>
         <Terminal
+          blinkCursor={false}
           text={getCurrentViewText()}
           ActionComponent={MemoizedActionComponent}
           css={theme({ width: TERMINAL_WIDTH })}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only CSS and a Terminal prop in one marketing/docs component; no API or auth changes.
> 
> **Overview**
> Fixes **empty or collapsed Microlink API code examples** in the interactive multi-language editor by styling highlighted snippet markup the same way as the main `CodeEditor`.
> 
> The `Content` wrapper now lays out inner `code` as a block with `pre` whitespace and gives each `.code-line` span full width and spacing so `wrapLinesWithHighlight` output is visible. The surrounding `Terminal` also passes **`blinkCursor={false}`** so the default blinking cursor layout does not fight the editor chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a0f28b29d1efb202afb5f42f84bd56effa45020. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Code blocks now display with improved formatting rules that ensure consistent and proper rendering of code elements throughout the editor
  * Code lines now render as full-width block components with appropriate bottom spacing for better visual separation
  * Terminal cursor animation has been disabled, providing a steady, non-blinking cursor in interactive terminal displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->