### PR TITLE
Add Subtext primitive for the 20px supporting-text tier

### DIFF
--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -509,7 +509,7 @@
   "src/pages/embed.js": "2026-05-26T00:00:00.000Z",
   "src/pages/embed/examples.js": "2019-06-09T00:00:00.000Z",
   "src/pages/embed/index.js": "2026-07-14T00:00:00.000Z",
-  "src/pages/embed/providers.js": "2026-07-12T00:00:00.000Z",
+  "src/pages/embed/providers.js": "2026-07-14T00:00:00.000Z",
   "src/pages/embed/template.js": "2019-06-09T00:00:00.000Z",
   "src/pages/enterprise.js": "2026-07-12T00:00:00.000Z",
   "src/pages/feature/headers.js": "2026-06-27T00:00:00.000Z",

--- a/src/components/patterns/Subtext/Subtext.js
+++ b/src/components/patterns/Subtext/Subtext.js
@@ -1,0 +1,19 @@
+import Text from 'components/elements/Text'
+import { commonHeadingStyles } from 'components/elements/Heading'
+import styled from 'styled-components'
+import { theme } from 'theme'
+import React from 'react'
+
+const StyledSubtext = styled(Text)(
+  theme({
+    ...commonHeadingStyles,
+    textWrap: 'balance',
+    lineHeight: 1,
+    fontWeight: 'normal',
+    fontSize: [1, 1, 2, 2]
+  })
+)
+
+const Subtext = props => <StyledSubtext as='p' {...props} />
+
+export default Subtext

--- a/src/pages/embed/index.js
+++ b/src/pages/embed/index.js
@@ -35,6 +35,7 @@ import { Check as CheckIcon, Star as StarIcon } from 'react-feather'
 
 import ArrowLink from 'components/patterns/ArrowLink'
 import CaptionBase from 'components/patterns/Caption/Caption'
+import Subtext from 'components/patterns/Subtext/Subtext'
 import { CUSTOMERS } from 'components/patterns/CustomerStory'
 import Faq from 'components/patterns/Faq/Faq'
 import Features from 'components/patterns/Features/Features'
