### PR TITLE
Fold 20px sub-notes into the Caption pattern (drop Subtext idea)

### DIFF
--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -509,7 +509,7 @@
   "src/pages/embed.js": "2026-05-26T00:00:00.000Z",
   "src/pages/embed/examples.js": "2019-06-09T00:00:00.000Z",
   "src/pages/embed/index.js": "2026-07-14T00:00:00.000Z",
-  "src/pages/embed/providers.js": "2026-07-12T00:00:00.000Z",
+  "src/pages/embed/providers.js": "2026-07-14T00:00:00.000Z",
   "src/pages/embed/template.js": "2019-06-09T00:00:00.000Z",
   "src/pages/enterprise.js": "2026-07-12T00:00:00.000Z",
   "src/pages/feature/headers.js": "2026-06-27T00:00:00.000Z",

--- a/src/pages/embed/index.js
+++ b/src/pages/embed/index.js
@@ -1983,8 +1983,7 @@ const CustomerStories = () => {
           pt: [2, 2, 3, 3],
           px: [4, 4, 4, 0],
           maxWidth: layout.normal,
-          textAlign: 'center',
-          fontSize: [1, 1, 2, 2]
+          textAlign: 'center'
         })}
       >
         How MyMahi powers its newsfeed and Luckynote unfurls links inside notes

--- a/src/pages/integrations/cli.js
+++ b/src/pages/integrations/cli.js
@@ -383,7 +383,6 @@ const Hero = () => (
             maxWidth: layout.small,
             mx: ['auto', 'auto', 0, 0],
             textAlign: ['center', 'center', 'left', 'left'],
-            fontSize: [1, 1, 2, 2],
             lineHeight: 2
           })}
         >

--- a/src/pages/link-preview.js
+++ b/src/pages/link-preview.js
@@ -1738,8 +1738,7 @@ const CustomerStories = () => {
           pt: [2, 2, 3, 3],
           px: [4, 4, 4, 0],
           maxWidth: layout.normal,
-          textAlign: 'center',
-          fontSize: [1, 1, 2, 2]
+          textAlign: 'center'
         })}
       >
         How MyMahi powers its newsfeed and Luckynote unfurls links inside notes

--- a/src/pages/metadata.js
+++ b/src/pages/metadata.js
@@ -2816,8 +2816,7 @@ const Capabilities = ({ currentUrl, currentData }) => {
             forwardedAs='div'
             css={theme({
               maxWidth: layout.small,
-              textAlign: ['center', 'center', 'center', 'left'],
-              fontSize: [1, 1, 2, 2]
+              textAlign: ['center', 'center', 'center', 'left']
             })}
           >
             Microlink returns a unified JSON response — plus the brand color
@@ -3257,15 +3256,13 @@ const Stack = ({ currentUrl }) => {
                   </Subhead>
                 </Flex>
               </Flex>
-              <Caption
-                forwardedAs='div'
+              <Text
                 css={theme({
-                  fontSize: [1, 1, 2, 2],
                   textAlign: 'left'
                 })}
               >
                 {item.description}
-              </Caption>
+              </Text>
               <StackApiCode $accent={item.accentColor}>
                 {renderStackApi(item.apiCall, currentUrl)}
               </StackApiCode>
@@ -4014,7 +4011,6 @@ const OpenSource = () => (
               layout.normal,
               layout.normal
             ],
-            fontSize: [1, 1, 2, 2],
             textAlign: ['center', 'center', 'center', 'left']
           })}
         >

--- a/src/pages/pdf.js
+++ b/src/pages/pdf.js
@@ -2812,7 +2812,6 @@ const OpenSource = () => (
               layout.normal,
               layout.normal
             ],
-            fontSize: [1, 1, 2, 2],
             textAlign: ['center', 'center', 'center', 'left']
           })}
         >


### PR DESCRIPTION
Replaces the closed #2132. After evaluating the sub-note cases against the homepage **Subhead + Caption** pattern, `Subtext` turned out to be solving *drift*, not a real tier — so no new component.

## Evaluation
The homepage does section title + supporting text as `Subhead` (52px) + `Caption` (28px). The 7 cases that used `<Caption fontSize={[1,1,2,2]}>` (20px) were:
- **6 section/hero supporting texts** (link-preview/embed "How MyMahi…", metadata ×2, pdf, cli hero subtitle) — arbitrarily 20px; on the homepage they'd be a 28px `Caption`.
- **1 grid-card description** (`metadata {item.description}`) — a card body under a 28px card title; a smaller-than-title tier, i.e. `Text`.

## Change
- 6 section cases → drop the override → `Caption` default **28px**, matching every other section.
- `metadata {item.description}` → `Text` (body copy) — stays smaller than its 28px card title.

One visible effect (intended): the 6 supporting texts grow 20 → 28px so they're consistent with the rest of the site.

## Verified (1440)
`/link-preview` — "How MyMahi…" now 28px, matching the sibling section caption below it; `/metadata` — card descriptions render at Text size. No horizontal overflow.

Net: the site keeps exactly two supporting-text roles, both already covered — **`Caption`** (section/hero) and **`Text`** (card/inline). No `Subtext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual typography-only changes on static marketing pages; no API, auth, or data logic.
> 
> **Overview**
> Standardizes marketing-page supporting copy instead of adding a separate **Subtext** tier.
> 
> **Section and hero blurbs** on `embed`, `link-preview`, `metadata`, `pdf`, and the CLI integration hero drop `fontSize: [1, 1, 2, 2]` on `Caption`, so they use the component’s default **28px** scale and match other **Subhead + Caption** sections.
> 
> On **metadata**, stack-card `item.description` moves from `Caption` to **`Text`**, keeping body copy smaller than the card title. `data/git-timestamps-modified.json` is bumped for touched page files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d34f1526c8cb035aeec75d4fdb6063523e4ed45b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->