### PR TITLE
feat: add Skills tab to docs navigation

### DIFF
--- a/src/components/icons/Sparkles.js
+++ b/src/components/icons/Sparkles.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import Svg from 'components/elements/Svg'
+
+export const Sparkles = props => (
+  <Svg
+    xmlns='http://www.w3.org/2000/svg'
+    viewBox='0 0 24 24'
+    width='24'
+    height='24'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='2'
+    strokeLinecap='round'
+    strokeLinejoin='round'
+    aria-label='Sparkles'
+    {...props}
+  >
+    <path d='M16 18a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm0 -12a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm-7 12a6 6 0 0 1 6 -6a6 6 0 0 1 -6 -6a6 6 0 0 1 -6 6a6 6 0 0 1 6 6z' />
+  </Svg>
+)

--- a/src/components/icons/Sparkles.js
+++ b/src/components/icons/Sparkles.js
@@ -12,7 +12,7 @@ export const Sparkles = props => (
     strokeWidth='2'
     strokeLinecap='round'
     strokeLinejoin='round'
-    aria-label='Sparkles'
+    aria-hidden='true'
     {...props}
   >
     <path d='M16 18a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm0 -12a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm-7 12a6 6 0 0 1 6 -6a6 6 0 0 1 -6 -6a6 6 0 0 1 -6 6a6 6 0 0 1 6 6z' />

--- a/src/components/patterns/Aside/constants.js
+++ b/src/components/patterns/Aside/constants.js
@@ -47,7 +47,8 @@ export const DOC_TABS = [
   {
     name: 'CARDS',
     path: '/docs/cards/getting-started/overview'
-  }
+  },
+  { name: 'Skills ✨', path: '/skills' }
 ]
 
 const ROUTES_SDK = [

--- a/src/components/patterns/Aside/constants.js
+++ b/src/components/patterns/Aside/constants.js
@@ -5,6 +5,7 @@ import { Vue } from 'components/icons/Vue'
 import { Hugo } from 'components/icons/Hugo'
 import { Eleventy } from 'components/icons/Eleventy'
 import { _React as ReactIcon } from 'components/icons/React'
+import { Sparkles } from 'components/icons/Sparkles'
 
 const Icons = {
   HourGlass,
@@ -48,7 +49,7 @@ export const DOC_TABS = [
     name: 'CARDS',
     path: '/docs/cards/getting-started/overview'
   },
-  { name: 'Skills ✨', path: '/skills' }
+  { name: 'Skills', path: '/skills', icon: Sparkles }
 ]
 
 const ROUTES_SDK = [

--- a/src/components/patterns/DocTabs/DocTabs.js
+++ b/src/components/patterns/DocTabs/DocTabs.js
@@ -71,6 +71,7 @@ const DocTabs = ({ activeRouteName }) => {
               >
                 {tab.name}
               </Text>
+              {tab.icon && <tab.icon width='14px' height='14px' />}
             </Flex>
           </TabButton>
         ))}


### PR DESCRIPTION
Adds a **Skills** tab to the docs navigation, linking to `/skills`.

## What changed
- `DOC_TABS` gets a new entry `{ name: 'Skills', path: '/skills', icon: Sparkles }`. Both the desktop `DocTabs` bar and the mobile `Aside` `<Select>` render from `DOC_TABS`, so the tab appears in both automatically.
- New `Sparkles` icon component (`src/components/icons/Sparkles.js`) using the Tabler sparkles path, matching the existing stroke-based icon pattern (`WandSparkles`, `Bug`).
- `DocTabs` renders the icon inline after the label inside the existing `Flex gap:2`.

## Note
Icon size is passed as `'14px'` strings, not numeric props: `@techstack/styled-system` resolves a numeric `width={14}` against `theme.sizes` (index 14 = `100%`), which stretched the tab to full width. String values bypass the scale lookup.

## Verification
Ran the dev server and confirmed the tab bar renders `API · GUIDES · MQL · SDK · CARDS · SKILLS ✦`, the icon inherits the muted `black50` color, and the tab links to `/skills` (page already exists at `src/pages/skills.js`). Mobile `<Select>` shows plain "Skills" text and navigates to `/skills`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and presentational UI only; no auth, data, or API changes.
> 
> **Overview**
> Adds a **Skills** entry to `DOC_TABS` (`/skills`) with a new stroke-based **Sparkles** icon, so desktop `DocTabs` and the mobile aside `<Select>` both pick up the tab from the shared config.
> 
> **DocTabs** now optionally renders `tab.icon` beside the label (14px via string `width`/`height` so theme size scale doesn’t blow up layout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 219d7cf57823f13f9a75675931a71e0cf402d6a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Skills” tab to the documentation navigation.
  * Introduced a Sparkles icon and enabled documentation tabs to optionally render an icon beneath the tab label (14px) when available.
  * Decorative tab icons are marked as non-informative for assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->