### PR TITLE
feat: highlight enterprise caption with rough-notation

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: verify
+description: Verify UI changes in microlink/www by driving the Gatsby dev server with agent-browser.
+---
+
+# Verify microlink/www changes
+
+## Launch
+
+Kiko usually has `npm run dev` already running on port 8000 — check with
+`lsof -nP -iTCP:8000 -sTCP:LISTEN` before starting one (it serves this repo and
+hot-reloads edits). If nothing is listening, run `npm run dev` in the background;
+`predev` fetches remote data first, allow ~1-2 min until pages compile.
+
+## Drive
+
+Gatsby dev renders client-side, so `curl` won't show page content — use the
+agent-browser skill:
+
+```bash
+agent-browser open http://localhost:8000/<page>
+agent-browser wait --load networkidle   # first hit compiles the page; retry screenshot if it shows "Preparing requested page"
+agent-browser screenshot out.png
+agent-browser set viewport 480 800       # mobile check
+agent-browser set media light reduced-motion   # a11y motion check
+agent-browser eval "<js>"                # inspect DOM state
+```
+
+## Gotchas
+
+- `[error] 404 page could not be found` in the console is a Gatsby dev artifact, not a bug.
+- SPA navigation: exercise mount/unmount by clicking a `Link` then `window.history.back()` via eval.
+- Lint changed files with `npx standard <files>`.

--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -510,7 +510,7 @@
   "src/pages/embed/index.js": "2026-07-11T00:00:00.000Z",
   "src/pages/embed/providers.js": "2026-07-08T00:00:00.000Z",
   "src/pages/embed/template.js": "2019-06-09T00:00:00.000Z",
-  "src/pages/enterprise.js": "2026-07-11T00:00:00.000Z",
+  "src/pages/enterprise.js": "2026-07-12T00:00:00.000Z",
   "src/pages/feature/headers.js": "2026-06-27T00:00:00.000Z",
   "src/pages/feature/proxy.js": "2026-06-27T00:00:00.000Z",
   "src/pages/feature/ttl.js": "2026-06-27T00:00:00.000Z",

--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -228,7 +228,7 @@
   "src/content/docs/sdk/parameters/url.md": "2026-01-10T00:00:00.000Z",
   "src/content/dpa.md": "2026-01-21T00:00:00.000Z",
   "src/content/fragments/changelog.md": "2026-07-06T00:00:00.000Z",
-  "src/content/fragments/enterprise.md": "2026-07-11T00:00:00.000Z",
+  "src/content/fragments/enterprise.md": "2026-07-12T00:00:00.000Z",
   "src/content/privacy.md": "2026-01-13T00:00:00.000Z",
   "src/content/security.md": "2026-01-10T00:00:00.000Z",
   "src/content/styleguide.md": "2026-01-10T00:00:00.000Z",

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "react-twitter-widgets": "~1.11.0",
     "rehype-slug": "~6.0.0",
     "remark-gfm": "~3.0.1",
+    "rough-notation": "~0.5.1",
     "sass": "~1.97.3",
     "simple-icons": "~16.24.1",
     "styled-components": "~6.3.11",

--- a/src/components/elements/Annotation.js
+++ b/src/components/elements/Annotation.js
@@ -1,0 +1,54 @@
+/* global IntersectionObserver */
+
+import React, { useEffect, useRef } from 'react'
+import { annotate } from 'rough-notation'
+import { colors } from 'theme'
+
+const Annotation = ({
+  type = 'highlight',
+  color = 'yellow2',
+  animationDuration = 800,
+  multiline = true,
+  children,
+  ...props
+}) => {
+  const ref = useRef(null)
+
+  useEffect(() => {
+    const { current } = ref
+    if (!current) return
+
+    const annotation = annotate(current, {
+      type,
+      color: colors[color] || color,
+      animate: !window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+      animationDuration,
+      multiline
+    })
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          annotation.show()
+          observer.disconnect()
+        }
+      },
+      { threshold: 1 }
+    )
+
+    observer.observe(current)
+
+    return () => {
+      observer.disconnect()
+      annotation.remove()
+    }
+  }, [type, color, animationDuration, multiline])
+
+  return (
+    <span ref={ref} {...props}>
+      {children}
+    </span>
+  )
+}
+
+export default Annotation

