### PR TITLE
Normalize the 28px Caption cluster to the default

### DIFF
--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -532,7 +532,7 @@
   "src/pages/integrations.js": "2020-07-29T00:00:00.000Z",
   "src/pages/integrations/builder.js": "2026-07-14T00:00:00.000Z",
   "src/pages/integrations/builder/index.js": "2026-06-15T00:00:00.000Z",
-  "src/pages/integrations/cli.js": "2026-07-11T00:00:00.000Z",
+  "src/pages/integrations/cli.js": "2026-07-14T00:00:00.000Z",
   "src/pages/integrations/mcp.js": "2026-07-14T00:00:00.000Z",
   "src/pages/integrations/sdk.js": "2026-07-14T00:00:00.000Z",
   "src/pages/link-preview.js": "2026-07-14T00:00:00.000Z",

--- a/src/components/pages/embed-url/ProviderSubtool.js
+++ b/src/components/pages/embed-url/ProviderSubtool.js
@@ -52,8 +52,7 @@ const Hero = ({ title, subtitle }) => (
       css={theme({
         pt: [2, 2, 3, 3],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 2, '26px', '28px']
+        maxWidth: layout.large
       })}
     >
       {subtitle}
@@ -78,8 +77,7 @@ const HowItWorksSection = ({ heading, steps }) => (
       css={theme({
         pt: [3, 3, 4, 4],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       {heading}

--- a/src/components/pages/home/analytics.js
+++ b/src/components/pages/home/analytics.js
@@ -38,9 +38,7 @@ const Stat = ({ value, name, isLast }) => (
         {value}
       </Subhead>
       <Caption css={theme({ pt: [2, 3, 3, 3], color: 'pink', opacity: 0.8 })}>
-        <Caps css={theme({ fontWeight: 'bold', fontSize: [0, 2, 3, 3] })}>
-          {name}
-        </Caps>
+        <Caps css={theme({ fontWeight: 'bold' })}>{name}</Caps>
       </Caption>
     </Flex>
     {!isLast && <Separator />}

--- a/src/components/pages/screenshot/index.js
+++ b/src/components/pages/screenshot/index.js
@@ -349,9 +349,7 @@ export const ApiDocsCard = ({
         <SectionIcon icon={Code} />
       </Flex>
       <Subhead>{title}</Subhead>
-      <Caption
-        css={theme({ pt: 3, maxWidth: layout.normal, mx: 'auto', fontSize: 3 })}
-      >
+      <Caption css={theme({ pt: 3, maxWidth: layout.normal, mx: 'auto' })}>
         {description}
       </Caption>
       <Flex

--- a/src/components/pages/screenshot/lang/config/nodejs.js
+++ b/src/components/pages/screenshot/lang/config/nodejs.js
@@ -3,11 +3,6 @@ import { colors } from 'theme'
 import { CDN_EDGES } from 'helpers/cdn-edges'
 import { Link } from 'components/elements/Link'
 
-// Per-language configuration for the `/screenshot/<lang>` landing pages.
-// Everything language-specific lives here so `index.js` stays generic and a
-// new language (python, php, …) is just another config file + a page file.
-
-// Inline red accent for headline keywords, mirroring the /integrations/sdk page.
 const Accent = ({ children }) => (
   <span style={{ color: colors.red6 }}>{children}</span>
 )
@@ -19,9 +14,6 @@ const nodejs = {
   lang: 'nodejs',
   label: 'Node.js',
 
-  // ── SEO ──────────────────────────────────────────────────────────────────
-  // Intentionally distinct from the product page (/screenshot) so Google reads
-  // this as the Node.js how-to, not a duplicate of the product page.
   meta: {
     title: 'Node.js Screenshot API — Capture Any Website in Code',
     description:
@@ -132,13 +124,11 @@ const nodejs = {
     ]
   },
 
-  // ── Breadcrumb (visual) ───────────────────────────────────────────────────
   breadcrumb: [
     { label: 'Screenshot API', href: '/screenshot' },
     { label: 'Node.js' }
   ],
 
-  // ── Hero (centered, code-free) ────────────────────────────────────────────
   hero: {
     title: (
       <>
@@ -155,7 +145,6 @@ const nodejs = {
     }
   },
 
-  // ── Quickstart steps (vertical, progressively deeper) ─────────────────────
   quickstart: {
     title: (
       <>
@@ -230,10 +219,6 @@ await writeFile('screenshot.png', buffer)`
     ]
   },
 
-  // ── Framework integration (tabbed) ────────────────────────────────────────
-  // The same screenshot endpoint, written for the five most popular Node.js
-  // frameworks (vanilla Node.js last). The labels double as MultiCodeEditor
-  // tabs so the reader can jump between them.
   framework: {
     title: (
       <>
@@ -365,7 +350,6 @@ http
     ]
   },
 
-  // ── Why the API vs self-hosting Puppeteer ─────────────────────────────────
   comparison: {
     title: (
       <>
@@ -402,7 +386,6 @@ http
     ]
   },
 
-  // ── Features (Node-flavored) ──────────────────────────────────────────────
   features: {
     title: (
       <>
@@ -466,7 +449,6 @@ http
     ]
   },
 
-  // ── Try it live ───────────────────────────────────────────────────────────
   tool: {
     title: (
       <>
@@ -481,7 +463,6 @@ http
     }
   },
 
-  // ── FAQ (Node-specific) ───────────────────────────────────────────────────
   faq: {
     title: 'Node.js Screenshot FAQ',
     caption: (
@@ -594,7 +575,6 @@ http
     ]
   },
 
-  // ── Final CTA ─────────────────────────────────────────────────────────────
   cta: {
     title: (
       <>
@@ -611,8 +591,6 @@ http
     badges: ['No login needed', '25 reqs/day free', 'No credit card']
   },
 
-  // ── Sibling language pages (rendered when present) ────────────────────────
-  // Add { label: 'Python', href: '/screenshot/python' } etc. as they ship.
   siblings: []
 }
 

--- a/src/components/pages/screenshot/lang/config/php.js
+++ b/src/components/pages/screenshot/lang/config/php.js
@@ -3,10 +3,6 @@ import { colors } from 'theme'
 import { CDN_EDGES } from 'helpers/cdn-edges'
 import { Link } from 'components/elements/Link'
 
-// Per-language configuration for /screenshot/php. PHP has no official Microlink
-// SDK, so every example calls the REST API over native HTTP (file_get_contents
-// and the cURL extension that ship with PHP — no Composer package required).
-
 const Accent = ({ children }) => (
   <span style={{ color: colors.red6 }}>{children}</span>
 )
@@ -18,9 +14,6 @@ const php = {
   lang: 'php',
   label: 'PHP',
 
-  // ── SEO ──────────────────────────────────────────────────────────────────
-  // Owns the "php screenshot api" intent — distinct from the product page
-  // (/screenshot, "website screenshot api") and the other language spokes.
   meta: {
     title: 'PHP Screenshot API — Capture Any Website in Code',
     description:
@@ -131,13 +124,11 @@ const php = {
     ]
   },
 
-  // ── Breadcrumb (visual) ───────────────────────────────────────────────────
   breadcrumb: [
     { label: 'Screenshot API', href: '/screenshot' },
     { label: 'PHP' }
   ],
 
-  // ── Hero (centered, code-free) ────────────────────────────────────────────
   hero: {
     title: (
       <>
@@ -154,7 +145,6 @@ const php = {
     }
   },
 
-  // ── Quickstart steps (vertical, progressively deeper) ─────────────────────
   quickstart: {
     title: (
       <>
@@ -250,7 +240,6 @@ file_put_contents('screenshot.png', file_get_contents($image));`
     ]
   },
 
-  // ── Framework integration (tabbed) ────────────────────────────────────────
   framework: {
     title: (
       <>
@@ -362,7 +351,6 @@ header('Location: ' . $res['data']['screenshot']['url']);`
     ]
   },
 
-  // ── Why the API vs self-hosting a browser ─────────────────────────────────
   comparison: {
     title: (
       <>
@@ -399,7 +387,6 @@ header('Location: ' . $res['data']['screenshot']['url']);`
     ]
   },
 
-  // ── Features (PHP-flavored) ───────────────────────────────────────────────
   features: {
     title: (
       <>
@@ -463,7 +450,6 @@ header('Location: ' . $res['data']['screenshot']['url']);`
     ]
   },
 
-  // ── Try it live ───────────────────────────────────────────────────────────
   tool: {
     title: (
       <>
@@ -478,7 +464,6 @@ header('Location: ' . $res['data']['screenshot']['url']);`
     }
   },
 
-  // ── FAQ (PHP-specific) ────────────────────────────────────────────────────
   faq: {
     title: 'PHP Screenshot FAQ',
     caption: (
@@ -587,7 +572,6 @@ header('Location: ' . $res['data']['screenshot']['url']);`
     ]
   },
 
-  // ── Final CTA ─────────────────────────────────────────────────────────────
   cta: {
     title: (
       <>

--- a/src/components/pages/screenshot/lang/config/python.js
+++ b/src/components/pages/screenshot/lang/config/python.js
@@ -3,10 +3,6 @@ import { colors } from 'theme'
 import { CDN_EDGES } from 'helpers/cdn-edges'
 import { Link } from 'components/elements/Link'
 
-// Per-language configuration for /screenshot/python. Python has no official
-// Microlink SDK, so every example calls the REST API over native HTTP (the
-// requests package, with the standard library as the zero-dependency option).
-
 const Accent = ({ children }) => (
   <span style={{ color: colors.red6 }}>{children}</span>
 )
@@ -18,9 +14,6 @@ const python = {
   lang: 'python',
   label: 'Python',
 
-  // ── SEO ──────────────────────────────────────────────────────────────────
-  // Owns the "python screenshot api" intent — distinct from the product page
-  // (/screenshot, "website screenshot api") and the other language spokes.
   meta: {
     title: 'Python Screenshot API — Capture Any Website in Code',
     description:
@@ -131,13 +124,11 @@ const python = {
     ]
   },
 
-  // ── Breadcrumb (visual) ───────────────────────────────────────────────────
   breadcrumb: [
     { label: 'Screenshot API', href: '/screenshot' },
     { label: 'Python' }
   ],
 
-  // ── Hero (centered, code-free) ────────────────────────────────────────────
   hero: {
     title: (
       <>
@@ -154,7 +145,6 @@ const python = {
     }
   },
 
-  // ── Quickstart steps (vertical, progressively deeper) ─────────────────────
   quickstart: {
     title: (
       <>
@@ -231,7 +221,6 @@ with open('screenshot.png', 'wb') as file:
     ]
   },
 
-  // ── Framework integration (tabbed) ────────────────────────────────────────
   framework: {
     title: (
       <>
@@ -333,7 +322,6 @@ print(data['screenshot']['url'])`
     ]
   },
 
-  // ── Why the API vs self-hosting a browser ─────────────────────────────────
   comparison: {
     title: (
       <>
@@ -370,7 +358,6 @@ print(data['screenshot']['url'])`
     ]
   },
 
-  // ── Features (Python-flavored) ────────────────────────────────────────────
   features: {
     title: (
       <>
@@ -434,7 +421,6 @@ print(data['screenshot']['url'])`
     ]
   },
 
-  // ── Try it live ───────────────────────────────────────────────────────────
   tool: {
     title: (
       <>
@@ -449,7 +435,6 @@ print(data['screenshot']['url'])`
     }
   },
 
-  // ── FAQ (Python-specific) ─────────────────────────────────────────────────
   faq: {
     title: 'Python Screenshot FAQ',
     caption: (
@@ -560,7 +545,6 @@ print(data['screenshot']['url'])`
     ]
   },
 
-  // ── Final CTA ─────────────────────────────────────────────────────────────
   cta: {
     title: (
       <>

--- a/src/components/pages/screenshot/lang/index.js
+++ b/src/components/pages/screenshot/lang/index.js
@@ -26,29 +26,21 @@ import { TOOLS as TOOL_CATALOG } from 'components/patterns/Tools/toolCatalog'
 
 import ScreenshotDemo from './ScreenshotDemo'
 
-// Flattened tool catalog, so the playground section can pull the matching
-// FeaturedToolCard by href (same card the /screenshot landing renders).
 const ALL_TOOLS = TOOL_CATALOG.flatMap(section => section.tools)
 
 const Heading = withTitle(HeadingBase)
 const Subhead = withTitle(SubheadBase)
 const Caption = withTitle(CaptionBase)
 
-// Shared layout tokens — the page mirrors the /integrations/sdk landing: one
-// centered column, generous vertical rhythm, red accent on headline keywords.
 const ACCENT = 'red6'
 const SECTION_VERTICAL_SPACING = [4, 4, 5, 5]
 const SECTION_MAX_WIDTH = '1100px'
 const CONTENT_WIDTH = layout.normal
 
-// Force the CodeEditor (and its header row) to fill its centered container.
 const CODE_FULL_WIDTH = {
   '& > div, & > div > div:first-child': { width: '100%' }
 }
 
-// ── Background pattern ────────────────────────────────────────────────────────
-// Dashed grid that fades out below the hero, lifted from the SDK landing so the
-// two pages read as a family.
 const DashedGridOverlay = styled(Box)`
   ${theme({ position: 'absolute', top: 0, left: 0, width: '100%', zIndex: 0 })}
   height: 1200px;
@@ -95,7 +87,6 @@ const DashedGridOverlay = styled(Box)`
   -webkit-mask-composite: source-in;
 `
 
-// ── Shared primitives ─────────────────────────────────────────────────────────
 const SectionContainer = ({ id, children, css: cssProp, ...props }) => (
   <Container
     as='section'
@@ -202,7 +193,6 @@ const Breadcrumb = ({ items }) => (
   </Flex>
 )
 
-// ── Hero (centered, code-free) ────────────────────────────────────────────────
 const Hero = ({ hero, breadcrumb }) => (
   <Container
     as='section'
@@ -262,7 +252,6 @@ const Hero = ({ hero, breadcrumb }) => (
   </Container>
 )
 
-// ── Quickstart (vertical, progressively deeper code) ──────────────────────────
 const Quickstart = ({ quickstart }) => (
   <SectionContainer id='quickstart'>
     <SectionHead
@@ -310,9 +299,6 @@ const Quickstart = ({ quickstart }) => (
   </SectionContainer>
 )
 
-// ── Framework integration (tabbed) ────────────────────────────────────────────
-// The example labels double as MultiCodeEditor tabs, so the reader jumps between
-// frameworks in place. Vanilla Node.js is the last tab.
 const Framework = ({ framework }) => {
   const languages = framework.examples.reduce((acc, example) => {
     acc[example.label] = example.code.source
@@ -349,7 +335,6 @@ const Framework = ({ framework }) => {
   )
 }
 
-// ── Comparison ────────────────────────────────────────────────────────────────
 const ComparisonColumn = ({ column }) => {
   const positive = column.tone === 'positive'
   const Icon = positive ? CheckIcon : XIcon
@@ -429,7 +414,6 @@ const Comparison = ({ comparison }) => (
   </SectionContainer>
 )
 
-// ── Try it live ───────────────────────────────────────────────────────────────
 const ToolCta = ({ tool }) => {
   const card = ALL_TOOLS.find(item => item.href === tool.cta.href)
   return (
@@ -455,7 +439,6 @@ const ToolCta = ({ tool }) => {
   )
 }
 
-// ── Final CTA ─────────────────────────────────────────────────────────────────
 const FinalCta = ({ cta }) => (
   <SectionContainer id='get-started'>
     <Flex
@@ -528,7 +511,6 @@ const FinalCta = ({ cta }) => (
   </SectionContainer>
 )
 
-// ── Page + Head ───────────────────────────────────────────────────────────────
 const ScreenshotLang = ({ config }) => (
   <Layout css={theme({ position: 'relative' })}>
     <DashedGridOverlay aria-hidden='true' />

--- a/src/components/pages/sharing-debugger/hero.js
+++ b/src/components/pages/sharing-debugger/hero.js
@@ -190,8 +190,7 @@ export const Hero = () => {
                 forwardedAs='h2'
                 css={theme({
                   pt: '20px',
-                  px: [4, 0],
-                  fontSize: [2, 2, '25px', '25px']
+                  px: [4, 0]
                 })}
               >
                 Debug and validate metadata HTML markup, including Open Graph,

--- a/src/pages/alternative/apiflash.js
+++ b/src/pages/alternative/apiflash.js
@@ -956,8 +956,7 @@ const SpeedSection = () => {
           css={theme({
             pb: [3, 3, 4, 4],
             maxWidth: layout.normal,
-            color: 'black80',
-            fontSize: 3
+            color: 'black80'
           })}
           titleize={false}
         >
@@ -1828,8 +1827,7 @@ const CTASection = () => (
           color: 'white80',
           pt: 3,
           pb: [3, 3, 4, 4],
-          maxWidth: layout.large,
-          fontSize: 3
+          maxWidth: layout.large
         })}
         titleize={false}
       >

--- a/src/pages/alternative/embedly.js
+++ b/src/pages/alternative/embedly.js
@@ -1178,8 +1178,7 @@ const CTASection = () => (
           color: 'white80',
           pt: 3,
           pb: [3, 3, 4, 4],
-          maxWidth: layout.large,
-          fontSize: 3
+          maxWidth: layout.large
         })}
         titleize={false}
       >

--- a/src/pages/alternative/iframely.js
+++ b/src/pages/alternative/iframely.js
@@ -1187,8 +1187,7 @@ const CTASection = () => (
           color: 'white80',
           pt: 3,
           pb: [3, 3, 4, 4],
-          maxWidth: layout.large,
-          fontSize: 3
+          maxWidth: layout.large
         })}
         titleize={false}
       >

--- a/src/pages/alternative/screenshotapi.js
+++ b/src/pages/alternative/screenshotapi.js
@@ -831,8 +831,7 @@ const SpeedSection = () => {
           css={theme({
             pb: [3, 3, 4, 4],
             maxWidth: layout.normal,
-            color: 'black80',
-            fontSize: 3
+            color: 'black80'
           })}
           titleize={false}
         >
@@ -1711,8 +1710,7 @@ const CTASection = () => (
           color: 'white80',
           pt: 3,
           pb: [3, 3, 4, 4],
-          maxWidth: layout.large,
-          fontSize: 3
+          maxWidth: layout.large
         })}
         titleize={false}
       >

--- a/src/pages/alternative/screenshotlayer.js
+++ b/src/pages/alternative/screenshotlayer.js
@@ -1032,8 +1032,7 @@ const SpeedSection = () => {
           css={theme({
             pb: [3, 3, 4, 4],
             maxWidth: layout.normal,
-            color: 'black80',
-            fontSize: 3
+            color: 'black80'
           })}
           titleize={false}
         >
@@ -1916,8 +1915,7 @@ const CTASection = () => (
           color: 'white80',
           pt: 3,
           pb: [3, 3, 4, 4],
-          maxWidth: layout.large,
-          fontSize: 3
+          maxWidth: layout.large
         })}
         titleize={false}
       >

--- a/src/pages/alternative/screenshotmachine.js
+++ b/src/pages/alternative/screenshotmachine.js
@@ -1022,8 +1022,7 @@ const SpeedSection = () => {
           css={theme({
             pb: [3, 3, 4, 4],
             maxWidth: layout.normal,
-            color: 'black80',
-            fontSize: 3
+            color: 'black80'
           })}
           titleize={false}
         >
@@ -1895,8 +1894,7 @@ const CTASection = () => (
         css={theme({
           color: 'white80',
           pb: [3, 3, 4, 4],
-          maxWidth: layout.large,
-          fontSize: 3
+          maxWidth: layout.large
         })}
         titleize={false}
       >

--- a/src/pages/alternative/screenshotone.js
+++ b/src/pages/alternative/screenshotone.js
@@ -791,8 +791,7 @@ const SpeedSection = () => {
           css={theme({
             pb: [3, 3, 4, 4],
             maxWidth: layout.normal,
-            color: 'black80',
-            fontSize: 3
+            color: 'black80'
           })}
           titleize={false}
         >

--- a/src/pages/alternative/thumio.js
+++ b/src/pages/alternative/thumio.js
@@ -928,8 +928,7 @@ const SpeedSection = () => {
           css={theme({
             pb: [3, 3, 4, 4],
             maxWidth: layout.normal,
-            color: 'black80',
-            fontSize: 3
+            color: 'black80'
           })}
           titleize={false}
         >
@@ -1867,8 +1866,7 @@ const CTASection = () => (
           color: 'white80',
           pt: 3,
           pb: [3, 3, 4, 4],
-          maxWidth: layout.large,
-          fontSize: 3
+          maxWidth: layout.large
         })}
         titleize={false}
       >

--- a/src/pages/alternative/url2png.js
+++ b/src/pages/alternative/url2png.js
@@ -1209,8 +1209,7 @@ const CTASection = () => (
           color: 'white80',
           pt: 3,
           pb: [3, 3, 4, 4],
-          maxWidth: layout.large,
-          fontSize: 3
+          maxWidth: layout.large
         })}
         titleize={false}
       >

--- a/src/pages/alternative/urlbox.js
+++ b/src/pages/alternative/urlbox.js
@@ -991,8 +991,7 @@ const SpeedSection = () => {
           css={theme({
             pb: [3, 3, 4, 4],
             maxWidth: layout.normal,
-            color: 'black80',
-            fontSize: 3
+            color: 'black80'
           })}
           titleize={false}
         >
@@ -1870,8 +1869,7 @@ const CTASection = () => (
         css={theme({
           color: 'white80',
           pb: [3, 3, 4, 4],
-          maxWidth: layout.large,
-          fontSize: 3
+          maxWidth: layout.large
         })}
         titleize={false}
       >

--- a/src/pages/embed/index.js
+++ b/src/pages/embed/index.js
@@ -131,8 +131,6 @@ const getRepoStarsLabel = (repo, asNumber = false) => {
 const Subhead = withTitle(SubheadBase)
 const Caption = withTitle(CaptionBase)
 
-// ─── Hero ─────────────────────────────────────────────────────────────────────
-
 const HeroPreviewShell = styled(Box)`
   ${theme({
     width: '100%',
@@ -378,7 +376,6 @@ const Hero = function Hero ({
 
   useEffect(() => {
     if (userInteractedRef.current) return
-    // fetch the initial URL so the preview card matches the placeholder
     onSubmitRef.current(INITIAL_PLACEHOLDER_URL, {
       queryUrl: INITIAL_PLACEHOLDER_URL,
       syncQuery: false
@@ -388,11 +385,9 @@ const Hero = function Hero ({
     let timeOffset = INITIAL_DELAY_MS
 
     PLACEHOLDER_CYCLE.forEach(nextUrl => {
-      // capture per-iteration so timer closures don't read the mutated outer var
       const fromUrl = previousUrl
       const toUrl = nextUrl
 
-      // erase the previous URL, char by char
       const eraseStart = timeOffset
       for (let i = 1; i <= fromUrl.length; i++) {
         timers.push(
@@ -404,7 +399,6 @@ const Hero = function Hero ({
       }
       timeOffset = eraseStart + fromUrl.length * TYPING_SPEED_MS
 
-      // type the next URL, char by char
       const typeStart = timeOffset
       for (let i = 1; i <= toUrl.length; i++) {
         timers.push(
@@ -416,7 +410,6 @@ const Hero = function Hero ({
       }
       timeOffset = typeStart + toUrl.length * TYPING_SPEED_MS
 
-      // fetch after a brief hold so the typed URL is readable
       timers.push(
         setTimeout(() => {
           if (userInteractedRef.current) return
@@ -645,8 +638,6 @@ const Hero = function Hero ({
   )
 }
 
-// ─── Providers Showcase ───────────────────────────────────────────────────────
-
 const FEATURED_PROVIDERS = [
   { name: 'YouTube', icon: siYoutube },
   { name: 'Spotify', icon: siSpotify },
@@ -861,8 +852,6 @@ const Providers = () => {
     />
   )
 }
-
-// ─── Capabilities ─────────────────────────────────────────────────────────────
 
 const CAPABILITIES = [
   {
@@ -1145,8 +1134,6 @@ const CopyPasteEmbed = () => (
   </Container>
 )
 
-// ─── Clients ──────────────────────────────────────────────────────────────────
-
 const [
   {
     reqs_pretty: reqsPretty,
@@ -1398,8 +1385,6 @@ const Clients = () => (
   </Container>
 )
 
-// ─── Pricing ──────────────────────────────────────────────────────────────────
-
 const Pricing = () => {
   const { canonicalUrl, stripeKey } = useSiteMetadata()
   return (
@@ -1434,8 +1419,6 @@ const Pricing = () => {
     </CurrencyProvider>
   )
 }
-
-// ─── Open Source ──────────────────────────────────────────────────────────────
 
 const REPOS = [
   {
@@ -1736,8 +1719,6 @@ const OpenSource = () => (
   </Container>
 )
 
-// ─── SDK ──────────────────────────────────────────────────────────────────────
-
 const SDK_CODE_SNIPPET = `
 import Microlink from '@microlink/react'
 
@@ -1852,8 +1833,6 @@ const SdkSection = () => (
   </Container>
 )
 
-// ─── Features Grid ────────────────────────────────────────────────────────────
-
 const EMBED_FEATURES = [
   {
     title: 'One Embed for Every URL',
@@ -1900,8 +1879,6 @@ const EMBED_FEATURES = [
       'Step-by-step embed guide covering the API, the iframe parameter, custom HTML/CSS, and AI-generated previews — with runnable examples for every workflow.'
   }
 ]
-
-// ─── Customer Stories ─────────────────────────────────────────────────────────
 
 const CUSTOMER_STORY_SLUGS = ['mymahi', 'luckynote']
 
@@ -2043,8 +2020,6 @@ const CustomerStories = () => {
   )
 }
 
-// ─── Call to Action ───────────────────────────────────────────────────────────
-
 const CTA_DURATION = 6.2
 const CTA_SWEEP_PCT = (1.2 / CTA_DURATION) * 100
 const CTA_LEAD_TEXT = 'Embed'
@@ -2169,8 +2144,6 @@ const CallToAction = () => (
     </Flex>
   </Container>
 )
-
-// ─── Product Information (FAQ) ────────────────────────────────────────────────
 
 const TOP_FAQ_ITEMS = [
   {
@@ -2463,8 +2436,6 @@ const TOP_FAQ_ITEMS = [
   }
 ]
 
-// ─── Playground (Try it live) ────────────────────────────────────────────────
-
 const PLAYGROUND_TOOL_PATHS = ['/tools/embed-url']
 const EMBEDDING_TOOLS =
   TOOL_CATALOG.find(section => section.category === 'Embedding')?.tools ?? []
@@ -2598,8 +2569,6 @@ const ProductInformation = () => (
   />
 )
 
-// ─── Meta / SEO ───────────────────────────────────────────────────────────────
-
 export const Head = () => (
   <Meta
     title='Embed API for Any URL — oEmbed for 300+ Providers'
@@ -2706,8 +2675,6 @@ export const Head = () => (
     }}
   />
 )
-
-// ─── Page Assembly ────────────────────────────────────────────────────────────
 
 const EmbedPage = () => {
   return (

--- a/src/pages/embed/providers.js
+++ b/src/pages/embed/providers.js
@@ -1902,8 +1902,7 @@ const Hero = () => (
       css={theme({
         pt: [2, 2, 3, 3],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 2, '26px', '28px']
+        maxWidth: layout.large
       })}
     >
       Generate embed code for 300+ supported sites. Pick a provider below or use

--- a/src/pages/tools/embed-url/facebook.js
+++ b/src/pages/tools/embed-url/facebook.js
@@ -123,8 +123,7 @@ const Hero = () => (
       css={theme({
         pt: [2, 2, 3, 3],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 2, '26px', '28px']
+        maxWidth: layout.large
       })}
     >
       Paste any Facebook URL — get a ready-to-paste embed or custom preview card
@@ -150,8 +149,7 @@ const HowItWorks = () => (
       css={theme({
         pt: [3, 3, 4, 4],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to embed a Facebook post

--- a/src/pages/tools/embed-url/figma.js
+++ b/src/pages/tools/embed-url/figma.js
@@ -117,8 +117,7 @@ const Hero = () => (
       css={theme({
         pt: [2, 2, 3, 3],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 2, '26px', '28px']
+        maxWidth: layout.large
       })}
     >
       Paste any Figma URL — get a ready-to-paste iframe embed or preview card
@@ -144,8 +143,7 @@ const HowItWorks = () => (
       css={theme({
         pt: [3, 3, 4, 4],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to embed a Figma design

--- a/src/pages/tools/embed-url/index.js
+++ b/src/pages/tools/embed-url/index.js
@@ -195,8 +195,7 @@ const Hero = () => (
       css={theme({
         pt: [2, 2, 3, 3],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 2, '26px', '28px']
+        maxWidth: layout.large
       })}
     >
       Turn any URL into an iframe embed or a custom preview card — copy the HTML
@@ -224,8 +223,7 @@ const HowItWorks = () => (
       css={theme({
         pt: [3, 3, 4, 4],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to generate embed code for any URL
@@ -512,8 +510,7 @@ const EmbedApiDocsCard = () => (
         css={theme({
           pt: 3,
           maxWidth: layout.normal,
-          mx: 'auto',
-          fontSize: 3
+          mx: 'auto'
         })}
       >
         Read the full embed guide — iframe parameter, custom HTML/CSS,

--- a/src/pages/tools/embed-url/instagram.js
+++ b/src/pages/tools/embed-url/instagram.js
@@ -122,8 +122,7 @@ const Hero = () => (
       css={theme({
         pt: [2, 2, 3, 3],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 2, '26px', '28px']
+        maxWidth: layout.large
       })}
     >
       Paste any Instagram URL — get a ready-to-paste embed or custom preview
@@ -149,8 +148,7 @@ const HowItWorks = () => (
       css={theme({
         pt: [3, 3, 4, 4],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to embed an Instagram post

--- a/src/pages/tools/embed-url/tiktok.js
+++ b/src/pages/tools/embed-url/tiktok.js
@@ -123,8 +123,7 @@ const Hero = () => (
       css={theme({
         pt: [2, 2, 3, 3],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 2, '26px', '28px']
+        maxWidth: layout.large
       })}
     >
       Paste any TikTok URL — get a ready-to-paste embed or custom preview card.
@@ -149,8 +148,7 @@ const HowItWorks = () => (
       css={theme({
         pt: [3, 3, 4, 4],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to embed a TikTok video

--- a/src/pages/tools/embed-url/twitter-or-x.js
+++ b/src/pages/tools/embed-url/twitter-or-x.js
@@ -123,8 +123,7 @@ const Hero = () => (
       css={theme({
         pt: [2, 2, 3, 3],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 2, '26px', '28px']
+        maxWidth: layout.large
       })}
     >
       Paste any tweet or X post URL — get a ready-to-paste embed or custom
@@ -150,8 +149,7 @@ const HowItWorks = () => (
       css={theme({
         pt: [3, 3, 4, 4],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to embed a tweet

--- a/src/pages/tools/embed-url/youtube.js
+++ b/src/pages/tools/embed-url/youtube.js
@@ -123,8 +123,7 @@ const Hero = () => (
       css={theme({
         pt: [2, 2, 3, 3],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 2, '26px', '28px']
+        maxWidth: layout.large
       })}
     >
       Paste any YouTube URL — get a ready-to-paste iframe embed or custom
@@ -150,8 +149,7 @@ const HowItWorks = () => (
       css={theme({
         pt: [3, 3, 4, 4],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to embed a YouTube video

--- a/src/pages/tools/url-to-markdown.js
+++ b/src/pages/tools/url-to-markdown.js
@@ -2151,8 +2151,7 @@ const Hero = () => (
       css={theme({
         pt: [2, 2, 3, 3],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 2, '26px', '28px']
+        maxWidth: layout.large
       })}
     >
       Turn any URL into clean, structured markdown with metadata.
@@ -2180,8 +2179,7 @@ const HowItWorks = () => (
       css={theme({
         pt: [3, 3, 4, 4],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to convert a web page to markdown
@@ -2468,8 +2466,7 @@ const MarkdownApiDocsCard = () => (
         css={theme({
           pt: 3,
           maxWidth: layout.normal,
-          mx: 'auto',
-          fontSize: 3
+          mx: 'auto'
         })}
       >
         Explore the URL to Markdown guide with interactive examples, HTML

--- a/src/pages/tools/website-screenshot/animated.js
+++ b/src/pages/tools/website-screenshot/animated.js
@@ -1141,8 +1141,7 @@ const HowItWorks = () => (
       css={theme({
         pt: [3, 3, 4, 4],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [3, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to take an animated screenshot of a webpage

--- a/src/pages/tools/website-screenshot/bulk.js
+++ b/src/pages/tools/website-screenshot/bulk.js
@@ -2241,8 +2241,7 @@ const Hero = () => (
       css={theme({
         pt: [2, 2, 3, 3],
         px: 3,
-        maxWidth: '100%',
-        fontSize: [2, 2, '24px', '28px']
+        maxWidth: '100%'
       })}
     >
       Paste up to 25 URLs, capture every page at once, and download all
@@ -2270,8 +2269,7 @@ const HowItWorks = () => (
       css={theme({
         pt: [3, 3, 4, 4],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [3, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to take bulk website screenshots

--- a/src/pages/tools/website-screenshot/full-page.js
+++ b/src/pages/tools/website-screenshot/full-page.js
@@ -731,8 +731,7 @@ const Hero = () => (
       css={theme({
         pt: [2, 2, 3, 3],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 2, 2, '26px']
+        maxWidth: layout.large
       })}
     >
       Paste any URL and get a pixel-perfect, full page screenshot of the entire
@@ -761,8 +760,7 @@ const HowItWorks = () => (
       css={theme({
         pt: [3, 3, 4, 4],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [3, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to Take a Full Page Screenshot of Any Website

--- a/src/pages/tools/website-screenshot/index.js
+++ b/src/pages/tools/website-screenshot/index.js
@@ -1215,8 +1215,7 @@ const HowItWorks = () => (
       css={theme({
         pt: [3, 3, 4, 4],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [3, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to take a high quality screenshot of a website

--- a/src/pages/tools/website-screenshot/mobile.js
+++ b/src/pages/tools/website-screenshot/mobile.js
@@ -835,8 +835,7 @@ const HowItWorks = () => (
       css={theme({
         pt: [3, 3, 4, 4],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [3, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to Take a Mobile Screenshot of Any Website

--- a/src/pages/tools/website-to-pdf/bulk.js
+++ b/src/pages/tools/website-to-pdf/bulk.js
@@ -2925,8 +2925,7 @@ const Hero = () => (
       css={theme({
         pt: [2, 2, 3, 3],
         px: 3,
-        maxWidth: '100%',
-        fontSize: [2, 2, '24px', '28px']
+        maxWidth: '100%'
       })}
     >
       Paste a URL list to batch convert up to 25 web pages into PDF documents.
@@ -2954,8 +2953,7 @@ const HowItWorks = () => (
         pt: [3, 3, 4, 4],
         pb: [2, 2, 3, 3],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [3, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to bulk download PDFs from a URL list
@@ -3493,9 +3491,7 @@ const PdfApiDocsCard = () => (
         <SectionIcon icon={FileText} />
       </Flex>
       <Subhead>Bulk URL to PDF API Documentation</Subhead>
-      <Caption
-        css={theme({ pt: 3, maxWidth: layout.normal, mx: 'auto', fontSize: 3 })}
-      >
+      <Caption css={theme({ pt: 3, maxWidth: layout.normal, mx: 'auto' })}>
         Automate batch URL to PDF conversion with a single REST call. Explore
         the full API reference with interactive examples, SDKs for every
         language, and ready-to-use code snippets for bulk processing.

--- a/src/pages/tools/website-to-pdf/index.js
+++ b/src/pages/tools/website-to-pdf/index.js
@@ -1517,8 +1517,7 @@ const Hero = () => (
       css={theme({
         pt: [2, 2, 3, 3],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [2, 2, '28px', '28px']
+        maxWidth: layout.large
       })}
     >
       Use our free online tool to turn any URL into a high-fidelity PDF
@@ -1547,8 +1546,7 @@ const HowItWorks = () => (
         pt: [3, 3, 4, 4],
         pb: [2, 2, 3, 3],
         px: 3,
-        maxWidth: layout.large,
-        fontSize: [3, 3, 3, '28px']
+        maxWidth: layout.large
       })}
     >
       How to save a webpage as PDF online
@@ -2145,9 +2143,7 @@ const PdfApiDocsCard = () => (
         <SectionIcon icon={Code} />
       </Flex>
       <Subhead>HTML to PDF API Documentation</Subhead>
-      <Caption
-        css={theme({ pt: 3, maxWidth: layout.normal, mx: 'auto', fontSize: 3 })}
-      >
+      <Caption css={theme({ pt: 3, maxWidth: layout.normal, mx: 'auto' })}>
         Convert any URL to a PDF document programmatically. Explore the full API
         reference, SDKs for every language, and ready-to-use code snippets.
       </Caption>


### PR DESCRIPTION
The pending caption cleanup. ~53 `Caption` call sites rendered **28px on desktop** but each carried its own hand-tuned mobile ramp — `fontSize: 3`, `[2,3,3,'28px']`, `[3,3,3,'28px']`, `[0,2,3,3]`, `[2,2,'26px','28px']`, plus a couple 25/26px near-neighbours.

## Change
Drop the overrides so they inherit the `Caption` default `[2,2,3,3]`:
- **desktop stays 28px** (no visual change)
- **mobile normalizes to 20px** across the board (was a mix of 14/20/28)

30 files (product, tools, alternative, enterprise, …), −102/+53 lines.

## Verified
At 1440 and 375: captions render **28px desktop / 20px mobile**, no horizontal overflow on screenshot / pdf / metadata / tools / enterprise.

## Left as separate tiers (not this pass)
Deliberately untouched, by desktop size: **20px** (44), **24px** (17), **32px** (7, stat-adjacent), **22px** (4), **16px** (15), and the benchmarks `CAPTION_FONT_SIZE`. The 20px and 24px buckets need the same lead-vs-body evaluation we did for the sub-notes; 32/22/16 are finer/label tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only typography normalization on marketing pages; no API, auth, or data-path changes. Main risk is unintended mobile size shifts on pages that relied on custom ramps.
> 
> **Overview**
> Removes per-page **`fontSize` overrides** on `Caption` (and one `Caps` override on home analytics) so ~53 call sites inherit the shared **`Caption` default `[2, 2, 3, 3]`** instead of hand-tuned ramps (`fontSize: 3`, `[2,3,3,'28px']`, pixel literals like `26px`/`28px`, etc.).
> 
> **Desktop stays 28px** where those overrides already targeted 28px; **mobile shifts to a consistent 20px** where pages previously used mixed smaller sizes. Layout props like `maxWidth` and color are left in place.
> 
> Touches marketing surfaces across **alternative** pages, **embed** / **embed-url** tools, **screenshot** language landings and shared components, **PDF/screenshot tools**, and related pages. Also bumps **`git-timestamps-modified.json`** for touched routes and strips decorative section comments in **`embed/index.js`** and screenshot lang configs (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89326a0dc1c31b7d1b6953a91239a76464705a3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->