### PR TITLE
docs(markdown): add YouTube transcript

### DIFF
--- a/src/content/docs/guides/content-conversion/url-to-markdown.md
+++ b/src/content/docs/guides/content-conversion/url-to-markdown.md
@@ -94,6 +94,27 @@ If the full page includes navigation, footers, or cookie banners, scope the rule
 
 For LLM and indexing workflows, setting [meta](/docs/api/parameters/meta) to `true` prepends YAML frontmatter with normalized fields such as title, description, author, publisher, date, word count, and reading time. Keep `meta: false` when you only want the Markdown body.
 
+## YouTube videos
+
+Point [url](/docs/api/parameters/url) at a YouTube video URL — `watch`, `youtu.be`, `shorts`, or `embed` — and Microlink returns the video's caption transcript as the Markdown body, with `title`, `author`, `image`, and `date` resolved from the video metadata.
+
+<MultiCodeEditorInteractive
+  height={280}
+  mqlCode={{
+    url: 'https://www.youtube.com/watch?v=tY2M2g-tG1Q',
+    data: {
+      transcript: {
+        attr: 'markdown'
+      }
+    },
+    meta: false
+  }}
+/>
+
+<Figcaption>Read the caption transcript from <code>data.transcript</code>.</Figcaption>
+
+The transcript is the video's own caption language — manual subtitles when the creator provided them, otherwise the auto-generated ones. Videos without captions, and live or private videos, return the standard metadata without a transcript body.
+
 ## Supported source formats
 
 Any HTML page works. Direct file URLs are converted first: PDFs with a text layer, and the office formats `docx`, `xlsx`, `pptx`, `odt`, `rtf`, and `epub`. Image-only PDF scans, the legacy binary formats (`doc`, `xls`, `ppt`), and the OpenDocument spreadsheet and presentation formats (`ods`, `odp`) are not converted: the request still succeeds, but the field is left as the raw response instead of readable Markdown.


### PR DESCRIPTION
When a YouTube URL is provided, it's now possible to get video transcript as part of the markdown output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API implementation in this diff.
> 
> **Overview**
> Adds a **YouTube videos** section to the URL to Markdown guide, documenting how to fetch caption transcripts as Markdown via `data.transcript` with `attr: 'markdown'`.
> 
> It covers supported URL shapes (`watch`, `youtu.be`, `shorts`, `embed`), includes an interactive example, and notes caption vs auto-generated subtitles plus behavior when captions are missing or the video is live/private.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88cb6e2d4d0943b6e3fe4992c101618826ac6fdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “YouTube videos” section to the content conversion guide.
  * Documented how YouTube links can be converted to Markdown, including supported URL formats and the metadata returned.
  * Included an example configuration for transcript-based Markdown output.
  * Clarified behavior for videos without captions, as well as live or private videos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->