--- a/src/content/fragments/enterprise.md
+++ b/src/content/fragments/enterprise.md
@@ -14,7 +14,16 @@ Running a **Microlink Enterprise** plan means:
 - A GDPR-compliant [Data Processing Agreement](/dpa).
 - Enterprise onboarding and launch validation.
 
-The physical servers associated with your Microlink API endpoint can be chosen from 8 locations (🇺🇸 New York, 🇺🇸 San Francisco, 🇳🇱 Amsterdam, 🇸🇬 Singapore, 🇬🇧 London, 🇩🇪 Frankfurt, 🇨🇦 Toronto, or 🇮🇳 Bangalore).
+The physical servers associated with your Microlink API endpoint can be chosen from 8 locations:
+
+- 🇺🇸 New York
+- 🇺🇸 San Francisco
+- 🇳🇱 Amsterdam
+- 🇸🇬 Singapore
+- 🇬🇧 London
+- 🇩🇪 Frankfurt
+- 🇨🇦 Toronto
+- 🇮🇳 Bangalore
 
 Enterprise pricing has two parts: an infrastructure subscription for your dedicated environment, plus a usage plan tier that follows the same model as **Microlink Pro**.
 

--- a/src/content/fragments/enterprise.md
+++ b/src/content/fragments/enterprise.md
@@ -1,8 +1,9 @@
 import { CDN_EDGES } from 'helpers/cdn-edges'
+import Annotation from 'components/elements/Annotation'
 
 The **Microlink Enterprise** plan is designed for customers who want to maximize Microlink's capabilities, unleashing maximum performance with dedicated hardware and seamless software integration with their existing infrastructure.
 
-If your **Microlink Pro** plan is hitting its limits or you need fully isolated infrastructure, **Microlink Enterprise** is the next step.
+If your **Microlink Pro** plan is hitting its limits or you need <Annotation type='underline' color='secondary'>fully isolated infrastructure</Annotation>, **Microlink Enterprise** is the next step.
 
 Running a **Microlink Enterprise** plan means:
 
@@ -10,11 +11,11 @@ Running a **Microlink Enterprise** plan means:
 - Your own S3-like storage service for asset integration, with no time-to-live (TTL) restrictions.
 - Your own worldwide CDN distribution ({CDN_EDGES} nodes around the world, powered by Cloudflare).
 - Priority support via email and Slack, with direct access to the Microlink team and a maximum 12-hour response time.
-- 99.9% uptime SLA.
+- <Annotation type='box' color='secondary'>99.9% uptime SLA</Annotation>.
 - A GDPR-compliant [Data Processing Agreement](/dpa).
 - Enterprise onboarding and launch validation.
 
-The physical servers associated with your Microlink API endpoint can be chosen from 8 locations:
+The physical servers associated with your Microlink API endpoint can be chosen from <Annotation type='circle' color='secondary'>8 locations</Annotation>:
 
 - 🇺🇸 New York
 - 🇺🇸 San Francisco
@@ -29,6 +30,6 @@ Enterprise pricing has two parts: an infrastructure subscription for your dedica
 
 Usage costs scale linearly with your traffic, so growth never changes your subscription, only the usage component. 
 
-Annual commitments get a 10% discount. 
+Annual commitments get a <Annotation>10% discount</Annotation>. 
 
 Final terms are negotiated based on your specific needs.

--- a/src/content/fragments/enterprise.md
+++ b/src/content/fragments/enterprise.md
@@ -1,7 +1,7 @@
 import { CDN_EDGES } from 'helpers/cdn-edges'
 import Annotation from 'components/elements/Annotation'
 
-**Microlink Enterprise** is the Microlink API running on <Annotation type='underline' color='secondary'>hardware that serves only you</Annotation>. No shared capacity. No noisy neighbors. One environment, tuned for your workload, integrated with your existing infrastructure.
+**Microlink Enterprise** is the Microlink API running on <Annotation>hardware that serves only you</Annotation>. No shared capacity. No noisy neighbors. One environment, tuned for your workload, integrated with your existing infrastructure.
 
 When **Microlink Pro** starts hitting its limits, this is the next step.
 
