### PR TITLE
perf: drop NODE_OPTIONS

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -77,7 +77,7 @@ exports.createSchemaCustomization = ({ actions }) => {
   `)
 }
 
-exports.onCreateWebpackConfig = ({ actions }) => {
+exports.onCreateWebpackConfig = ({ stage, actions, getConfig }) => {
   actions.setWebpackConfig({
     resolve: {
       modules: [path.resolve(__dirname, 'src'), 'node_modules'],
@@ -86,6 +86,17 @@ exports.onCreateWebpackConfig = ({ actions }) => {
       }
     }
   })
+
+  if (stage === 'develop' || stage === 'develop-html') {
+    const config = getConfig()
+    config.devtool = 'eval'
+    if (config.cache && config.cache.type === 'filesystem') {
+      config.cache.maxMemoryGenerations = 1
+      config.cache.compression = 'gzip'
+      config.cache.allowCollectingMemory = true
+    }
+    actions.replaceWebpackConfig(config)
+  }
 }
 
 exports.onPostBuild = async ({ graphql, reporter }) => {

--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
     "clean:build": "gatsby clean",
     "clean:data": "rm -rf data/*.json",
     "contributors": "(npx git-authors-cli && npx finepack && git add package.json && git commit -m 'build: contributors' --no-verify) || true",
-    "dev": "NODE_OPTIONS='--max-old-space-size=8192' gatsby develop --host 0.0.0.0 --port 8000",
+    "dev": "gatsby develop --host 0.0.0.0 --port 8000",
     "lint": "standard",
     "postinstall": "npm run transpile",
     "postrelease": "npm run release:tags && npm run release:github",


### PR DESCRIPTION
Webpack cache is now 957MB with gzip — down from 7.6GB uncompressed. That's an 8x reduction.

```
  ┌────────────────────┬──────────────┬───────────┐
  │                    │ Without gzip │ With gzip │
  ├────────────────────┼──────────────┼───────────┤
  │ stage-develop      │ 4.1 GB       │ 161 MB    │
  ├────────────────────┼──────────────┼───────────┤
  │ stage-develop-html │ 3.5 GB       │ 785 MB    │
  ├────────────────────┼──────────────┼───────────┤
  │ Total              │ 7.6 GB       │ 957 MB    │
  └────────────────────┴──────────────┴───────────┘
```

From the issue thread:
  - @pieh (Gatsby contributor) identified the Head API (4.19.0) as the cause of the memory regression
  - @pixelsoup found disabling source maps was the key fix — we did this with devtool: 'eval'
  - @pieh recommended cache.compression: 'gzip' — reduces cache from 7.6GB to 957MB (8x smaller)
  - @nkuehn tested maxMemoryGenerations and allowCollectingMemory — both help GC reclaim memory

  Final config applied:

```
  config.devtool = 'eval'
  config.cache.maxMemoryGenerations = 1
  config.cache.compression = 'gzip'
  config.cache.allowCollectingMemory = true
```

Results: 315 pages, ~80s build, no --max-old-space-size flag, cache stays under 1GB on disk instead of growing to 50GB+.

Related: https://github.com/gatsbyjs/gatsby/issues/36899
  
  <!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to local dev webpack settings and the dev npm script; production builds are unaffected.
> 
> **Overview**
> This PR speeds up local Gatsby development by tuning webpack only for `develop` / `develop-html`: **`eval`** source maps and tighter **filesystem cache** settings (`maxMemoryGenerations`, gzip compression, memory collection).
> 
> It also **removes** `NODE_OPTIONS='--max-old-space-size=8192'` from the **`dev`** npm script, so `gatsby develop` no longer forces an 8GB Node heap at startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a2f20d85baa0266d066e45f01d841f4f1bd928e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted development build behavior to apply enhanced webpack settings only during local development, improving dev build diagnostics and caching.
  * Simplified the development startup command by removing the manual Node memory setting for a cleaner local launch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->