### PR TITLE
docs(blog): rewrite "WebGL Without a GPU" in a plainer voice

### DIFF
--- a/src/content/blog/webgl-without-a-gpu.md
+++ b/src/content/blog/webgl-without-a-gpu.md
@@ -1,7 +1,7 @@
 ---
 title: 'WebGL Without a GPU'
 subtitle: 'How one Chrome flag makes 3D pages render 4× faster'
-description: 'A deep dive into how Microlink renders WebGL screenshots on a GPU-less fleet: the ANGLE delegation chain, why SwiftShader is slow, how Mesa llvmpipe JIT-compiles the pipeline with LLVM, the Xvfb surface requirement, and the silent 2D fallback we guard against in CI.'
+description: 'How Microlink renders WebGL screenshots on a GPU-less fleet: the ANGLE backend, why SwiftShader is slow, how Mesa llvmpipe JIT-compiles the pipeline with LLVM, the Xvfb surface requirement, and the 2D fallback we guard against in CI.'
 authors:
   - kiko
 date: '2026-06-29'
@@ -12,61 +12,50 @@ import { Figcaption } from 'components/markdown/Figcaption'
 import { Video } from 'components/markdown/Video'
 import { BrowserlessReport } from 'components/pages/blog/webgl-without-a-gpu'
 
-WebGL is everywhere now: 3D maps, seat charts, product configurators, shader-art landing pages. It was also the slowest thing you could ask Microlink to [screenshot](/docs/api/parameters/screenshot). One Chrome flag fixed that.
+A lot of the web is WebGL now: 3D maps, seat charts, product configurators, shader-art landing pages. Those were also the slowest pages you could ask Microlink to [screenshot](/docs/api/parameters/screenshot), and the ones most likely to time out. Switching a single Chrome flag fixed most of it. This post walks through why, and the things that flag turned out to depend on.
 
 <Video src="/images/screenshot-animated.mp4" />
 
 <Figcaption>A WebGL page (three.js) captured as an [animated screenshot](/tools/website-screenshot/animated), rendered through Mesa llvmpipe on a GPU-less node</Figcaption>
 
-**TL;DR**
+The short version: our servers have no GPU, but WebGL still has to render somewhere. Chrome's default software path (SwiftShader) took around 24 seconds per 3D page. Pointing Chrome's graphics layer at Mesa llvmpipe instead (`--use-angle=gl`) brought that down to about 6 seconds. The flag is one line; the display setup, the from-source Mesa build, and keeping it on the fast path are the rest of the work.
 
-- Our servers have no GPU. WebGL still has to render somewhere.
-- Chrome's default software path (SwiftShader) took **~24s** per 3D page.
-- Pointing ANGLE at Mesa llvmpipe (`--use-angle=gl`) dropped it to **~6s**.
-- The one-line flag is the easy part. The display, the from-source Mesa, and proving it stays on the fast path are the rest of the story.
+## The constraint
 
-## No GPU, on purpose
+Our browser fleet runs on commodity Linux nodes with no graphics card and no `/dev/dri`. That keeps the machines cheap and means there are no GPU drivers to maintain. The downside is that WebGL is a GPU API, so without one, something has to emulate it on the CPU. The renderer we pick for that emulation is what separated a 24-second screenshot from a 6-second one.
 
-Our browser fleet runs on commodity Linux nodes with no graphics card and no `/dev/dri`. Cheaper, simpler, fewer drivers to babysit. But WebGL is a GPU API, so without one, something has to emulate it on the CPU. *Which* something was the difference between a 24-second screenshot and a 6-second one.
+## How Chrome renders WebGL
 
-## Chrome doesn't render WebGL. ANGLE does.
+Chrome doesn't rasterize WebGL itself. It hands the GL commands to **[ANGLE](https://chromium.googlesource.com/angle/angle/)**, which translates them to whatever backend the platform offers: Direct3D on Windows, Metal on macOS, native OpenGL or Vulkan on Linux, or a software renderer when there's no GPU at all.
 