@@ -11,11 +11,11 @@ Everything is yours:
 - Your own S3-like storage for assets, with no time-to-live (TTL) restrictions.
 - Your own worldwide CDN: {CDN_EDGES} nodes, powered by Cloudflare.
 - Priority support via email and Slack, with direct access to the Microlink team and a 12-hour maximum response time.
-- <Annotation type='box' color='secondary'>99.9% uptime SLA</Annotation>.
+- <Annotation>99.9% uptime SLA</Annotation>.
 - A GDPR-compliant [Data Processing Agreement](/dpa).
 - Enterprise onboarding and launch validation.
 
-Choose where your hardware lives, from <Annotation type='circle' color='secondary'>8 locations</Annotation>:
+Choose where your hardware lives, from <Annotation>8 locations</Annotation>:
 
 - 🇺🇸 New York
 - 🇺🇸 San Francisco

--- a/src/content/fragments/enterprise.md
+++ b/src/content/fragments/enterprise.md
@@ -1,21 +1,21 @@
 import { CDN_EDGES } from 'helpers/cdn-edges'
 import Annotation from 'components/elements/Annotation'
 
-The **Microlink Enterprise** plan is designed for customers who want to maximize Microlink's capabilities, unleashing maximum performance with dedicated hardware and seamless software integration with their existing infrastructure.
+**Microlink Enterprise** is the Microlink API running on <Annotation type='underline' color='secondary'>hardware that serves only you</Annotation>. No shared capacity. No noisy neighbors. One environment, tuned for your workload, integrated with your existing infrastructure.
 
-If your **Microlink Pro** plan is hitting its limits or you need <Annotation type='underline' color='secondary'>fully isolated infrastructure</Annotation>, **Microlink Enterprise** is the next step.
+When **Microlink Pro** starts hitting its limits, this is the next step.
 
-Running a **Microlink Enterprise** plan means:
+Everything is yours:
 
-- Your own Microlink API endpoint, isolated from other customers, with your own dedicated pool of always-ready browsers.
-- Your own S3-like storage service for asset integration, with no time-to-live (TTL) restrictions.
-- Your own worldwide CDN distribution ({CDN_EDGES} nodes around the world, powered by Cloudflare).
-- Priority support via email and Slack, with direct access to the Microlink team and a maximum 12-hour response time.
+- Your own API endpoint, isolated from other customers, backed by a dedicated pool of always-ready browsers.
+- Your own S3-like storage for assets, with no time-to-live (TTL) restrictions.
+- Your own worldwide CDN: {CDN_EDGES} nodes, powered by Cloudflare.
+- Priority support via email and Slack, with direct access to the Microlink team and a 12-hour maximum response time.
 - <Annotation type='box' color='secondary'>99.9% uptime SLA</Annotation>.
 - A GDPR-compliant [Data Processing Agreement](/dpa).
 - Enterprise onboarding and launch validation.
 
-The physical servers associated with your Microlink API endpoint can be chosen from <Annotation type='circle' color='secondary'>8 locations</Annotation>:
+Choose where your hardware lives, from <Annotation type='circle' color='secondary'>8 locations</Annotation>:
 
 - 🇺🇸 New York
 - 🇺🇸 San Francisco
@@ -26,10 +26,6 @@ The physical servers associated with your Microlink API endpoint can be chosen f
 - 🇨🇦 Toronto
 - 🇮🇳 Bangalore
 
-Enterprise pricing has two parts: an infrastructure subscription for your dedicated environment, plus a usage plan tier that follows the same model as **Microlink Pro**.
+Pricing is two numbers: infrastructure and usage. Infrastructure is a flat subscription for your dedicated environment. Usage follows the same model as **Microlink Pro**, scaling linearly with your traffic. Growth never touches your subscription.
 
-Usage costs scale linearly with your traffic, so growth never changes your subscription, only the usage component. 
-
-Annual commitments get a <Annotation>10% discount</Annotation>. 
-
-Final terms are negotiated based on your specific needs.
+Annual commitments get a <Annotation>10% discount</Annotation>. Final terms are negotiated to fit your needs.

--- a/src/pages/enterprise.js
+++ b/src/pages/enterprise.js
@@ -6,7 +6,6 @@ import Markdown from 'components/markdown'
 import { trackEvent } from 'helpers/plausible'
 import React from 'react'
 
