### PR TITLE
Hero

### DIFF
--- a/src/components/pages/home/hero.js
+++ b/src/components/pages/home/hero.js
@@ -1248,6 +1248,72 @@ const renderJsValue = (value, keyBase) => {
   )
 }
 
+const jsValueText = value => {
+  if (typeof value === 'string') {
+    return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+  }
+  if (typeof value !== 'object' || value === null) return String(value)
+  return `{ ${Object.entries(value)
+    .map(([k, v]) => `${k}: ${jsValueText(v)}`)
+    .join(', ')} }`
+}
+
+const snippetText = (snippet, arg) => {
+  const call = snippet.code
+    ? `(\n  '${arg}',\n  ${snippet.code}\n)`
+    : `('${arg}'${snippet.opts ? `, ${jsValueText(snippet.opts)}` : ''})`
+  return [
+    INSTALL_COMMENT,
+    "import createClient from 'microlink.io'",
+    '',
+    'const microlink = createClient({ apiKey: process.env.MICROLINK_API_KEY })',
+    '',
+    `const ${snippet.binding} = await microlink.${snippet.method}${call}`,
+    '',
+    `// ${snippet.comment}`,
+    `console.log(${snippet.log})`
+  ].join('\n')
+}
+
+const copyPayload = (req, tab, snippet, snippetArg) => {
+  if (tab === 'headers') {
+    return (req.headerRows || []).map(({ k, v }) => `${k}: ${v}`).join('\n')
+  }
+  if (tab === 'timing') {
+    return (req.rows || [])
+      .map(({ name, dur, pct }) => `${name}  ${dur}  ${pct}`)
+      .join('\n')
+  }
+  if (tab === 'code') return snippetText(snippet, snippetArg)
+  return JSON.stringify(req.body, null, 2)
+}
+
+const CopyResultButton = styled.button`
+  cursor: pointer;
+  transition: color ${transition.short};
+  ${theme({
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    border: 0,
+    bg: 'transparent',
+    color: 'gray6',
+    p: 1,
+    pb: '14px',
+    borderRadius: 2
+  })};
+
+  &[data-copied='true'] {
+    ${theme({ color: 'green8' })};
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      ${theme({ color: 'black' })};
+    }
+  }
+`
+
 const ResultPanel = React.memo(({ tab, setTab, req }) => {
   const { D, status, body, headerRows, bars, rows, totalMs } = req
   const isLoading = status === 'loading'
@@ -1256,6 +1322,23 @@ const ResultPanel = React.memo(({ tab, setTab, req }) => {
   const hideTabs = isError || isRateLimited
   const snippet = CODE_TAB[D.vertical]
   const snippetArg = snippet.query ? SEARCH_EXAMPLE.query : D.fullUrl
+
+  const [copied, setCopied] = useState(false)
+  const copiedTimer = useRef(null)
+  useEffect(() => () => clearTimeout(copiedTimer.current), [])
+
+  const copyResult = () => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return
+    navigator.clipboard
+      .writeText(copyPayload(req, tab, snippet, snippetArg))
+      .then(() => {
+        trackEvent('hero copy result', { tab, product: D.vertical })
+        setCopied(true)
+        clearTimeout(copiedTimer.current)
+        copiedTimer.current = setTimeout(() => setCopied(false), 1500)
+      })
+      .catch(() => {})
+  }
 
   const tabs = [
     { key: 'output', label: 'Output' },
@@ -1350,35 +1433,50 @@ const ResultPanel = React.memo(({ tab, setTab, req }) => {
         </Mono>
       </Flex>
 
-      <TabBar
-        ref={barRef}
-        role='tablist'
-        aria-label='Response views'
-        onKeyDown={onTabKeyDown}
+      <Flex
         css={theme({
+          alignItems: 'center',
+          justifyContent: 'space-between',
           pt: 3,
           px: 3,
           borderBottom: 1,
           borderBottomColor: 'gray1'
         })}
       >
-        {tabs.map(t => (
-          <TabButton
-            key={t.key}
-            id={`hero-tab-${t.key}`}
-            role='tab'
-            aria-selected={tab === t.key}
-            aria-controls='hero-tabpanel'
-            tabIndex={tab === t.key ? 0 : -1}
-            data-active={tab === t.key}
-            $active={tab === t.key}
-            onClick={() => setTab(t.key)}
+        <TabBar
+          ref={barRef}
+          role='tablist'
+          aria-label='Response views'
+          onKeyDown={onTabKeyDown}
+        >
+          {tabs.map(t => (
+            <TabButton
+              key={t.key}
+              id={`hero-tab-${t.key}`}
+              role='tab'
+              aria-selected={tab === t.key}
+              aria-controls='hero-tabpanel'
+              tabIndex={tab === t.key ? 0 : -1}
+              data-active={tab === t.key}
+              $active={tab === t.key}
+              onClick={() => setTab(t.key)}
+            >
+              {t.label}
+            </TabButton>
+          ))}
+          <TabIndicator ref={indicatorRef} />
+        </TabBar>
+        {!hideTabs && !isLoading && body && (
+          <CopyResultButton
+            type='button'
+            data-copied={copied}
+            aria-label='Copy result'
+            onClick={copyResult}
           >
-            {t.label}
-          </TabButton>
-        ))}
-        <TabIndicator ref={indicatorRef} />
-      </TabBar>
+            {copied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
+          </CopyResultButton>
+        )}
+      </Flex>
 
       <TabContent
         key={isError ? 'error' : isRateLimited ? 'rate-limited' : tab}

--- a/src/components/pages/home/hero.js
+++ b/src/components/pages/home/hero.js
@@ -147,7 +147,6 @@ const {
   INITIAL_VERTICAL,
   heroDemoPath,
   shortUrl,
-  demoKey,
   canonicalDemoUrl
 } = heroDemoRequests
 
@@ -383,10 +382,6 @@ const EXAMPLE_CHIPS = [
 ].map(vertical => ({ text: PROMPTS[vertical], vertical }))
 
 const VERT_BORDER_ACTIVE = rgba(colors.grape7, 0.45)
-
-const DEMO_KEYS = new Set(Object.values(DEFAULT_URLS).map(demoKey))
-
-const isDemoUrl = url => DEMO_KEYS.has(demoKey(url))
 
 const derive = (text, override) => {
   const p = parseLocal(text)
@@ -2091,8 +2086,10 @@ const Hero = () => {
   }
 
   const typedUrl = () => {
-    const { raw } = parseLocal(dText)
-    return raw && !isDemoUrl(raw) ? raw : null
+    const p = parseLocal(dText)
+    if (!p.raw) return null
+    const v = dVert || p.vertical
+    return canonicalDemoUrl(p.url, v) === DEFAULT_URLS[v] ? null : p.raw
   }
 
   const pickExample = value => () => {

--- a/src/components/pages/home/hero.js
+++ b/src/components/pages/home/hero.js
@@ -1275,7 +1275,7 @@ const snippetText = (snippet, arg) => {
   ].join('\n')
 }
 
-const copyPayload = (req, tab, snippet, snippetArg) => {
+const copyBody = (req, tab, snippet, snippetArg) => {
   if (tab === 'headers') {
     return (req.headerRows || []).map(({ k, v }) => `${k}: ${v}`).join('\n')
   }
@@ -1287,6 +1287,9 @@ const copyPayload = (req, tab, snippet, snippetArg) => {
   if (tab === 'code') return snippetText(snippet, snippetArg)
   return JSON.stringify(req.body, null, 2)
 }
+
+const copyPayload = (req, tab, snippet, snippetArg) =>
+  `// ${req.apiUrl}\n${copyBody(req, tab, snippet, snippetArg)}`
 
 const CopyResultButton = styled.button`
   cursor: pointer;

--- a/src/components/pages/home/output.js
+++ b/src/components/pages/home/output.js
@@ -347,11 +347,13 @@ const LighthouseOutput = ({ url }) => (
 )
 
 const TechCard = styled(Flex)`
-  align-items: center;
-  gap: 10px;
-  width: 232px;
-  border: 1px solid ${colors.gray1};
-  border-radius: 10px;
+  ${theme({
+    alignItems: 'center',
+    gap: 3,
+    border: 1,
+    borderColor: 'gray1',
+    borderRadius: '10px'
+  })};
 `
 
 const TechnologiesOutput = ({ technologies }) => {
@@ -362,16 +364,17 @@ const TechnologiesOutput = ({ technologies }) => {
     <PanelContent
       css={theme({ p: 3, maxHeight: PANEL_HEIGHT, overflow: 'auto' })}
     >
-      <Flex
+      <Box
         css={theme({
-          justifyContent: 'center',
-          flexWrap: 'wrap',
-          gap: 2,
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+          gap: 3,
+          width: '100%',
           my: 'auto'
         })}
       >
         {technologies.map(tech => (
-          <TechCard key={tech.name} css={theme({ p: 2 })}>
+          <TechCard key={tech.name} css={theme({ p: 3 })}>
             {tech.logo && (
               <Box
                 as='img'
@@ -379,8 +382,8 @@ const TechnologiesOutput = ({ technologies }) => {
                 alt=''
                 loading='lazy'
                 css={theme({
-                  width: '30px',
-                  height: '30px',
+                  width: '40px',
+                  height: '40px',
                   objectFit: 'contain',
                   flexShrink: 0
                 })}
@@ -394,7 +397,7 @@ const TechnologiesOutput = ({ technologies }) => {
                 rel='noopener noreferrer'
                 css={theme({
                   display: 'block',
-                  fontSize: 0,
+                  fontSize: 1,
                   fontWeight: 'bold',
                   color: 'black',
                   textDecoration: 'none'
@@ -407,7 +410,7 @@ const TechnologiesOutput = ({ technologies }) => {
                   as='span'
                   css={theme({
                     display: 'block',
-                    fontSize: '12px',
+                    fontSize: 0,
                     color: 'gray6',
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',
@@ -420,7 +423,7 @@ const TechnologiesOutput = ({ technologies }) => {
             </Box>
           </TechCard>
         ))}
-      </Flex>
+      </Box>
     </PanelContent>
   )
 }

--- a/test/components/home-hero-copy-result.js
+++ b/test/components/home-hero-copy-result.js
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'vitest'
+import { sourceHarness } from '../utils/eval-source.mjs'
+
+const { source, slice, evaluate } = sourceHarness(
+  'src/components/pages/home/hero.js'
+)
+
+const helpers = [
+  "const INSTALL_COMMENT = '// npm install microlink.io'",
+  slice('const jsValueText', 'const CopyResultButton')
+].join('\n')
+
+const copyPayload = evaluate(helpers, 'copyPayload')
+const snippetText = evaluate(helpers, 'snippetText')
+
+describe('hero copy result', () => {
+  test('the tab bar hosts a copy result button', () => {
+    expect(source).toContain("aria-label='Copy result'")
+    expect(source).toContain('copyPayload(req, tab, snippet, snippetArg)')
+    expect(source).toContain("trackEvent('hero copy result'")
+  })
+
+  test('output and data tabs copy the pretty printed response', () => {
+    const req = { body: { status: 'success', data: { url: 'x' } } }
+    const json = JSON.stringify(req.body, null, 2)
+    expect(copyPayload(req, 'output')).toBe(json)
+    expect(copyPayload(req, 'data')).toBe(json)
+  })
+
+  test('headers tab copies header lines', () => {
+    const req = {
+      headerRows: [
+        { k: 'a', v: '1' },
+        { k: 'b', v: '2' }
+      ]
+    }
+    expect(copyPayload(req, 'headers')).toBe('a: 1\nb: 2')
+  })
+
+  test('timing tab copies the metric rows', () => {
+    const req = { rows: [{ name: 'total', dur: '10.0ms', pct: '100.0%' }] }
+    expect(copyPayload(req, 'timing')).toBe('total  10.0ms  100.0%')
+  })
+
+  test('code tab copies the runnable snippet', () => {
+    const snippet = {
+      binding: 'screenshot',
+      method: 'screenshot',
+      log: 'screenshot.url',
+      comment: 'hosted screenshot URL'
+    }
+    const text = snippetText(snippet, 'https://example.com')
+    expect(text).toContain('// npm install microlink.io')
+    expect(text).toContain(
+      "const screenshot = await microlink.screenshot('https://example.com')"
+    )
+    expect(text).toContain('console.log(screenshot.url)')
+    const withOpts = snippetText(
+      { ...snippet, opts: { animated: true } },
+      'https://example.com'
+    )
+    expect(withOpts).toContain("('https://example.com', { animated: true })")
+  })
+})

--- a/test/components/home-hero-copy-result.js
+++ b/test/components/home-hero-copy-result.js
@@ -20,26 +20,43 @@ describe('hero copy result', () => {
     expect(source).toContain("trackEvent('hero copy result'")
   })
 
+  const API_URL = 'https://api.microlink.io/?url=x'
+  const REQUEST_COMMENT = `// ${API_URL}\n`
+
+  test('every copy starts with the request as a comment', () => {
+    const req = { apiUrl: API_URL, body: { status: 'success' } }
+    expect(copyPayload(req, 'data').startsWith(REQUEST_COMMENT)).toBe(true)
+  })
+
   test('output and data tabs copy the pretty printed response', () => {
-    const req = { body: { status: 'success', data: { url: 'x' } } }
-    const json = JSON.stringify(req.body, null, 2)
+    const req = {
+      apiUrl: API_URL,
+      body: { status: 'success', data: { url: 'x' } }
+    }
+    const json = REQUEST_COMMENT + JSON.stringify(req.body, null, 2)
     expect(copyPayload(req, 'output')).toBe(json)
     expect(copyPayload(req, 'data')).toBe(json)
   })
 
   test('headers tab copies header lines', () => {
     const req = {
+      apiUrl: API_URL,
       headerRows: [
         { k: 'a', v: '1' },
         { k: 'b', v: '2' }
       ]
     }
-    expect(copyPayload(req, 'headers')).toBe('a: 1\nb: 2')
+    expect(copyPayload(req, 'headers')).toBe(REQUEST_COMMENT + 'a: 1\nb: 2')
   })
 
   test('timing tab copies the metric rows', () => {
-    const req = { rows: [{ name: 'total', dur: '10.0ms', pct: '100.0%' }] }
-    expect(copyPayload(req, 'timing')).toBe('total  10.0ms  100.0%')
+    const req = {
+      apiUrl: API_URL,
+      rows: [{ name: 'total', dur: '10.0ms', pct: '100.0%' }]
+    }
+    expect(copyPayload(req, 'timing')).toBe(
+      REQUEST_COMMENT + 'total  10.0ms  100.0%'
+    )
   })
 
   test('code tab copies the runnable snippet', () => {

--- a/test/components/home-hero-demo-cache.js
+++ b/test/components/home-hero-demo-cache.js
@@ -179,7 +179,9 @@ describe('hero demo snapshot cache', () => {
 
   test('pickers fill the vertical demo URL unless the user typed one', () => {
     const pick = slice('const typedUrl', 'const MENU_COLS')
-    expect(pick).toContain('!isDemoUrl(raw)')
+    expect(pick).toContain(
+      'canonicalDemoUrl(p.url, v) === DEFAULT_URLS[v] ? null : p.raw'
+    )
     expect(pick).toContain('typedUrl() || shortUrl(DEFAULT_URLS[vertical])')
     expect(pick).toContain(
       "typedUrl() || (k !== 'search' && shortUrl(DEFAULT_URLS[k]))"


### PR DESCRIPTION
typedUrl checked the composer URL against every vertical's demo URL, so
deliberately typing a URL that happens to be some other demo (e.g.
example.com, the html demo) got replaced when switching products. Auto
fill only ever writes the active vertical's own demo URL, so that is
now the only URL treated as replaceable; anything else survives picker
switches.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing UI and clipboard helpers on the home hero; no auth or API changes. Main behavioral change is narrower demo URL replacement in the composer.
> 
> **Overview**
> Fixes **home hero** composer behavior so product/example pickers only auto-replace the **current vertical’s** default demo URL. Custom URLs (including ones that match another product’s demo, e.g. `example.com`) are kept when switching products; the old global `isDemoUrl` / `demoKey` check is removed from that path.
> 
> Adds a **Copy result** control on the hero response panel (next to Output/Data/Headers/Timing/Code tabs). Clipboard text is tab-specific—pretty JSON, headers, timing rows, or a runnable Microlink snippet—with the request URL as a leading comment and `hero copy result` analytics.
> 
> Refreshes the **technologies** output layout to a responsive CSS grid with updated card spacing, logo size, and typography. New Vitest coverage for copy payloads and updated picker/`typedUrl` expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ecc85cd97be1b9fe21a3e7afbcf2049f2c20051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved demo URL recognition and canonicalization in the home page editor, including correct handling of default vs. custom URLs.
* **New Features**
  * Added “Copy result” to the results panel to copy tab-specific output to the clipboard, including request context, with success tracking.
* **Style**
  * Refreshed the technologies section with a responsive grid layout and updated card spacing, logo sizing, and typography.
* **Tests**
  * Updated/added tests for demo URL picker behavior and the new copy-result outputs across tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->