### PR TITLE
feat: content-hash cache buster on per-page og:image cards

### DIFF
--- a/src/components/elements/Meta/Meta.js
+++ b/src/components/elements/Meta/Meta.js
@@ -70,7 +70,9 @@ const mergeMeta = (props, location, metadata) => {
   // banner. The card lives on the deploy host (`ogImageBase`) — empty in dev,
   // and distinct from the canonical `siteUrl` on preview deployments.
   const image =
-    props.image || ogImageUrl(location?.pathname, ogImageBase) || metadata.image
+    props.image ||
+    ogImageUrl(location?.pathname, ogImageBase, `${title}\n${description}`) ||
+    metadata.image
 
   const author = normalizeAuthor(inputAuthors, fallbackAuthor)
 

--- a/src/components/elements/Meta/Meta.js
+++ b/src/components/elements/Meta/Meta.js
@@ -8,6 +8,7 @@ import React, { useMemo } from 'react'
 import { generateStructuredData } from './structured'
 import { toDate } from 'helpers/to-date'
 import { ogImageUrl } from 'helpers/og'
+import { fullTitle as buildFullTitle } from 'helpers/full-title'
 
 const getPage = ({ pathname }) => pathname.replace(/\/+$/, '').substring(1)
 
@@ -53,6 +54,8 @@ const mergeMeta = (props, location, metadata) => {
 
   const description = props.description || metadata.description || headline
 
+  const fullTitle = buildFullTitle({ title, name, noSuffix })
+
   const url = location ? `${siteUrl}${location.pathname}` : siteUrl
 
   // twitter:domain expects the bare host (e.g. microlink.io), not a full URL.
@@ -71,7 +74,11 @@ const mergeMeta = (props, location, metadata) => {
   // and distinct from the canonical `siteUrl` on preview deployments.
   const image =
     props.image ||
-    ogImageUrl(location?.pathname, ogImageBase, `${title}\n${description}`) ||
+    ogImageUrl(
+      location?.pathname,
+      ogImageBase,
+      `${fullTitle}\n${description}`
+    ) ||
     metadata.image
 
   const author = normalizeAuthor(inputAuthors, fallbackAuthor)
@@ -94,12 +101,12 @@ const mergeMeta = (props, location, metadata) => {
     logo,
     name,
     title,
+    fullTitle,
     twitter,
     url,
     domain,
     video,
     robots,
-    noSuffix,
     publishedDate,
     modifiedDate,
     schemaType,
@@ -120,13 +127,12 @@ function Meta ({ structured, ...props }) {
     image,
     logo,
     name,
-    title,
+    fullTitle,
     twitter,
     url,
     domain,
     video,
     robots,
-    noSuffix,
     publishedDate,
     modifiedDate,
     schemaType,
@@ -135,8 +141,6 @@ function Meta ({ structured, ...props }) {
     () => mergeMeta(props, location, siteMetadata),
     [props, location, siteMetadata]
   )
-
-  const fullTitle = noSuffix ? title : `${title} — ${name}`
 
   const autoStructuredData = useMemo(
     () =>

--- a/src/helpers/full-title.js
+++ b/src/helpers/full-title.js
@@ -1,0 +1,2 @@
+export const fullTitle = ({ title, name, noSuffix }) =>
+  noSuffix ? title : `${title} — ${name}`

--- a/src/helpers/og.js
+++ b/src/helpers/og.js
@@ -1,11 +1,16 @@
-// Build-time OG cards are written to `public/images/og/<slug>.png` and served
-// as plain static files at `/images/og/<slug>.png` — the same space as other
-// `/images/*` assets. `@microlink/og`'s `imagePath` returns `/og/<slug>.png`
-// (or null for pages that don't get a card, e.g. Gatsby internals); we serve
-// it under `/images`.
 import { imagePath } from '@microlink/og'
 
-export const ogImageUrl = (pathname, base) => {
+const fingerprint = content => {
+  let hash = 5381
+  for (let i = 0; i < content.length; i++) {
+    hash = ((hash << 5) + hash) ^ content.charCodeAt(i)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+export const ogImageUrl = (pathname, base, content) => {
   const path = imagePath(pathname)
-  return base && path ? `${base}/images${path}` : null
+  if (!base || !path) return null
+  const url = `${base}/images${path}`
+  return content ? `${url}?v=${fingerprint(content)}` : url
 }

--- a/test/helpers/full-title.js
+++ b/test/helpers/full-title.js
@@ -1,0 +1,29 @@
+import { expect, describe, it } from 'vitest'
+
+import { fullTitle } from '../../src/helpers/full-title.js'
+
+describe('fullTitle', () => {
+  it('appends the ` — name` brand suffix', () => {
+    expect(fullTitle({ title: 'Pricing', name: 'Microlink' })).toBe(
+      'Pricing — Microlink'
+    )
+  })
+
+  it('omits the suffix when noSuffix is set', () => {
+    expect(
+      fullTitle({ title: 'Pricing', name: 'Microlink', noSuffix: true })
+    ).toBe('Pricing')
+  })
+
+  it('changes when the site name changes', () => {
+    expect(fullTitle({ title: 'Pricing', name: 'Microlink' })).not.toBe(
+      fullTitle({ title: 'Pricing', name: 'Microlink API' })
+    )
+  })
+
+  it('changes when the suffix is toggled off', () => {
+    expect(fullTitle({ title: 'Pricing', name: 'Microlink' })).not.toBe(
+      fullTitle({ title: 'Pricing', name: 'Microlink', noSuffix: true })
+    )
+  })
+})

--- a/test/helpers/og.js
+++ b/test/helpers/og.js
@@ -1,0 +1,48 @@
+import { expect, describe, it } from 'vitest'
+
+import { ogImageUrl } from '../../src/helpers/og.js'
+
+const BASE = 'https://microlink.io'
+
+describe('ogImageUrl', () => {
+  it('returns null without a base', () => {
+    expect(ogImageUrl('/pricing', undefined)).toBe(null)
+    expect(ogImageUrl('/pricing', '')).toBe(null)
+  })
+
+  it('returns null for pathnames without a card', () => {
+    expect(ogImageUrl('/404', BASE)).toBe(null)
+    expect(ogImageUrl('', BASE)).toBe(null)
+  })
+
+  it('builds the card url without a query when no content is given', () => {
+    expect(ogImageUrl('/pricing', BASE)).toBe(`${BASE}/images/og/pricing.png`)
+    expect(ogImageUrl('/', BASE)).toBe(`${BASE}/images/og/home.png`)
+  })
+
+  it('appends a url-safe content fingerprint as `?v=`', () => {
+    const url = ogImageUrl('/pricing', BASE, 'Pricing\nSimple, transparent.')
+    expect(url).toMatch(
+      /^https:\/\/microlink\.io\/images\/og\/pricing\.png\?v=[0-9a-z]+$/
+    )
+  })
+
+  it('is deterministic for the same content', () => {
+    const content = 'Pricing\nSimple, transparent.'
+    expect(ogImageUrl('/pricing', BASE, content)).toBe(
+      ogImageUrl('/pricing', BASE, content)
+    )
+  })
+
+  it('changes the fingerprint when the content changes', () => {
+    const before = ogImageUrl('/pricing', BASE, 'Pricing\nSimple.')
+    const after = ogImageUrl('/pricing', BASE, 'Pricing\nSimple, transparent.')
+    expect(before).not.toBe(after)
+  })
+
+  it('keeps fingerprints distinct across similar content', () => {
+    const a = ogImageUrl('/pricing', BASE, 'ab')
+    const b = ogImageUrl('/pricing', BASE, 'ba')
+    expect(a).not.toBe(b)
+  })
+})


### PR DESCRIPTION
Append a deterministic ?v=<hash> to /images/og/<slug>.png, derived from the page title+description (the same inputs that produce the card). The URL only changes when the content that changes the image changes, so social crawlers refetch exactly when they should — unlike a build-time Date.now() that would bust every page on every deploy.

Scope is the per-page cards only; the static banner fallback and explicit image props are left untouched. Hash is a pure-JS djb2 so og.js stays safe to import from the browser bundle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SEO/social meta URL changes only; no auth, data, or payment paths. Behavior is covered by new unit tests.
> 
> **Overview**
> Per-page OG card URLs now get a deterministic `?v=<hash>` query string when **Meta** builds the image URL, so social crawlers refetch only when the card-driving copy changes—not on every deploy.
> 
> **`ogImageUrl`** accepts an optional third argument (`fullTitle` + newline + `description`). When present, a pure-JS djb2 fingerprint is appended as `?v=`; explicit `image` props and the static banner fallback stay unchanged.
> 
> **`fullTitle`** logic moves from inline **Meta** into `helpers/full-title.js` and is computed in `mergeMeta` so the same string feeds both meta tags and the OG hash input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a8e2a8c75fa3cea2d8a21f9fbfc3577ab01675. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Page titles now consistently include the site name when applicable.
  * Social sharing images can refresh automatically when page title or description content changes.

* **Bug Fixes**
  * Improved consistency between displayed page metadata and generated social sharing images.

* **Tests**
  * Added coverage for title formatting and social image URL generation, including content-change scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->