-import Annotation from 'components/elements/Annotation'
 import Box from 'components/elements/Box'
 import { Button } from 'components/elements/Button/Button'
 import Caps from 'components/elements/Caps'
@@ -39,8 +38,8 @@ const EnterprisePage = () => {
               maxWidth: layout.small
             })}
           >
-            The Microlink API <Annotation>you own</Annotation>. Dedicated
-            endpoint, always-ready browsers, worldwide CDN.
+            The Microlink API you own. Dedicated endpoint, always-ready
+            browsers, worldwide CDN.
           </Caption>
           <Box
             css={themeProp({

--- a/src/pages/enterprise.js
+++ b/src/pages/enterprise.js
@@ -39,8 +39,9 @@ const EnterprisePage = () => {
               maxWidth: layout.small
             })}
           >
-            For high-volume customers who've{' '}
-            <Annotation>outgrown shared infrastructure</Annotation>.
+            The Microlink API on{' '}
+            <Annotation>dedicated infrastructure</Annotation>: your own
+            endpoint, browser pool, and worldwide CDN.
           </Caption>
           <Box
             css={themeProp({

--- a/src/pages/enterprise.js
+++ b/src/pages/enterprise.js
@@ -39,7 +39,7 @@ const EnterprisePage = () => {
             })}
           >
             The Microlink API you own. Dedicated endpoint, always-ready
-            browsers, worldwide CDN.
+            infrastructure, worldwide distribution.
           </Caption>
           <Box
             css={themeProp({

--- a/src/pages/enterprise.js
+++ b/src/pages/enterprise.js
@@ -6,6 +6,7 @@ import Markdown from 'components/markdown'
 import { trackEvent } from 'helpers/plausible'
 import React from 'react'
 
+import Annotation from 'components/elements/Annotation'
 import Box from 'components/elements/Box'
 import { Button } from 'components/elements/Button/Button'
 import Caps from 'components/elements/Caps'
@@ -38,7 +39,8 @@ const EnterprisePage = () => {
               maxWidth: layout.small
             })}
           >
-            For high-volume customers who've outgrown shared infrastructure.
+            For high-volume customers who've{' '}
+            <Annotation>outgrown shared infrastructure</Annotation>.
           </Caption>
           <Box
             css={themeProp({

--- a/src/pages/enterprise.js
+++ b/src/pages/enterprise.js
@@ -39,9 +39,8 @@ const EnterprisePage = () => {
               maxWidth: layout.small
             })}
           >
-            The Microlink API on{' '}
-            <Annotation>dedicated infrastructure</Annotation>: your own
-            endpoint, browser pool, and worldwide CDN.
+            The Microlink API <Annotation>you own</Annotation>. Dedicated
+            endpoint, always-ready browsers, worldwide CDN.
           </Caption>
           <Box
             css={themeProp({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Marketing copy and a small presentational component only; no API, auth, or billing logic changes.
> 
> **Overview**
> Adds **`rough-notation`** and a reusable **`Annotation`** component that draws scroll-triggered highlights (with **`prefers-reduced-motion`** respected) on wrapped text.
> 
> The Enterprise page gets a **rewritten** hero caption and **`enterprise.md`** copy, with **`Annotation`** on phrases like dedicated hardware, SLA, regions, and annual discount. Server locations move from inline prose to a **bullet list**.
> 
> Also adds a **`.claude/skills/verify`** skill for checking UI via **agent-browser** against the Gatsby dev server, plus **git timestamp** bumps for touched content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa20755b1ee996a14a34cc339095d59d08f745d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual annotations to highlight key Enterprise plan benefits.
  * Updated Enterprise messaging to emphasize dedicated infrastructure, global distribution, and customer-owned API access.
  * Clarified Enterprise offerings, including dedicated endpoints, isolated browser capacity, unlimited asset storage, priority support, uptime commitments, and onboarding.
  * Simplified pricing explanations, including infrastructure subscription, usage-based scaling, and annual discounts.
  * Added an explicit list of available server locations.

* **Documentation**
  * Added guidance for verifying UI changes across viewports, accessibility settings, and page navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->