### PR TITLE
fix: stop Cloudflare email obfuscation from breaking hydration

### DIFF
--- a/data/git-timestamps-created.json
+++ b/data/git-timestamps-created.json
@@ -234,6 +234,7 @@
   "src/content/styleguide.md": "2026-01-06T00:00:00.000Z",
   "src/content/subprocessors.md": "2026-01-06T00:00:00.000Z",
   "src/content/tos.md": "2026-01-06T00:00:00.000Z",
+  "src/pages/404.js": "2026-07-12T00:00:00.000Z",
   "src/pages/about.md": "2025-10-30T00:00:00.000Z",
   "src/pages/alternative/apiflash.js": "2026-04-09T00:00:00.000Z",
   "src/pages/alternative/embedly.js": "2026-05-14T00:00:00.000Z",

--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -234,6 +234,7 @@
   "src/content/styleguide.md": "2026-01-10T00:00:00.000Z",
   "src/content/subprocessors.md": "2026-07-11T00:00:00.000Z",
   "src/content/tos.md": "2026-01-10T00:00:00.000Z",
+  "src/pages/404.js": "2026-07-12T00:00:00.000Z",
   "src/pages/about.md": "2025-10-30T00:00:00.000Z",
   "src/pages/alternative/apiflash.js": "2026-07-11T00:00:00.000Z",
   "src/pages/alternative/embedly.js": "2026-07-11T00:00:00.000Z",

--- a/src/components/elements/Email.js
+++ b/src/components/elements/Email.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const emailOff = email => `<!--email_off-->${email}<!--/email_off-->`
+
+const Email = ({ as = 'span', children, ...props }) =>
+  React.createElement(as, {
+    ...props,
+    dangerouslySetInnerHTML: { __html: emailOff(children) }
+  })
+
+export default Email

--- a/src/components/pages/home/faqs.js
+++ b/src/components/pages/home/faqs.js
@@ -1,3 +1,4 @@
+import Email from 'components/elements/Email'
 import Box from 'components/elements/Box'
 import { Link } from 'components/elements/Link'
 import Faq from 'components/patterns/Faq/Faq'
@@ -151,7 +152,9 @@ export const getFaqQuestions = () => {
       answer: (
         <div>
           Yes, send an email to{' '}
-          <Link href='mailto:hello@microlink.io'>hello@microlink.io</Link>{' '}
+          <Link href='mailto:hello@microlink.io'>
+            <Email>hello@microlink.io</Email>
+          </Link>{' '}
           requesting the change. You will receive a link where you&apos;ll be
           able to securely update your details.
         </div>
@@ -174,7 +177,10 @@ export const getFaqQuestions = () => {
       answer: (
         <div>
           We’re always available at{' '}
-          <Link href='mailto:hello@microlink.io'>hello@microlink.io</Link>.
+          <Link href='mailto:hello@microlink.io'>
+            <Email>hello@microlink.io</Email>
+          </Link>
+          .
         </div>
       )
     }

--- a/src/components/patterns/Footer/Footer.js
+++ b/src/components/patterns/Footer/Footer.js
@@ -11,6 +11,7 @@ import Choose from 'components/elements/Choose'
 import Container from 'components/elements/Container'
 import Caps from 'components/elements/Caps'
 import Box from 'components/elements/Box'
+import Email from 'components/elements/Email'
 import { Button } from 'components/elements/Button/Button'
 import Flex from 'components/elements/Flex'
 import Input from 'components/elements/Input/Input'
@@ -357,7 +358,8 @@ const GiantEmail = () => (
         width: '100%'
       })}
     >
-      <text
+      <Email
+        as='text'
         x='0'
         y='100'
         textLength='1000'
@@ -368,7 +370,7 @@ const GiantEmail = () => (
         fill={colors.black}
       >
         hello@microlink.io
-      </text>
+      </Email>
     </Box>
   </Box>
 )

--- a/src/components/patterns/NerdStats/NerdStats.js
+++ b/src/components/patterns/NerdStats/NerdStats.js
@@ -10,6 +10,7 @@ import {
   transition,
   shadows
 } from 'theme'
+import Email from 'components/elements/Email'
 import Box from 'components/elements/Box'
 import Flex from 'components/elements/Flex'
 import { parseServerTimingEntries } from 'helpers/server-timing'
@@ -514,7 +515,7 @@ const NerdStatsOverlay = ({ stats, mqlQuery, responseData }) => {
               textDecoration: 'none'
             }}
           >
