### PR TITLE
feat: serve OG cards from /images/og/ as static files

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -150,8 +150,9 @@ const pageMetadata = pathname => {
   }
 }
 
-// Render an OG card for every page into `public/og/<slug>.png` so the images
-// ship as static files with the build; `Meta.js` points `og:image` at them.
+// Render an OG card for every page into `public/images/og/<slug>.png` so the
+// images ship as plain static files (served at /images/og/<slug>.png, like any
+// other /images asset); `Meta.js` points `og:image` at them.
 //
 // The build fails only on a total failure (the page query fails, generation
 // crashes, or every card fails). A single failed card just warns rather than
@@ -173,7 +174,7 @@ const generateOgImages = async ({ graphql, reporter }) => {
   try {
     cards = await generateOgCards({
       pathnames,
-      outDir: path.join(process.cwd(), 'public', 'og'),
+      outDir: path.join(process.cwd(), 'public', 'images', 'og'),
       metadata: pageMetadata,
       onError: (pathname, error) =>
         reporter.warn(`OG ${pathname}: ${error.message}`)

--- a/src/components/elements/Meta/Meta.js
+++ b/src/components/elements/Meta/Meta.js
@@ -7,7 +7,7 @@ import { useSiteMetadata } from 'components/hook/use-site-meta'
 import React, { useMemo } from 'react'
 import { generateStructuredData } from './structured'
 import { toDate } from 'helpers/to-date'
-import { imageUrl as ogImageUrl } from '@microlink/og'
+import { ogImageUrl } from 'helpers/og'
 
 const getPage = ({ pathname }) => pathname.replace(/\/+$/, '').substring(1)
 
@@ -56,9 +56,9 @@ const mergeMeta = (props, location, metadata) => {
   const url = location ? `${siteUrl}${location.pathname}` : siteUrl
 
   // Prefer an explicit `image` prop, else the per-page card generated at build
-  // time (`public/og/<slug>.png`), falling back to the default banner. The card
-  // lives on the deploy host (`ogImageBase`) — empty in dev, and distinct from
-  // the canonical `siteUrl` on preview deployments.
+  // time (served at `/images/og/<slug>.png`), falling back to the default
+  // banner. The card lives on the deploy host (`ogImageBase`) — empty in dev,
+  // and distinct from the canonical `siteUrl` on preview deployments.
   const image =
     props.image || ogImageUrl(location?.pathname, ogImageBase) || metadata.image
 

--- a/src/helpers/og.js
+++ b/src/helpers/og.js
@@ -1,0 +1,11 @@
+// Build-time OG cards are written to `public/images/og/<slug>.png` and served
+// as plain static files at `/images/og/<slug>.png` — the same space as other
+// `/images/*` assets. `@microlink/og`'s `imagePath` returns `/og/<slug>.png`
+// (or null for pages that don't get a card, e.g. Gatsby internals); we serve
+// it under `/images`.
+import { imagePath } from '@microlink/og'
+
+export const ogImageUrl = (pathname, base) => {
+  const path = imagePath(pathname)
+  return base && path ? `${base}/images${path}` : null
+}


### PR DESCRIPTION
## What

Move the build-time OG cards from `/og/<slug>.png` to **`/images/og/<slug>.png`** — the same static-file URL space as `/images/cookies.jpeg`.

- `gatsby-node.js`: generate into `public/images/og/` (was `public/og/`).
- `src/helpers/og.js`: `ogImageUrl(pathname, base)` = `${base}/images${imagePath(pathname)}` → `…/images/og/<slug>.png`, reusing `@microlink/og`'s `imagePath` (which also returns `null` for pages without a card).
- `Meta.js`: `og:image` uses the helper.

The cards are still build-generated (per-page, metadata-driven), so they live in the build output (`public/images/og/`) and are served at `/images/og/…` exactly like any committed `static/images/*` file. No package change.

## Why

Production `https://microlink.io/og/home.png` was returning **404** — not because the file was missing (it exists in every build), but because **Cloudflare cached a year-long immutable 404** for it during the brief window before the cards first deployed (the `.png` immutable cache header was applied to the 404). Moving to a fresh `/images/og/` path gives a clean cache key, and the new HTML + cards deploy together so there's no 404 window.

## Verify

After deploy: `https://microlink.io/images/og/home.png` → 200, and the homepage `og:image` points there. The old `/og/home.png` can be purged from Cloudflare at leisure (nothing references it anymore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static asset path and meta URL construction only; no auth, data, or generation logic changes beyond output directory and URL prefix.
> 
> **Overview**
> Build-time OG card PNGs are written to **`public/images/og/`** instead of **`public/og/`**, so they are served at **`/images/og/<slug>.png`** alongside other static `/images/*` assets. This gives a new URL path (avoiding a long-lived Cloudflare 404 on the old `/og/…` route) while keeping the same per-page generation flow.
> 
> **`src/helpers/og.js`** adds **`ogImageUrl`**, which still uses `@microlink/og`'s **`imagePath`** but prefixes **`/images`** on the deploy base (e.g. `…/images/og/home.png`). **`Meta.js`** now imports that helper instead of **`imageUrl`** from the package, so **`og:image`** targets the new location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee79c13e2b3b096f217139d46f0681c76dc8ee9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Social sharing cards now use a new image location, improving Open Graph image availability across the site.
  * Added a shared helper for generating page-specific preview image URLs.

* **Bug Fixes**
  * Updated metadata handling so shared links point to the correct preview image path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->