@@ -1978,18 +1979,17 @@ const CustomerStories = () => {
       >
         Already shipping in <span css={{ color: ACCENT }}>real products</span>
       </Subhead>
-      <Caption
+      <Subtext
         css={theme({
           pt: [2, 2, 3, 3],
           px: [4, 4, 4, 0],
           maxWidth: layout.normal,
-          textAlign: 'center',
-          fontSize: [1, 1, 2, 2]
+          textAlign: 'center'
         })}
       >
         How MyMahi powers its newsfeed and Luckynote unfurls links inside notes
         — two short reads on the embed API in production.
-      </Caption>
+      </Subtext>
       <CustomerStoryGrid css={theme({ pt: [3, 3, 4, 4], px: [3, 4, 0, 0] })}>
         {stories.map(({ slug, name, blurb, icon }) => (
           <CustomerStoryCard

--- a/src/pages/integrations/cli.js
+++ b/src/pages/integrations/cli.js
@@ -17,7 +17,7 @@ import { GitHub as GitHubIcon } from 'components/icons/GitHub'
 import { Terminal as TerminalPromptIcon } from 'components/icons/Terminal'
 import { SectionCaption } from 'components/pages/search/Sections'
 import { SEARCH_LAYOUT_WIDE_MAX_WIDTH } from 'components/pages/search'
-import Caption from 'components/patterns/Caption/Caption'
+import Subtext from 'components/patterns/Subtext/Subtext'
 import Layout from 'components/patterns/Layout'
 
 import { colors, layout, space, theme } from 'theme'
@@ -376,21 +376,20 @@ const Hero = () => (
           <LineBreak />
           in your <span css={theme({ color: ACCENT })}>terminal</span>.
         </Text>
-        <Caption
+        <Subtext
           forwardedAs='p'
           css={theme({
             pt: [3, 3, 4, 4],
             maxWidth: layout.small,
             mx: ['auto', 'auto', 0, 0],
             textAlign: ['center', 'center', 'left', 'left'],
-            fontSize: [1, 1, 2, 2],
             lineHeight: 2
           })}
         >
           Install the global command, pass any URL, and inspect screenshots,
           metadata, PDFs, cache status, timing, headers, and JSON payloads
           without leaving your shell.
-        </Caption>
+        </Subtext>
         <Flex
           css={theme({
             pt: [3, 3, 4, 4],

--- a/src/pages/link-preview.js
+++ b/src/pages/link-preview.js
@@ -36,6 +36,7 @@ import {
 
 import ArrowLink from 'components/patterns/ArrowLink'
 import CaptionBase from 'components/patterns/Caption/Caption'
+import Subtext from 'components/patterns/Subtext/Subtext'
 import { CUSTOMERS } from 'components/patterns/CustomerStory'
 import Faq from 'components/patterns/Faq/Faq'
 import Features from 'components/patterns/Features/Features'
@@ -1733,18 +1734,17 @@ const CustomerStories = () => {
       >
         Already shipping in <span css={{ color: ACCENT }}>real products</span>
       </Subhead>
-      <Caption
+      <Subtext
         css={theme({
           pt: [2, 2, 3, 3],
           px: [4, 4, 4, 0],
           maxWidth: layout.normal,
-          textAlign: 'center',
-          fontSize: [1, 1, 2, 2]
+          textAlign: 'center'
         })}
       >
         How MyMahi powers its newsfeed and Luckynote unfurls links inside notes
         — two short reads on the link preview API in production.
-      </Caption>
+      </Subtext>
       <CustomerStoryGrid css={theme({ pt: [3, 3, 4, 4], px: [3, 4, 0, 0] })}>
         {stories.map(({ slug, name, blurb, icon }) => (
           <CustomerStoryCard

--- a/src/pages/metadata.js
+++ b/src/pages/metadata.js
@@ -36,6 +36,7 @@ import ArrowLink from 'components/patterns/ArrowLink'
 import Block from 'components/patterns/Block/Block'
 import { withTitle } from 'helpers/hoc/with-title'
 import CaptionBase from 'components/patterns/Caption/Caption'
+import Subtext from 'components/patterns/Subtext/Subtext'
 import Faq from 'components/patterns/Faq/Faq'
 import Features from 'components/patterns/Features/Features'
 import Layout from 'components/patterns/Layout'
@@ -2812,18 +2813,17 @@ const Capabilities = ({ currentUrl, currentData }) => {
             <LineBreak />
             <span css={{ color: ACCENT }}>that actually render</span>
           </Subhead>
-          <Caption
+          <Subtext
             forwardedAs='div'
             css={theme({
               maxWidth: layout.small,
-              textAlign: ['center', 'center', 'center', 'left'],
-              fontSize: [1, 1, 2, 2]
+              textAlign: ['center', 'center', 'center', 'left']
             })}
           >
             Microlink returns a unified JSON response — plus the brand color
             palette, logo, and favicon. Everything you need to render a
             pixel-perfect link preview or URL preview on the first try.
-          </Caption>
+          </Subtext>
           <Flex
             css={[
               theme({ gap: [3, 3, 3, 4], width: '100%' }),
@@ -3257,15 +3257,14 @@ const Stack = ({ currentUrl }) => {
                   </Subhead>
                 </Flex>
               </Flex>
-              <Caption
+              <Subtext
                 forwardedAs='div'
                 css={theme({
-                  fontSize: [1, 1, 2, 2],
                   textAlign: 'left'
                 })}
               >
                 {item.description}
-              </Caption>
+              </Subtext>
               <StackApiCode $accent={item.accentColor}>
                 {renderStackApi(item.apiCall, currentUrl)}
               </StackApiCode>
@@ -4004,7 +4003,7 @@ const OpenSource = () => (
           <br />
           trusted by developers
         </Subhead>
-        <Caption
+        <Subtext
           css={theme({
             pt: [3, 3, 4, 4],
             px: [4, 4, 4, 0],
@@ -4014,7 +4013,6 @@ const OpenSource = () => (
               layout.normal,
               layout.normal
             ],
-            fontSize: [1, 1, 2, 2],
             textAlign: ['center', 'center', 'center', 'left']
           })}
         >
@@ -4022,7 +4020,7 @@ const OpenSource = () => (
           <Link href='https://metascraper.js.org'>metascraper</Link>, our
           battle-tested open source library used by thousands of developers
           worldwide. You can inspect the code, contribute, or self-host it.
-        </Caption>
+        </Subtext>
         <Flex
           css={theme({
             pt: [3, 3, 4, 4],

--- a/src/pages/pdf.js
+++ b/src/pages/pdf.js
@@ -38,6 +38,7 @@ import ArrowLink from 'components/patterns/ArrowLink'
 import Block from 'components/patterns/Block/Block'
 import { withTitle } from 'helpers/hoc/with-title'
 import CaptionBase from 'components/patterns/Caption/Caption'
+import Subtext from 'components/patterns/Subtext/Subtext'
 import Faq from 'components/patterns/Faq/Faq'
 import Features from 'components/patterns/Features/Features'
 import Layout from 'components/patterns/Layout'
@@ -2802,7 +2803,7 @@ const OpenSource = () => (
           <br />
           trusted by developers
         </Subhead>
-        <Caption
+        <Subtext
           css={theme({
             pt: [3, 3, 4, 4],
             px: [4, 4, 4, 0],
@@ -2812,7 +2813,6 @@ const OpenSource = () => (
               layout.normal,
               layout.normal
             ],
-            fontSize: [1, 1, 2, 2],
             textAlign: ['center', 'center', 'center', 'left']
           })}
         >
@@ -2820,7 +2820,7 @@ const OpenSource = () => (
           libraries used by thousands of developers worldwide. Our HTML to PDF
           API open source foundation means you can explore the code, contribute,
           or run it yourself.
-        </Caption>
+        </Subtext>
         <Flex
           css={theme({
             pt: [3, 3, 4, 4],


### PR DESCRIPTION
Introduces the new typography primitive we discussed — **`Subtext`** — filling the gap between `Caption` (28px) and `Text` (body).

## The tier
| Component | Tag | Size (mobile → desktop) | Role |
|---|---|---|---|
| Heading | h1 | 52 → 64 | Page title |
| Subhead | h2 | 52 | Section title |
| Caption | h3 | 20 → 28 | Lead / primary supporting text |
| **Subtext** | **p** | **16 → 20** | **Secondary supporting text (NEW)** |
| Text | — | 16 → 20 | Body copy |
| Caps | span | 16 | Uppercase micro-labels |

`Subtext` mirrors `Caption`'s treatment (`text-wrap: balance`, `line-height 1.45`, `overflow-wrap`) one size down (`fontSize: [1, 1, 2, 2]`), rendered as a semantic `<p>` rather than a heading.

## Migration in this PR
The 7 sub-notes that faked this tier with `<Caption css={theme({ fontSize: [1,1,2,2] })}>` now use `<Subtext>` — embed, cli, link-preview, metadata (×3), pdf. Zero visual change; call sites stop passing `fontSize`. Dropped the now-unused `Caption` import in cli.

Verified at 1440: `/link-preview` and `/metadata` render the Subtext at 20px, centered/balanced, no overflow.

## Follow-up (not in this PR)
The rest of the `Caption` overrides are a **~28px cluster with inconsistent mobile ramps** (`[1,2,2,2]`, `[0,2,2,2]`, `3`, `[2,2,'26px','28px']`… all ≈28px desktop) plus scattered 24px/32px stat-adjacent captions. Those should normalize to the `Caption` default, but they change mobile sizing across ~90 usages — worth its own reviewed PR. `Subtext` unblocks that pass by giving the smaller tier a home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational refactor and component swap with no API or business-logic changes; scope is limited marketing pages and one new styled primitive.
> 
> **Overview**
> Adds a **`Subtext`** pattern component for the 16→20px secondary supporting-text tier (semantic `<p>`, balanced wrap, `fontSize: [1, 1, 2, 2]`), sitting below **`Caption`**’s lead size.
> 
> Seven call sites that previously used **`Caption`** with a manual `fontSize: [1, 1, 2, 2]` override now use **`Subtext`** instead — on embed, link-preview, and CLI hero copy, plus metadata (hero, stack cards, open-source) and pdf (open-source). Inline `fontSize` overrides are removed; CLI drops the unused **`Caption`** import. **`git-timestamps-modified.json`** is bumped for touched page paths.
> 
> No intended visual change; this standardizes the smaller supporting-text tier ahead of broader **`Caption`** cleanup elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0402c7fa0099ce676768d5cb1c6b62434eab7539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->