-            Say hi at hello@microlink.io
+            Say hi at <Email>hello@microlink.io</Email>
           </a>
         </Box>
       </Flex>

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,0 +1,64 @@
+import { withTitle } from 'helpers/hoc/with-title'
+import Caption from 'components/patterns/Caption/Caption'
+import Layout from 'components/patterns/Layout'
+import { layout, theme } from 'theme'
+import React from 'react'
+
+import Caps from 'components/elements/Caps'
+import Flex from 'components/elements/Flex'
+import HeadingBase from 'components/elements/Heading'
+import { Link } from 'components/elements/Link'
+import Meta from 'components/elements/Meta/Meta'
+
+const Heading = withTitle(HeadingBase)
+
+export const Head = () => (
+  <Meta
+    title='Page not found'
+    description='The page you’re looking for doesn’t exist or has been moved.'
+  />
+)
+
+const NotFoundPage = () => (
+  <Layout>
+    <Flex
+      css={theme({
+        flexDirection: 'column',
+        alignItems: 'center'
+      })}
+    >
+      <Heading titleize={false}>Page not found</Heading>
+
+      <Caption
+        css={theme({
+          pt: [3, null, 4],
+          px: 4,
+          maxWidth: layout.small
+        })}
+      >
+        The page you’re looking for doesn’t exist or has been moved.
+      </Caption>
+
+      <Flex
+        css={theme({
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 4,
+          pt: [3, null, 4]
+        })}
+      >
+        <Link href='/'>
+          <Caps css={theme({ fontSize: 0 })}>Home</Caps>
+        </Link>
+        <Link href='/docs/api/getting-started/overview'>
+          <Caps css={theme({ fontSize: 0 })}>Documentation</Caps>
+        </Link>
+        <Link href='/search'>
+          <Caps css={theme({ fontSize: 0 })}>Search</Caps>
+        </Link>
+      </Flex>
+    </Flex>
+  </Layout>
+)
+
+export default NotFoundPage

--- a/test/components/email-obfuscation.js
+++ b/test/components/email-obfuscation.js
@@ -1,0 +1,33 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+const read = relpath =>
+  fs.readFileSync(path.join(process.cwd(), relpath), 'utf8')
+
+describe('email obfuscation', () => {
+  test('the Email element wraps addresses in Cloudflare email_off comments', () => {
+    const source = read('src/components/elements/Email.js')
+    expect(source).toContain('<!--email_off-->')
+    expect(source).toContain('<!--/email_off-->')
+    expect(source).toContain('dangerouslySetInnerHTML')
+  })
+
+  test('no SSR page renders a bare email text node Cloudflare would rewrite', () => {
+    const files = [
+      'src/components/patterns/Footer/Footer.js',
+      'src/components/pages/home/faqs.js',
+      'src/components/patterns/NerdStats/NerdStats.js'
+    ]
+    for (const file of files) {
+      const source = read(file)
+      expect(source).toContain("from 'components/elements/Email'")
+      const stripped = source.replace(/<Email[\s\S]*?<\/Email>/g, '')
+      for (const line of stripped.split('\n')) {
+        const jsxText = /^[^/]*>[^<]*hello@microlink\.io[^>]*</.test(line)
+        const bareText = /^\s*(Say hi at )?hello@microlink\.io\s*$/.test(line)
+        expect(jsxText || bareText, `${file}: ${line.trim()}`).toBe(false)
+      }
+    }
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,15 @@
       ]
     },
     {
+      "source": "/(.*)\\.(js|css)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
       "source": "/page-data/(.*)",
       "headers": [
         {


### PR DESCRIPTION
## Why

microlink.io plays the hero entrance animation twice. Diagnosed on production: React throws hydration errors (#418/#425/#423) on load, discards the server-rendered DOM, and re-renders the whole app client-side, replaying every entrance animation.

The mismatch is not in the app: Cloudflare's Email Address Obfuscation (Scrape Shield) rewrites the three plain-text `hello@microlink.io` occurrences in the served HTML (footer giant email + both FAQ contact links) into `__cf_email__` spans, so the DOM React hydrates against differs from what it rendered.

## What

- New `Email` element that renders addresses via `dangerouslySetInnerHTML` wrapped in Cloudflare's documented `<!--email_off-->` escape comments: Cloudflare skips those regions and hydration doesn't diff them. Applied to the footer SVG text, both FAQ links, and NerdStats.
- `mailto:` hrefs stay as-is — their rewrite is attribute-only, which production hydration ignores.
- Regression test fails if a bare email text node reappears in those files.

Also in this branch: custom 404 page and immutable cache headers for hashed js/css bundles.

## Verified

- Local production build: zero hydration errors, single entrance animation run (was 16 `riseIn` starts with late restarts on production, 8 in one stagger window locally).
- Built HTML carries all six `email_off` markers.
- After deploy, `curl -s https://microlink.io/ | grep -c cf_email` should drop to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The hydration fix touches shared UI (footer, FAQs) via `dangerouslySetInnerHTML`; wrong usage could regress SSR/client parity, though scope is narrow and covered by tests.
> 
> **Overview**
> Fixes production **React hydration mismatches** caused by Cloudflare rewriting plain-text `hello@microlink.io` in SSR HTML, which was forcing a full client re-render and replaying hero entrance animations.
> 
> Adds an **`Email`** component that outputs addresses inside Cloudflare’s `<!--email_off-->` comments via `dangerouslySetInnerHTML`, and wires it into the footer giant SVG text, home FAQ mailto links, and NerdStats. **`mailto:` hrefs are unchanged.** A Vitest guard fails if bare email text nodes return in those files.
> 
> Also ships a **custom `404` page** (layout, meta, links to home/docs/search) and **`vercel.json` immutable `Cache-Control`** for `*.js` and `*.css` bundles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 058f2112db926c6d73b03ce2d96ab2cb6dc2ec8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “Page not found” experience with navigation links to Home, Documentation, and Search.
* **Improvements**
  * Improved protection of displayed email addresses across FAQs, footer, and statistics sections.
  * Added long-term caching for JavaScript and CSS assets to improve loading performance.
* **Bug Fixes**
  * Ensured email addresses remain protected during page rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->