### PR TITLE
fix: give footer giant email full glyph height

### DIFF
--- a/src/components/patterns/Footer/Footer.js
+++ b/src/components/patterns/Footer/Footer.js
@@ -343,7 +343,6 @@ const GiantEmail = () => (
     onClick={() => track('Email', { location: 'Footer' })}
     css={theme({
       display: 'block',
-      overflow: 'hidden',
       opacity: 0.08,
       transition: `opacity ${transition.medium}`,
       _hover: { opacity: 0.16 }
@@ -351,17 +350,16 @@ const GiantEmail = () => (
   >
     <Box
       as='svg'
-      viewBox='0 0 1000 130'
+      viewBox='0 0 1000 128'
       preserveAspectRatio='xMinYMax meet'
       css={theme({
         display: 'block',
-        width: '100%',
-        transform: 'translateY(14%)'
+        width: '100%'
       })}
     >
       <text
         x='0'
-        y='110'
+        y='100'
         textLength='1000'
         lengthAdjust='spacingAndGlyphs'
         fontFamily={fonts.sans}


### PR DESCRIPTION
The @ descends 0.209em below the baseline in Inter Bold but the SVG left only 20/130 units under the baseline and translateY(14%) inside an overflow:hidden wrapper clipped it further. viewBox and baseline now match the measured ink bounds of the string (99.8 above, 27.2 below at fontSize 130), no transform needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Footer presentation-only SVG/layout tweak with no auth, data, or API impact.
> 
> **Overview**
> Fixes clipping of the footer **giant email** SVG so descenders (e.g. on `@`) render fully instead of being cut off.
> 
> The SVG **viewBox** is tightened from `0 0 1000 130` to `0 0 1000 128` with the text baseline moved from `y='110'` to `y='100'` to match Inter Bold ink bounds at `fontSize` 130. The wrapper no longer uses `overflow: 'hidden'`, and the SVG no longer applies `translateY(14%)`—positioning is handled by the viewBox alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 744a7ac36fafa2cf664a79302a9eca957c1f30c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the vertical alignment and spacing of the footer’s large email graphic for a cleaner visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->