-Chrome hands WebGL to **[ANGLE](https://chromium.googlesource.com/angle/angle/)**, which translates it to whatever backend the platform has: Direct3D, Metal, native OpenGL or Vulkan, or a software renderer when there's no GPU.
+On a GPU-less node that software renderer is all you have, and Chrome ships two. The default is **SwiftShader**, its own bundled rasterizer. The other is the system OpenGL stack, which on our Linux nodes resolves to **[Mesa llvmpipe](https://docs.mesa3d.org/drivers/llvmpipe.html)**. Both draw the same pixels on the CPU, but they are far apart on speed.
 
-With no GPU, that software renderer is the whole ballgame. Chrome ships two: **SwiftShader**, its bundled default, or the system OpenGL stack, which on our Linux nodes is **[Mesa llvmpipe](https://docs.mesa3d.org/drivers/llvmpipe.html)**. Same pixels on the CPU, wildly different speed.
+## SwiftShader versus llvmpipe
 
-## Why the gap is 4×
+SwiftShader is built to draw correctly anywhere, so it emulates the pipeline conservatively. On a heavy 3D scene that costs around 24 seconds, while the 2D pages next to it finish in 2 to 3.
 
-**SwiftShader** emulates the whole pipeline conservatively, optimizing for "draws correctly anywhere." A heavy 3D scene takes ~24s; the 2D pages next to it, 2-3s.
+llvmpipe takes a different approach, and two design choices account for most of the difference. It uses LLVM to JIT-compile the active shader and GL state into native x86-64, so the inner loop runs compiled rather than interpreted. And it rasterizes in tiles spread across worker threads, so it uses all the cores instead of one. The result is the same image, several times faster.
 
-**llvmpipe** is built differently:
+## The flag change
 
-- **It JITs to native code.** LLVM compiles the live shader and GL state into real x86-64. No interpreter loop.
-- **It is tiled and multi-threaded.** It actually uses every core.
-
-Several times faster, same output.
-
-## The change: one line
+The actual change is a single launch flag:
 
 ```diff
 - '--use-angle=swiftshader',
 + '--use-angle=gl',
 ```
 
-What you must **not** add back:
+Two flags that show up in almost every headless setup quietly break this path, so they have to stay out. `--disable-gpu` forces Chrome back onto SwiftShader, and it's the most-copied flag in the genre. `--in-process-gpu` removes the GPU process that ANGLE binds its GL surface to.
 
-- `--disable-gpu` silently forces SwiftShader on again. It is the most-copied flag in every headless tutorial.
-- `--in-process-gpu` kills the GL surface ANGLE needs.
+## You also need an X display
 
-## The catch: you need a display
+`--use-angle=gl` has to bind a GL surface, and on Linux that requires an X display even in headless mode. Without one, WebGL doesn't error: it silently falls back to a flat 2D rasterizer. The screenshot still succeeds and the request still returns `200`, but the output is wrong in a way that's easy to miss.
 
-`--use-angle=gl` has to bind a GL surface, which needs an X display, even headless. No display, and WebGL **silently degrades to a flat 2D fallback**: the screenshot still succeeds, the request still returns `200`, and the output is wrong but plausible.
+To avoid that, every container starts a virtual display ([Xvfb](https://en.wikipedia.org/wiki/Xvfb)) before Chrome launches, and sets `LIBGL_ALWAYS_SOFTWARE=1` so Mesa stays on llvmpipe.
 
-So every container boots a virtual display ([Xvfb](https://en.wikipedia.org/wiki/Xvfb)) before Chrome starts, with `LIBGL_ALWAYS_SOFTWARE=1` pinning Mesa to llvmpipe.
+## Building Mesa from source
 
-## Why Mesa is built from source
-
-Ubuntu jammy's Mesa is too old for this, and the PPAs that used to backport it are gone. So the base image compiles its own:
+Ubuntu jammy's packaged Mesa is too old for this, and the PPAs that used to backport newer versions are gone. So the base image builds its own:
 
 ```bash
 meson setup build \
@@ -74,38 +63,33 @@ meson setup build \
   -Dllvm=enabled -Dshared-llvm=enabled
 ```
 
-llvmpipe only, no Vulkan, **shared LLVM** (that's where the JIT speed lives). The build toolchain is huge (LLVM, clang, Rust, ~160 `-dev` packages), so the Dockerfile is multi-stage: compile Mesa, then `COPY` only the artifacts into a clean image. **2.65GB instead of 4.5GB.**
+It builds llvmpipe only, skips Vulkan, and links shared LLVM, which is what the JIT relies on. The toolchain to compile it is large (LLVM, clang, Rust, around 160 `-dev` packages), so the Dockerfile is multi-stage: Mesa compiles in a builder stage, and the final image copies only the resulting libraries. That keeps the runtime image at roughly 2.65GB instead of 4.5GB.
 
-## Proving it: browserless.report()
+## Checking what a node actually renders
 
-You can't tell which renderer a node uses by looking at it. `apt list` lies (we side-load Mesa over the package), and the real answer lives inside the page. So [browserless.report()](https://github.com/microlinkhq/browserless) asks the live GL context directly:
+You can't tell which renderer a node is using by looking at the machine. `apt list` reports the packaged Mesa, not the one we side-loaded over it, and the real answer is only available inside a running page. So [browserless](https://github.com/microlinkhq/browserless) has a `report()` method that queries the live GL context directly:
 
 <BrowserlessReport />
 
 <Figcaption>`browserless.report()` from a production node. Expand `gpu` and `cpu` for the full picture.</Figcaption>
 
-The `gpu` block is the whole story:
+The fields under `gpu` are the ones that matter here. `type` reads `software` with a `device` of `llvmpipe`; a `device` of `swiftshader` would mean we'd fallen back, and `hardware` would mean a real GPU had appeared. `mesa` comes from the `libgallium-<ver>.so` that's actually loaded, not from dpkg, which still reports the stale packaged version. And `simdWidth: 256` shows llvmpipe running on AVX2, which accounts for a good part of the speed.
 
-- **`type`** is `software` / `llvmpipe` here. `swiftshader` would mean we fell back; `hardware` would mean a GPU appeared.
-- **`mesa`** is read from the loaded `libgallium-<ver>.so`, not dpkg, which reports the stale package version under our side-load.
-- **`simdWidth: 256`** means llvmpipe is using AVX2, which is most of why it's fast.
+Passing `report({ benchmark: true })` adds a `performance` block: a deterministic shader benchmark that runs in about 300ms on llvmpipe and is useful for comparing two nodes.
 
-`report({ benchmark: true })` adds a deterministic shader benchmark (~300ms on llvmpipe) for comparing nodes.
+## Guarding it in CI
 
-## That report is also the CI gate
+The flat 2D fallback is the dangerous case because it looks like success. So CI runs `report()` and asserts that `gpu.type` is `software` and `gpu.device` is `llvmpipe`. If a flag change, a missing display, or a Mesa regression knocks Chrome off the fast path, the build fails instead of shipping flat 3D. The same check runs against production pods.
 
-The flat-2D fallback is dangerous because it looks like success. So CI asserts on `report()`: `gpu.type` must be `software`, `gpu.device` must be `llvmpipe`. Any drift fails the build instead of shipping flat 3D. The same call runs against production pods.
+## How we measured it
 
-## Most of the work was benchmarking, not coding
+The change is one line, but settling on the right line took a while, mostly because two things made measurement misleading.
 
-The diff is one line. Proving it was the *right* line took weeks of measurement, mostly fighting two traps:
+The first is the dev machine. A laptop or CI runner has a real GPU, so it renders pages that come out black on a GPU-less prod node. Benchmarking on hardware with a GPU tells you nothing about hardware without one, so every number had to come from production-shaped machines.
 
-- **Dev machines lie.** A real GPU renders pages that come back black on prod. Every number had to come from prod-shaped hardware.
-- **Single runs lie.** Cold JIT, first-paint races, shared cores. The fastest-looking result was sometimes the *wrong* one: the flat fallback shipped ~1s quicker.
+The second is variance. llvmpipe pays a one-time JIT cost on its first draw, each page has its own first-paint timing, and nodes under load share cores between captures. Some of the fastest results turned out to be the flat fallback, which finished about a second quicker precisely because it rendered nothing real. To get a number we could trust, we added the deterministic benchmark above: a fixed shader, a fixed frame count, each frame forced to complete. With that, the comparison was consistent: SwiftShader around 24 to 31 seconds, llvmpipe around 6 warm and correct.
 
-That's why the deterministic benchmark exists: fixed shader, forced frames, one stable number. With it, the comparison stopped being anecdotal. SwiftShader landed at ~24-31s; llvmpipe at ~6s warm and correct.
-
-## The numbers
+## Results
 
 Same 3D chart, same GPU-less hardware, measured on production:
 
@@ -116,7 +100,7 @@ Same 3D chart, same GPU-less hardware, measured on production:
 | Failed requests | timed out → errors | none |
 | Active renderer | SwiftShader | llvmpipe (asserted in CI) |
 
-Isolated, the chart finishes in ~6s. Under real traffic, where captures share cores, expect ~2×. Either way, the requests that used to time out now finish.
+In isolation the chart finishes in about 6 seconds. Under real traffic, where captures share cores, it's closer to 2×. In both cases the requests that used to time out now complete.
 
 <MultiCodeEditorInteractive
   mqlCode={{
@@ -125,10 +109,10 @@ Isolated, the chart finishes in ~6s. Under real traffic, where captures share co
   }}
 />
 
-<Figcaption>Try it: a WebGL page captured live through ANGLE → Mesa llvmpipe. See the [animated screenshot docs](/docs/api/parameters/screenshot/animated) for the parameters.</Figcaption>
+<Figcaption>A WebGL page captured live through ANGLE and Mesa llvmpipe. See the [animated screenshot docs](/docs/api/parameters/screenshot/animated) for the parameters.</Figcaption>
 
-## The honest limit
+## Where it still falls short
 
-Software GL closes most of the gap, not all. Heavy fragment-shader heroes can still come back black, because the canvas hasn't painted by capture time. That's a first-paint race, not a renderer problem, and no flag fixes it. The real fixes are gating capture on first paint, or real GPUs. We're doing the first.
+Software rendering closes most of the gap to a real GPU, but not all of it. Heavy fragment-shader heroes can still come back black, because the canvas hasn't painted its first frame by the time the capture fires. That's a first-paint timing problem rather than a renderer one, and no backend flag fixes it. The two real fixes are gating the capture on first paint, or putting real GPUs on those nodes; we're working on the first.
 
-For everything else, moving from SwiftShader to llvmpipe turned our slowest, flakiest requests into ordinary ones.
+For everything short of that, moving from SwiftShader to llvmpipe turned our slowest and flakiest requests into ordinary ones.


### PR DESCRIPTION
Follow-up to #2094. Feedback was that the post read as obviously AI-written.

The tells were the rhetorical headers ("Chrome doesn't render WebGL. ANGLE does.", "The catch: …", "Proving it: …", one-word "The numbers") and the two-beat sentence fragments ("Same pixels on the CPU, wildly different speed.", "Dev machines lie. Single runs lie.").

This flattens the headers to plain descriptive ones, rewrites the fragmenty lines into normal prose, drops the TL;DR list and the bolded inline labels. Same technical content, embeds, code, and numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy edits with no runtime, API, or build impact.
> 
> **Overview**
> **Editorial pass only** on `webgl-without-a-gpu.md`—no changes to embeds, code blocks, benchmarks table, or technical claims.
> 
> The post is rewritten to sound less “AI-polished”: rhetorical section titles become plain headings (e.g. “The constraint”, “How Chrome renders WebGL”), the **TL;DR** bullet list is folded into opening prose, and punchy two-beat fragments are expanded into full sentences. Front matter `description` is slightly shortened; a few captions and `browserless.report()` wording are tightened for clarity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88014d5655ccb244dda86bc529720c3bcf257a43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “WebGL Without a GPU” blog post with clearer explanations of software rendering on GPU-less systems.
  * Refined the performance comparison and benchmarking results, including updated notes on isolated vs. under-load behavior.
  * Reworked the conclusion to highlight remaining limitations and a first-paint timing edge case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->