### PR TITLE
build: use pnpm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -9,3 +9,4 @@ save=false
 shamefully-hoist=true
 strict-peer-dependencies=false
 enable-pre-post-scripts=true
+lockfile=false

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "NODE_ENV=development npm install --legacy-peer-deps",
+  "installCommand": "npm i -g pnpm@latest-11 && NODE_ENV=development pnpm install",
   "headers": [
     {
       "source": "/static/(.*)",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Deploy install path changes can break builds if pnpm lockfile or workspace config is missing on Vercel, though CI already uses pnpm.
> 
> **Overview**
> Switches **Vercel** dependency installation from **npm** (`npm install --legacy-peer-deps`) to **pnpm** by installing **pnpm@latest-11** globally and running `pnpm install` with `NODE_ENV=development`.
> 
> Adds **`lockfile=false`** to **`.npmrc`** so npm does not write/update an npm lockfile—consistent with using pnpm as the package manager for deploys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d0265d9440337fab276e50abcb8b2f84b063b2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled automatic npm lockfile generation to prevent creation of a lockfile during installs, reducing lockfile churn in CI and local environments.
  * Updated deployment install process to install and use pnpm for dependency installation in the development environment, aligning install behavior and improving install performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->