### PR TITLE
feat: sharpen homepage typography

### DIFF
--- a/src/components/elements/Heading.js
+++ b/src/components/elements/Heading.js
@@ -14,6 +14,7 @@ export const commonHeadingStyles = {
 const StyledHeading = styled(Text)(
   theme({
     ...commonHeadingStyles,
+    textWrap: 'balance',
     fontSize: [3, 4]
   })
 )

--- a/src/components/elements/Subhead.js
+++ b/src/components/elements/Subhead.js
@@ -7,6 +7,7 @@ import React from 'react'
 const StyledSubhead = styled(Text)(
   theme({
     ...commonHeadingStyles,
+    textWrap: 'balance',
     fontSize: [4, 4, 6, 6]
   })
 )

--- a/src/components/patterns/Caption/Caption.js
+++ b/src/components/patterns/Caption/Caption.js
@@ -7,6 +7,7 @@ import React from 'react'
 const StyledCaption = styled(Text)(
   theme({
     ...commonHeadingStyles,
+    textWrap: 'pretty',
     lineHeight: 2,
     fontWeight: 'normal',
     fontSize: [2, 2, 3, 3]

--- a/src/html.js
+++ b/src/html.js
@@ -30,7 +30,7 @@ export default function HTML (props) {
 
         <link
           rel='stylesheet'
-          href='https://fonts.googleapis.com/css2?family=Inter:wght@200;400;500;700&display=swap'
+          href='https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,200;0,400;0,500;0,700;1,400;1,500&display=swap'
         />
 
         <meta property='apple-mobile-web-app-capable' content='yes' />

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -206,6 +206,8 @@ a.active {
 
 * {
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-synthesis: none;
   text-rendering: optimizeLegibility;
   box-sizing: border-box;
 }


### PR DESCRIPTION
Applies the [better-typography](https://github.com/jakubkrehel/skills/tree/main/skills/better-typography) review to the homepage type primitives, so every home section (hero, products, analytics, production, faqs) inherits the fix.

## Changes

**Principle 9 — Wrap deliberately**
- `Heading`, `Subhead`: `text-wrap: balance` to even out multi-line display headings ("The web, automated", "From one request to millions").
- `Caption`: `text-wrap: pretty` to kill orphans on the long hero/production descriptions.

**Principle 16 — Font smoothing on the root**
- Added `-moz-osx-font-smoothing: grayscale` next to the existing `-webkit-font-smoothing` in the global `*` rule (Firefox/macOS was rendering heavier).

**Principle 3 — No fake weights**
- Load Inter's italic axis (`ital,wght@…;1,400;1,500`) so italics render from a real face.
- Set `font-synthesis: none` in the global `*` rule. All sans italics in use (testimonial, blockquote, card quotes, empty states, the homepage Next.js "N" chip) are weight 400–500 and now resolve to a real loaded face instead of a synthesized slant.

## Notes / failure modes
- No 700-italic exists in the codebase, so `1,700` is intentionally not loaded.
- Off-homepage mono italics (code-editor syntax tokens) now sit upright instead of faux-slanted monospace when Operator Mono isn't installed — cosmetic and arguably more honest.
- Two extra woff2 subsets ship via the same existing `display=swap` stylesheet link: no new request, no render-blocking change, no CLS.

## Verify
`npm run develop`, open the homepage, resize to watch headings re-balance, and open a testimonial/blockquote page to confirm a true italic renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and font-loading changes only; no auth, data, or business logic. Minor cosmetic shift possible for monospace italics where no italic face exists.
> 
> **Overview**
> Improves how shared homepage type primitives wrap and render across sections that use **Heading**, **Subhead**, and **Caption**.
> 
> **Heading** and **Subhead** now set `textWrap: 'balance'` for more even multi-line display titles. **Caption** uses `textWrap: 'pretty'` to reduce awkward line breaks on longer descriptive copy.
> 
> Global styles add **Firefox** grayscale font smoothing alongside WebKit, and **`font-synthesis: none`** so the browser does not fake bold/italic. The Inter Google Fonts stylesheet in `html.js` is extended to load real italic faces at weights 400 and 500 (`ital,wght@…;1,400;1,500`), matching in-app italics instead of synthesized slant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ce777fbdfc25acb786bf48eee2a612abc2b96f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->