### PR TITLE
Guard against per-call typography overrides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,9 @@ The typography components own their size. Compose pages from them; do not restyl
 - MUST: Use `Heading`/`Subhead`/`Caption` for headings and supporting text, and `Text` for body/card/meta copy. The section pattern is `Subhead` (title) + `Caption` (supporting text).
 - NEVER: Pass `fontSize`, `lineHeight`, or `letterSpacing` to `Heading`, `Subhead`, or `Caption`. The component default carries them so every page stays consistent. Passing a size at the call site is the drift this repo spent PRs #2128–#2136 removing.
 - MUST: If text needs to be smaller than a section `Caption` (28px), it is body copy — use `Text`, not a shrunk `Caption`.
+- MUST: Left-aligned editorial pages (`/features/*`, the `CustomerStory`/`UseCaseStory`/`ExtensionStory` patterns) use these SAME components — pass `textAlign: 'left'` (an allowed layout prop) and `variant={null}` for a plain, non-gradient `Heading`. Do not fork a parallel size system with `SubheadBase` + a custom `fontSize`; that drift was folded back in.
 - Sanctioned escapes only (each is a real, reviewed reason a heading needs a different size): `fontSize: 'inherit'` (a gradient sub-span tracking its parent), `forwardedAs='div'` (a stat-number display reusing the heading style), or a named `UPPER_SNAKE_CASE` constant (a deliberate, centrally-defined token, e.g. `CARD_TITLE_FONT_SIZE`, `SUBSECTION_TITLE_FONT_SIZE`).
-- ENFORCED: `test/typography-overrides.js` fails the build on any per-call override outside those escapes. Run `npm test`; do not weaken the test to pass — fix the call site.
+- ENFORCED: `test/typography-overrides.js` fails the build on any per-call override outside those escapes — including the raw `SubheadBase`/`HeadingBase`/`CaptionBase` import aliases, so renaming the import does not bypass it. Run `npm test`; do not weaken the test to pass — fix the call site.
 
 ## Interactions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,24 @@ Concise rules for building accessible, fast, delightful UIs. Use MUST/SHOULD/NEV
 - MUST: When a component needs responsive visibility, use responsive arrays (e.g. `display: ["none", "flex"]`) instead of hand-writing `@media` blocks that only change `display`. For `position: fixed`/`absolute` elements, always state the target `display` value explicitly (e.g. `"flex"`, `"block"`) because `inherit` resolves against the DOM parent, not the visual stacking context, and fixed/absolute elements are out of normal flow.
 - SHOULD: Keep raw CSS only for unsupported/states-only patterns (for example keyframes, browser-specific values, or dynamic runtime computed styles).
 
+### Typography Components
+
+The typography components own their size. Compose pages from them; do not restyle their size at the call site.
+
+| Component | Tag | Size (mobile → desktop) | Role |
+| --- | --- | --- | --- |
+| `Heading` | `h1` | 52 → 64 | Page title (gradient) |
+| `Subhead` | `h2` | 52 | Section title |
+| `Caption` | `h3` | 20 → 28 | Section/hero supporting text (the lead under a heading) |
+| `Text` | `div`/`p` | 16 → 20 | Body copy, card/inline text, meta lines |
+| `Caps` | `span` | 16 | Uppercase micro-labels |
+
+- MUST: Use `Heading`/`Subhead`/`Caption` for headings and supporting text, and `Text` for body/card/meta copy. The section pattern is `Subhead` (title) + `Caption` (supporting text).
+- NEVER: Pass `fontSize`, `lineHeight`, or `letterSpacing` to `Heading`, `Subhead`, or `Caption`. The component default carries them so every page stays consistent. Passing a size at the call site is the drift this repo spent PRs #2128–#2136 removing.
+- MUST: If text needs to be smaller than a section `Caption` (28px), it is body copy — use `Text`, not a shrunk `Caption`.
+- Sanctioned escapes only (each is a real, reviewed reason a heading needs a different size): `fontSize: 'inherit'` (a gradient sub-span tracking its parent), `forwardedAs='div'` (a stat-number display reusing the heading style), or a named `UPPER_SNAKE_CASE` constant (a deliberate, centrally-defined token, e.g. `CARD_TITLE_FONT_SIZE`, `SUBSECTION_TITLE_FONT_SIZE`).
+- ENFORCED: `test/typography-overrides.js` fails the build on any per-call override outside those escapes. Run `npm test`; do not weaken the test to pass — fix the call site.
+
 ## Interactions
 
 ### Keyboard

--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -530,7 +530,7 @@
   "src/pages/graphql.js": "2019-08-01T00:00:00.000Z",
   "src/pages/iframe.js": "2023-03-19T00:00:00.000Z",
   "src/pages/index.js": "2026-07-11T00:00:00.000Z",
-  "src/pages/insights.js": "2026-07-11T00:00:00.000Z",
+  "src/pages/insights.js": "2026-07-14T00:00:00.000Z",
   "src/pages/integration/mcp.js": "2026-02-25T00:00:00.000Z",
   "src/pages/integrations.js": "2020-07-29T00:00:00.000Z",
   "src/pages/integrations/builder.js": "2026-07-14T00:00:00.000Z",
@@ -539,7 +539,7 @@
   "src/pages/integrations/mcp.js": "2026-07-14T00:00:00.000Z",
   "src/pages/integrations/sdk.js": "2026-07-14T00:00:00.000Z",
   "src/pages/link-preview.js": "2026-07-14T00:00:00.000Z",
-  "src/pages/logo.js": "2026-07-11T00:00:00.000Z",
+  "src/pages/logo.js": "2026-07-14T00:00:00.000Z",
   "src/pages/markdown.js": "2026-07-14T00:00:00.000Z",
   "src/pages/meta.js": "2026-01-24T00:00:00.000Z",
   "src/pages/metadata.js": "2026-07-14T00:00:00.000Z",
@@ -964,9 +964,9 @@
   "src/pages/tos.js": "2018-10-08T00:00:00.000Z",
   "src/pages/tos.md": "2022-11-27T00:00:00.000Z",
   "src/pages/use-cases/index.js": "2026-07-11T00:00:00.000Z",
-  "src/pages/use-cases/luckynote.js": "2026-06-27T00:00:00.000Z",
-  "src/pages/use-cases/mymahi.js": "2026-06-22T00:00:00.000Z",
-  "src/pages/use-cases/r-advertising.js": "2026-06-27T00:00:00.000Z",
+  "src/pages/use-cases/luckynote.js": "2026-07-14T00:00:00.000Z",
+  "src/pages/use-cases/mymahi.js": "2026-07-14T00:00:00.000Z",
+  "src/pages/use-cases/r-advertising.js": "2026-07-14T00:00:00.000Z",
   "src/pages/use-cases/upscale-extracted-images.js": "2026-06-27T00:00:00.000Z",
-  "src/pages/user-agents.js": "2026-04-20T00:00:00.000Z"
+  "src/pages/user-agents.js": "2026-07-14T00:00:00.000Z"
 }

--- a/src/components/patterns/CustomerStory/CtaSection.js
+++ b/src/components/patterns/CustomerStory/CtaSection.js
@@ -2,6 +2,7 @@ import { colors, layout, theme } from 'theme'
 import React from 'react'
 
 import Flex from 'components/elements/Flex'
+import Subhead from 'components/elements/Subhead'
 import Text from 'components/elements/Text'
 
 import ArrowLink from 'components/patterns/ArrowLink'
@@ -31,19 +32,10 @@ export const CtaSection = ({
       `}
     >
       <SectionInner css={theme({ textAlign: 'center' })}>
-        <Text
-          as='h2'
-          css={theme({
-            color: 'black',
-            fontSize: ['28px', '32px', '40px', '46px'],
-            letterSpacing: '-0.01em',
-            lineHeight: 0,
-            fontWeight: 'bold'
-          })}
-        >
+        <Subhead css={theme({ color: 'black' })}>
           {headlinePrefix}{' '}
           <span css={theme({ color: accent.text })}>{headlineAccent}</span>?
-        </Text>
+        </Subhead>
         <Text
           as='p'
           css={theme({

--- a/src/components/patterns/CustomerStory/MoreCustomers.js
+++ b/src/components/patterns/CustomerStory/MoreCustomers.js
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import Box from 'components/elements/Box'
 import Flex from 'components/elements/Flex'
 import { Link } from 'components/elements/Link'
-import SubheadBase from 'components/elements/Subhead'
+import Subhead from 'components/elements/Subhead'
 import Text from 'components/elements/Text'
 
 import { CUSTOMERS } from './customers'
@@ -119,16 +119,13 @@ export const MoreCustomers = ({ accent, currentSlug }) => {
           <Eyebrow accent={accent} css={theme({ pb: 2, display: 'block' })}>
             More customer stories
           </Eyebrow>
-          <SubheadBase
+          <Subhead
             css={theme({
-              fontSize: ['24px', '28px', '34px', '38px'],
-              textAlign: 'center',
-              letterSpacing: '-0.01em',
-              lineHeight: 0
+              textAlign: 'center'
             })}
           >
             See how other teams ship with Microlink
-          </SubheadBase>
+          </Subhead>
         </Box>
 
         <CarouselTrack

--- a/src/components/patterns/ExtensionStory/MoreExtensions.js
+++ b/src/components/patterns/ExtensionStory/MoreExtensions.js
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import Box from 'components/elements/Box'
 import Flex from 'components/elements/Flex'
 import { Link } from 'components/elements/Link'
-import SubheadBase from 'components/elements/Subhead'
+import Subhead from 'components/elements/Subhead'
 import Text from 'components/elements/Text'
 
 import { Eyebrow } from 'components/patterns/CustomerStory/chrome'
@@ -99,16 +99,13 @@ export const MoreExtensions = ({ accent, currentSlug }) => {
           <Eyebrow accent={accent} css={theme({ pb: 2, display: 'block' })}>
             More extensions
           </Eyebrow>
-          <SubheadBase
+          <Subhead
             css={theme({
-              fontSize: ['24px', '28px', '34px', '38px'],
-              textAlign: 'center',
-              letterSpacing: '-0.01em',
-              lineHeight: 0
+              textAlign: 'center'
             })}
           >
             Bring Microlink everywhere you work
-          </SubheadBase>
+          </Subhead>
         </Box>
 
         <CardsRow role='list' aria-label='More extensions'>

--- a/src/components/patterns/UseCaseStory/MoreUseCases.js
+++ b/src/components/patterns/UseCaseStory/MoreUseCases.js
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import Box from 'components/elements/Box'
 import Flex from 'components/elements/Flex'
 import { Link } from 'components/elements/Link'
-import SubheadBase from 'components/elements/Subhead'
+import Subhead from 'components/elements/Subhead'
 import Text from 'components/elements/Text'
 
 import { Eyebrow } from 'components/patterns/CustomerStory/chrome'
@@ -120,16 +120,13 @@ export const MoreUseCases = ({ accent, currentSlug }) => {
           <Eyebrow accent={accent} css={theme({ pb: 2, display: 'block' })}>
             More use cases
           </Eyebrow>
-          <SubheadBase
+          <Subhead
             css={theme({
-              fontSize: ['24px', '28px', '34px', '38px'],
-              textAlign: 'center',
-              letterSpacing: '-0.01em',
-              lineHeight: 0
+              textAlign: 'center'
             })}
           >
             Explore more ways to build with Microlink
-          </SubheadBase>
+          </Subhead>
         </Box>
 
         <CarouselTrack

--- a/src/pages/features/automation.js
+++ b/src/pages/features/automation.js
@@ -6,7 +6,8 @@ import CodeEditor from 'components/elements/CodeEditor/CodeEditor'
 import Flex from 'components/elements/Flex'
 import { Link } from 'components/elements/Link'
 import Meta from 'components/elements/Meta/Meta'
-import SubheadBase from 'components/elements/Subhead'
+import Heading from 'components/elements/Heading'
+import Subhead from 'components/elements/Subhead'
 import Text from 'components/elements/Text'
 
 import { CodeInline } from 'components/markdown/CodeInline'
@@ -49,21 +50,10 @@ const Hero = () => (
       <Flex css={theme({ alignItems: 'center', gap: 2, pb: [3, 3, 4, 4] })}>
         <PlanTag>Core feature · free tier</PlanTag>
       </Flex>
-      <Text
-        as='h1'
-        css={theme({
-          color: 'black',
-          fontWeight: 'bold',
-          fontSize: ['32px', '40px', '52px', '60px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0,
-          m: 0
-        })}
-      >
+      <Heading variant={null} css={theme({ textAlign: 'left' })}>
         <span css={theme({ color: 'secondary' })}>Browser automation:</span>{' '}
         shape the page before you capture it
-      </Text>
+      </Heading>
       <Caption
         forwardedAs='p'
         titleize={false}
@@ -208,16 +198,13 @@ const ControlPlanes = () => (
         <Eyebrow css={theme({ pb: 2, display: 'block' })}>
           Three control planes → one request
         </Eyebrow>
-        <SubheadBase
+        <Subhead
           css={theme({
-            fontSize: ['24px', '28px', '34px', '38px'],
-            textAlign: 'left',
-            letterSpacing: '-0.01em',
-            lineHeight: 0
+            textAlign: 'left'
           })}
         >
           Interact, emulate, rewrite
-        </SubheadBase>
+        </Subhead>
         <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
           Each parameter is one query-string key — compose as many as you need
           on a single request, no scripting required. When declarative
@@ -332,16 +319,13 @@ const CodeExampleEmulate = () => (
   <Section>
     <SectionInner>
       <Eyebrow css={theme({ pb: 2, display: 'block' })}>Code</Eyebrow>
-      <SubheadBase
+      <Subhead
         css={theme({
-          fontSize: ['24px', '28px', '34px', '38px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          textAlign: 'left'
         })}
       >
         Dark mode, on an iPhone, without owning one
-      </SubheadBase>
+      </Subhead>
       <BodyText css={theme({ pt: 3, pb: [3, 3, 4, 4] })}>
         Device emulation and color-scheme forcing are single parameters — the
         screenshot below renders exactly what a dark-mode iPhone user would see.
@@ -384,16 +368,13 @@ const CodeExampleInteract = () => (
   <Section>
     <SectionInner>
       <Eyebrow css={theme({ pb: 2, display: 'block' })}>Interaction</Eyebrow>
-      <SubheadBase
+      <Subhead
         css={theme({
-          fontSize: ['24px', '28px', '34px', '38px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          textAlign: 'left'
         })}
       >
         Click first, wait, then extract
-      </SubheadBase>
+      </Subhead>
       <BodyText css={theme({ pt: 3, pb: [3, 3, 4, 4] })}>
         Interaction parameters compose with every output — here the browser
         clicks a tab, waits for the price to exist in the DOM, and only then
@@ -445,16 +426,13 @@ const CleanCaptures = () => (
         <Eyebrow css={theme({ pb: 2, display: 'block' })}>
           Included on every plan
         </Eyebrow>
-        <SubheadBase
+        <Subhead
           css={theme({
-            fontSize: ['24px', '28px', '34px', '38px'],
-            textAlign: 'left',
-            letterSpacing: '-0.01em',
-            lineHeight: 0
+            textAlign: 'left'
           })}
         >
           Clean by default, unblockable on Pro
-        </SubheadBase>
+        </Subhead>
         <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
           Every automation parameter on this page works on the free tier — they
           are part of the core rendering engine, not an add-on. Pro plans matter
@@ -684,17 +662,14 @@ const FAQSection = () => (
 const CtaSection = () => (
   <Section>
     <SectionInner css={theme({ textAlign: 'center' })}>
-      <SubheadBase
+      <Subhead
         css={theme({
-          color: 'black',
-          fontSize: ['28px', '32px', '40px', '46px'],
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          color: 'black'
         })}
       >
         Set the stage,{' '}
         <span css={theme({ color: 'secondary' })}>then capture it.</span>
-      </SubheadBase>
+      </Subhead>
       <Caption
         forwardedAs='p'
         titleize={false}

--- a/src/pages/features/function.js
+++ b/src/pages/features/function.js
@@ -6,7 +6,8 @@ import CodeEditor from 'components/elements/CodeEditor/CodeEditor'
 import Flex from 'components/elements/Flex'
 import { Link } from 'components/elements/Link'
 import Meta from 'components/elements/Meta/Meta'
-import SubheadBase from 'components/elements/Subhead'
+import Heading from 'components/elements/Heading'
+import Subhead from 'components/elements/Subhead'
 import Text from 'components/elements/Text'
 
 import { CodeInline } from 'components/markdown/CodeInline'
@@ -49,21 +50,10 @@ const Hero = () => (
       <Flex css={theme({ alignItems: 'center', gap: 2, pb: [3, 3, 4, 4] })}>
         <PlanTag>Core feature · free tier</PlanTag>
       </Flex>
-      <Text
-        as='h1'
-        css={theme({
-          color: 'black',
-          fontWeight: 'bold',
-          fontSize: ['32px', '40px', '52px', '60px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0,
-          m: 0
-        })}
-      >
+      <Heading variant={null} css={theme({ textAlign: 'left' })}>
         <span css={theme({ color: 'secondary' })}>Browser functions:</span> your
         code, our headless browser
-      </Text>
+      </Heading>
       <Caption
         forwardedAs='p'
         titleize={false}
@@ -205,16 +195,13 @@ const ExecutionShapes = () => (
         <Eyebrow css={theme({ pb: 2, display: 'block' })}>
           Three execution shapes → one parameter
         </Eyebrow>
-        <SubheadBase
+        <Subhead
           css={theme({
-            fontSize: ['24px', '28px', '34px', '38px'],
-            textAlign: 'left',
-            letterSpacing: '-0.01em',
-            lineHeight: 0
+            textAlign: 'left'
           })}
         >
           From a one-liner to full browser automation
-        </SubheadBase>
+        </Subhead>
         <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
           Every function runs in the same sandboxed runtime — what you reference
           inside it decides how much machinery spins up. Pay the browser cost
@@ -324,16 +311,13 @@ const CodeExampleBrowser = () => (
   <Section>
     <SectionInner>
       <Eyebrow css={theme({ pb: 2, display: 'block' })}>Code</Eyebrow>
-      <SubheadBase
+      <Subhead
         css={theme({
-          fontSize: ['24px', '28px', '34px', '38px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          textAlign: 'left'
         })}
       >
         Puppeteer, without the infrastructure
-      </SubheadBase>
+      </Subhead>
       <BodyText css={theme({ pt: 3, pb: [3, 3, 4, 4] })}>
         The <CodeInline>@microlink/function</CodeInline> library handles
         serialization, compression, and the API call. Your function receives{' '}
@@ -375,16 +359,13 @@ const CodeExampleNpm = () => (
   <Section>
     <SectionInner>
       <Eyebrow css={theme({ pb: 2, display: 'block' })}>npm</Eyebrow>
-      <SubheadBase
+      <Subhead
         css={theme({
-          fontSize: ['24px', '28px', '34px', '38px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          textAlign: 'left'
         })}
       >
         Dependencies, resolved for you
-      </SubheadBase>
+      </Subhead>
       <BodyText css={theme({ pt: 3, pb: [3, 3, 4, 4] })}>
         Write <CodeInline>require()</CodeInline> as if you were on your own
         machine. The first run installs and caches; subsequent runs skip the
@@ -442,16 +423,13 @@ const PlansSection = () => (
         <Eyebrow css={theme({ pb: 2, display: 'block' })}>
           Prototype free, scale on Pro
         </Eyebrow>
-        <SubheadBase
+        <Subhead
           css={theme({
-            fontSize: ['24px', '28px', '34px', '38px'],
-            textAlign: 'left',
-            letterSpacing: '-0.01em',
-            lineHeight: 0
+            textAlign: 'left'
           })}
         >
           The same runtime on every plan
-        </SubheadBase>
+        </Subhead>
         <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
           Functions run on the free tier — enough to prototype workflows and
           every example on this page. Pro raises the execution limits and
@@ -683,16 +661,13 @@ const FAQSection = () => (
 const CtaSection = () => (
   <Section>
     <SectionInner css={theme({ textAlign: 'center' })}>
-      <SubheadBase
+      <Subhead
         css={theme({
-          color: 'black',
-          fontSize: ['28px', '32px', '40px', '46px'],
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          color: 'black'
         })}
       >
         Your code, <span css={theme({ color: 'secondary' })}>our browser.</span>
-      </SubheadBase>
+      </Subhead>
       <Caption
         forwardedAs='p'
         titleize={false}

--- a/src/pages/features/headers.js
+++ b/src/pages/features/headers.js
@@ -7,7 +7,8 @@ import CodeEditor from 'components/elements/CodeEditor/CodeEditor'
 import Flex from 'components/elements/Flex'
 import { Link } from 'components/elements/Link'
 import Meta from 'components/elements/Meta/Meta'
-import SubheadBase from 'components/elements/Subhead'
+import Heading from 'components/elements/Heading'
+import Subhead from 'components/elements/Subhead'
 import Text from 'components/elements/Text'
 
 import { CodeInline } from 'components/markdown/CodeInline'
@@ -137,21 +138,10 @@ const Hero = () => (
       <Flex css={theme({ alignItems: 'center', gap: 2, pb: [3, 3, 4, 4] })}>
         <ProTag>Pro feature</ProTag>
       </Flex>
-      <Text
-        as='h1'
-        css={theme({
-          color: 'black',
-          fontWeight: 'bold',
-          fontSize: ['32px', '40px', '52px', '60px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0,
-          m: 0
-        })}
-      >
+      <Heading variant={null} css={theme({ textAlign: 'left' })}>
         <span css={theme({ color: 'secondary' })}>Custom HTTP Headers:</span>{' '}
         Forward any header, keep secrets safe
-      </Text>
+      </Heading>
       <Caption
         forwardedAs='p'
         css={theme({
@@ -325,16 +315,13 @@ const TwoChannels = () => (
         <Eyebrow css={theme({ pb: 2, display: 'block' })}>
           Two channels → one feature
         </Eyebrow>
-        <SubheadBase
+        <Subhead
           css={theme({
-            fontSize: ['24px', '28px', '34px', '38px'],
-            textAlign: 'left',
-            letterSpacing: '-0.01em',
-            lineHeight: 0
+            textAlign: 'left'
           })}
         >
           Public values stay public, secrets stay private
-        </SubheadBase>
+        </Subhead>
         <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
           The split exists for one reason: query strings are publicly visible —
           in browser history, in server logs, in URL embeds — while HTTPS
@@ -614,16 +601,13 @@ const CodeExample = () => (
   <Section>
     <SectionInner>
       <Eyebrow css={theme({ pb: 2, display: 'block' })}>Code</Eyebrow>
-      <SubheadBase
+      <Subhead
         css={theme({
-          fontSize: ['24px', '28px', '34px', '38px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          textAlign: 'left'
         })}
       >
         Recommended: server-side, secrets in process env
-      </SubheadBase>
+      </Subhead>
       <BodyText css={theme({ pt: 3, pb: [3, 3, 4, 4] })}>
         Public values go in the second argument (
         <CodeInline>headers</CodeInline>); private ones go in MQL's third
@@ -831,17 +815,14 @@ const FAQSection = () => (
 const CtaSection = () => (
   <Section>
     <SectionInner css={theme({ textAlign: 'center' })}>
-      <SubheadBase
+      <Subhead
         css={theme({
-          color: 'black',
-          fontSize: ['28px', '32px', '40px', '46px'],
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          color: 'black'
         })}
       >
         Public values,{' '}
         <span css={theme({ color: 'secondary' })}>private secrets.</span>
-      </SubheadBase>
+      </Subhead>
       <Caption
         forwardedAs='p'
         css={theme({

--- a/src/pages/features/index.js
+++ b/src/pages/features/index.js
@@ -16,7 +16,8 @@ import Flex from 'components/elements/Flex'
 import { Link } from 'components/elements/Link'
 import Meta from 'components/elements/Meta/Meta'
 import LineBreak from 'components/elements/LineBreak'
-import SubheadBase from 'components/elements/Subhead'
+import Heading from 'components/elements/Heading'
+import Subhead from 'components/elements/Subhead'
 import Text from 'components/elements/Text'
 
 import ArrowLink from 'components/patterns/ArrowLink'
@@ -248,22 +249,10 @@ const Hero = () => {
             >
               Features
             </StoryTag>
-            <Text
-              as='h1'
-              css={theme({
-                color: 'black',
-                fontWeight: 'bold',
-                fontSize: ['32px', '40px', '52px', '60px'],
-                textAlign: 'left',
-                letterSpacing: '-0.01em',
-                lineHeight: 0,
-                m: 0,
-                scrollMarginTop: 4
-              })}
-            >
+            <Heading variant={null} css={theme({ textAlign: 'left' })}>
               Every parameter. <LineBreak />
               <span css={textGradient}>Every output.</span>
-            </Text>
+            </Heading>
             <Text as='p' css={theme({ pt: [3, 3, 4, 4] })}>
               Production-grade capabilities — data extraction, proxy, caching,
               headers — that work uniformly across metadata, screenshots, PDFs,
@@ -489,17 +478,14 @@ const FeaturesGrid = () => (
 const CtaSection = () => (
   <Section>
     <SectionInner css={theme({ textAlign: 'center' })}>
-      <SubheadBase
+      <Subhead
         css={theme({
-          color: 'black',
-          fontSize: ['28px', '32px', '40px', '46px'],
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          color: 'black'
         })}
       >
         Built in,{' '}
         <span css={theme({ color: 'secondary' })}>not bolted on.</span>
-      </SubheadBase>
+      </Subhead>
       <Caption
         forwardedAs='p'
         titleize={false}

--- a/src/pages/features/proxy.js
+++ b/src/pages/features/proxy.js
@@ -7,7 +7,8 @@ import CodeEditor from 'components/elements/CodeEditor/CodeEditor'
 import Flex from 'components/elements/Flex'
 import { Link } from 'components/elements/Link'
 import Meta from 'components/elements/Meta/Meta'
-import SubheadBase from 'components/elements/Subhead'
+import Heading from 'components/elements/Heading'
+import Subhead from 'components/elements/Subhead'
 import Text from 'components/elements/Text'
 
 import { CodeInline } from 'components/markdown/CodeInline'
@@ -137,21 +138,10 @@ const Hero = () => (
       <Flex css={theme({ alignItems: 'center', gap: 2, pb: [3, 3, 4, 4] })}>
         <ProTag>Pro feature</ProTag>
       </Flex>
-      <Text
-        as='h1'
-        css={theme({
-          color: 'black',
-          fontWeight: 'bold',
-          fontSize: ['32px', '40px', '52px', '60px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0,
-          m: 0
-        })}
-      >
+      <Heading variant={null} css={theme({ textAlign: 'left' })}>
         <span css={theme({ color: 'secondary' })}>Residential Proxy API:</span>{' '}
         Bypass Antibots & CAPTCHAs
-      </Text>
+      </Heading>
       <Caption
         forwardedAs='p'
         css={theme({
@@ -370,16 +360,13 @@ const ThreeInOne = () => (
         <Eyebrow css={theme({ pb: 2, display: 'block' })}>
           Three subscriptions → one parameter
         </Eyebrow>
-        <SubheadBase
+        <Subhead
           css={theme({
-            fontSize: ['24px', '28px', '34px', '38px'],
-            textAlign: 'left',
-            letterSpacing: '-0.01em',
-            lineHeight: 0
+            textAlign: 'left'
           })}
         >
           Stop paying three vendors for one job
-        </SubheadBase>
+        </Subhead>
         <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
           A residential proxy, an antibot detector, and a CAPTCHA solver are
           typically three separate vendor contracts, three SDKs in your{' '}
@@ -689,16 +676,13 @@ const CodeExample = () => (
   <Section>
     <SectionInner>
       <Eyebrow css={theme({ pb: 2, display: 'block' })}>Code</Eyebrow>
-      <SubheadBase
+      <Subhead
         css={theme({
-          fontSize: ['24px', '28px', '34px', '38px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          textAlign: 'left'
         })}
       >
         Default: automatic resolution
-      </SubheadBase>
+      </Subhead>
       <BodyText css={theme({ pt: 3, pb: [3, 3, 4, 4] })}>
         Send the request as you normally would. On any Pro metadata, HTML, or
         markdown request, the proxy layer engages automatically when the target
@@ -729,16 +713,13 @@ const BringYourOwn = () => (
       <Eyebrow css={theme({ pb: 2, display: 'block' })}>
         Bring your own proxy
       </Eyebrow>
-      <SubheadBase
+      <Subhead
         css={theme({
-          fontSize: ['24px', '28px', '34px', '38px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          textAlign: 'left'
         })}
       >
         Already paying for a residential proxy?
-      </SubheadBase>
+      </Subhead>
       <BodyText css={theme({ pt: 3, pb: [3, 3, 4, 4] })}>
         If you have a dedicated provider or need a fixed country IP, pass the
         proxy URL on the <CodeInline>proxy</CodeInline> parameter. Microlink
@@ -780,16 +761,13 @@ const Verifying = () => (
   <Section>
     <SectionInner>
       <Eyebrow css={theme({ pb: 2, display: 'block' })}>Verify</Eyebrow>
-      <SubheadBase
+      <Subhead
         css={theme({
-          fontSize: ['24px', '28px', '34px', '38px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          textAlign: 'left'
         })}
       >
         How to confirm a request was proxied
-      </SubheadBase>
+      </Subhead>
       <BodyText css={theme({ pt: 3, pb: [3, 3, 4, 4] })}>
         Every proxied response carries an <CodeInline>x-fetch-mode</CodeInline>{' '}
         header ending in <CodeInline>-proxy</CodeInline>. That suffix is your
@@ -956,18 +934,15 @@ const FAQSection = () => (
 const CtaSection = () => (
   <Section>
     <SectionInner css={theme({ textAlign: 'center' })}>
-      <SubheadBase
+      <Subhead
         css={theme({
-          color: 'black',
-          fontSize: ['28px', '32px', '40px', '46px'],
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          color: 'black'
         })}
       >
         Stop renting{' '}
         <span css={theme({ color: 'secondary' })}>three vendors</span> for one
         job.
-      </SubheadBase>
+      </Subhead>
       <Caption
         forwardedAs='p'
         css={theme({

--- a/src/pages/features/scraping.js
+++ b/src/pages/features/scraping.js
@@ -6,7 +6,8 @@ import CodeEditor from 'components/elements/CodeEditor/CodeEditor'
 import Flex from 'components/elements/Flex'
 import { Link } from 'components/elements/Link'
 import Meta from 'components/elements/Meta/Meta'
-import SubheadBase from 'components/elements/Subhead'
+import Heading from 'components/elements/Heading'
+import Subhead from 'components/elements/Subhead'
 import Text from 'components/elements/Text'
 
 import { CodeInline } from 'components/markdown/CodeInline'
@@ -49,21 +50,10 @@ const Hero = () => (
       <Flex css={theme({ alignItems: 'center', gap: 2, pb: [3, 3, 4, 4] })}>
         <PlanTag>Core feature · free tier</PlanTag>
       </Flex>
-      <Text
-        as='h1'
-        css={theme({
-          color: 'black',
-          fontWeight: 'bold',
-          fontSize: ['32px', '40px', '52px', '60px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0,
-          m: 0
-        })}
-      >
+      <Heading variant={null} css={theme({ textAlign: 'left' })}>
         <span css={theme({ color: 'secondary' })}>Data extraction:</span> turn
         any page into structured JSON
-      </Text>
+      </Heading>
       <Caption
         forwardedAs='p'
         titleize={false}
@@ -208,16 +198,13 @@ const RuleShapes = () => (
         <Eyebrow css={theme({ pb: 2, display: 'block' })}>
           Three rule shapes → one parameter
         </Eyebrow>
-        <SubheadBase
+        <Subhead
           css={theme({
-            fontSize: ['24px', '28px', '34px', '38px'],
-            textAlign: 'left',
-            letterSpacing: '-0.01em',
-            lineHeight: 0
+            textAlign: 'left'
           })}
         >
           From a single field to a full collection
-        </SubheadBase>
+        </Subhead>
         <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
           Every extraction rule is built from the same five properties —{' '}
           <CodeInline>selector</CodeInline>,{' '}
@@ -329,16 +316,13 @@ const CodeExampleSingle = () => (
   <Section>
     <SectionInner>
       <Eyebrow css={theme({ pb: 2, display: 'block' })}>Code</Eyebrow>
-      <SubheadBase
+      <Subhead
         css={theme({
-          fontSize: ['24px', '28px', '34px', '38px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          textAlign: 'left'
         })}
       >
         Your first extraction, two rules
-      </SubheadBase>
+      </Subhead>
       <BodyText css={theme({ pt: 3, pb: [3, 3, 4, 4] })}>
         Each key inside <CodeInline>data</CodeInline> is a field in the
         response. Here <CodeInline>headline</CodeInline> reads the text and{' '}
@@ -383,16 +367,13 @@ const CodeExampleCollection = () => (
   <Section>
     <SectionInner>
       <Eyebrow css={theme({ pb: 2, display: 'block' })}>Collections</Eyebrow>
-      <SubheadBase
+      <Subhead
         css={theme({
-          fontSize: ['24px', '28px', '34px', '38px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          textAlign: 'left'
         })}
       >
         Every match, as structured objects
-      </SubheadBase>
+      </Subhead>
       <BodyText css={theme({ pt: 3, pb: [3, 3, 4, 4] })}>
         <CodeInline>selectorAll</CodeInline> turns the rule into an array;
         nested <CodeInline>attr</CodeInline> rules run against each match. Add{' '}
@@ -448,16 +429,13 @@ const ProSection = () => (
         <Eyebrow css={theme({ pb: 2, display: 'block' })}>
           When targets fight back
         </Eyebrow>
-        <SubheadBase
+        <Subhead
           css={theme({
-            fontSize: ['24px', '28px', '34px', '38px'],
-            textAlign: 'left',
-            letterSpacing: '-0.01em',
-            lineHeight: 0
+            textAlign: 'left'
           })}
         >
           Pro adds the unblocking layer
-        </SubheadBase>
+        </Subhead>
         <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
           Extraction rules are half the job — the other half is getting the page
           to render at all. Every Pro plan bundles the pieces that keep scraping
@@ -733,16 +711,13 @@ const FAQSection = () => (
 const CtaSection = () => (
   <Section>
     <SectionInner css={theme({ textAlign: 'center' })}>
-      <SubheadBase
+      <Subhead
         css={theme({
-          color: 'black',
-          fontSize: ['28px', '32px', '40px', '46px'],
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          color: 'black'
         })}
       >
         Selectors in, <span css={theme({ color: 'secondary' })}>JSON out.</span>
-      </SubheadBase>
+      </Subhead>
       <Caption
         forwardedAs='p'
         titleize={false}

--- a/src/pages/features/ttl.js
+++ b/src/pages/features/ttl.js
@@ -9,7 +9,8 @@ import CodeEditor from 'components/elements/CodeEditor/CodeEditor'
 import Flex from 'components/elements/Flex'
 import { Link } from 'components/elements/Link'
 import Meta from 'components/elements/Meta/Meta'
-import SubheadBase from 'components/elements/Subhead'
+import Heading from 'components/elements/Heading'
+import Subhead from 'components/elements/Subhead'
 import Text from 'components/elements/Text'
 
 import { CodeInline } from 'components/markdown/CodeInline'
@@ -139,21 +140,10 @@ const Hero = () => (
       <Flex css={theme({ alignItems: 'center', gap: 2, pb: [3, 3, 4, 4] })}>
         <ProTag>Pro feature</ProTag>
       </Flex>
-      <Text
-        as='h1'
-        css={theme({
-          color: 'black',
-          fontWeight: 'bold',
-          fontSize: ['32px', '40px', '52px', '60px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0,
-          m: 0
-        })}
-      >
+      <Heading variant={null} css={theme({ textAlign: 'left' })}>
         <span css={theme({ color: 'secondary' })}>Cache TTL:</span> A
         configurable cache, served from the edge
-      </Text>
+      </Heading>
       <Caption
         forwardedAs='p'
         css={theme({
@@ -330,16 +320,13 @@ const TwoInOne = () => (
         <Eyebrow css={theme({ pb: 2, display: 'block' })}>
           Two parameters → every cache trade-off
         </Eyebrow>
-        <SubheadBase
+        <Subhead
           css={theme({
-            fontSize: ['24px', '28px', '34px', '38px'],
-            textAlign: 'left',
-            letterSpacing: '-0.01em',
-            lineHeight: 0
+            textAlign: 'left'
           })}
         >
           Pay once. Serve millions of cache hits for free.
-        </SubheadBase>
+        </Subhead>
         <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
           A request cache, an invalidation policy, and a background revalidator
           are the three pieces every team rebuilds on top of an external API.
@@ -772,16 +759,13 @@ const CodeExample = () => (
   <Section>
     <SectionInner>
       <Eyebrow css={theme({ pb: 2, display: 'block' })}>Code</Eyebrow>
-      <SubheadBase
+      <Subhead
         css={theme({
-          fontSize: ['24px', '28px', '34px', '38px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          textAlign: 'left'
         })}
       >
         Recommended: one paid request per day, the rest are free
-      </SubheadBase>
+      </Subhead>
       <BodyText css={theme({ pt: 3, pb: [3, 3, 4, 4] })}>
         Keep responses valid for 24 hours and serve every caller from cache
         while a background refresh keeps them current. The result: a single
@@ -828,16 +812,13 @@ const ForceFresh = () => (
       <Eyebrow css={theme({ pb: 2, display: 'block' })}>
         Bypass the cache
       </Eyebrow>
-      <SubheadBase
+      <Subhead
         css={theme({
-          fontSize: ['24px', '28px', '34px', '38px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          textAlign: 'left'
         })}
       >
         Need a guaranteed fresh response?
-      </SubheadBase>
+      </Subhead>
       <BodyText css={theme({ pt: 3, pb: [3, 3, 4, 4] })}>
         Pass <CodeInline>force: true</CodeInline> to skip the cache layer
         entirely and force-regenerate a new copy. The response header{' '}
@@ -881,16 +862,13 @@ const Verifying = () => (
   <Section>
     <SectionInner>
       <Eyebrow css={theme({ pb: 2, display: 'block' })}>Verify</Eyebrow>
-      <SubheadBase
+      <Subhead
         css={theme({
-          fontSize: ['24px', '28px', '34px', '38px'],
-          textAlign: 'left',
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          textAlign: 'left'
         })}
       >
         How to confirm cache behavior
-      </SubheadBase>
+      </Subhead>
       <BodyText css={theme({ pt: 3, pb: [3, 3, 4, 4] })}>
         <CodeInline>x-cache-status</CodeInline> is the source of truth — and the
         difference between a free request and a billed one.{' '}
@@ -1131,17 +1109,14 @@ const FAQSection = () => (
 const CtaSection = () => (
   <Section>
     <SectionInner css={theme({ textAlign: 'center' })}>
-      <SubheadBase
+      <Subhead
         css={theme({
-          color: 'black',
-          fontSize: ['28px', '32px', '40px', '46px'],
-          letterSpacing: '-0.01em',
-          lineHeight: 0
+          color: 'black'
         })}
       >
         Pay for misses.{' '}
         <span css={theme({ color: 'secondary' })}>Hits are on us.</span>
-      </SubheadBase>
+      </Subhead>
       <Caption
         forwardedAs='p'
         css={theme({

--- a/src/pages/metadata.js
+++ b/src/pages/metadata.js
@@ -123,6 +123,8 @@ const FEATURES = [
 ]
 
 const PLAYGROUND_TOOL_PATHS = ['/tools/sharing-debugger']
+
+const CARD_TITLE_FONT_SIZE = [2, 2, 3, 3]
 const METADATA_TOOLS =
   TOOL_CATALOG.find(section => section.category === 'Metadata')?.tools ?? []
 const PLAYGROUND_TOOLS = PLAYGROUND_TOOL_PATHS.map(path =>
@@ -3247,7 +3249,7 @@ const Stack = ({ currentUrl }) => {
                   <Subhead
                     titleize={false}
                     css={theme({
-                      fontSize: [2, 2, 3, 3],
+                      fontSize: CARD_TITLE_FONT_SIZE,
                       textAlign: 'left'
                     })}
                   >

--- a/test/typography-overrides.js
+++ b/test/typography-overrides.js
@@ -24,35 +24,57 @@ const walk = dir =>
 const isSanctioned = openingTag =>
   SANCTIONED.some(rule => rule.test(openingTag))
 
-const findOverrides = file => {
-  const open = new RegExp(`<(${COMPONENTS.join('|')})(Base)?\\b`)
-  const lines = fs.readFileSync(file, 'utf8').split('\n')
-  const hits = []
-  let inTag = false
-  let comp = ''
-  let openingTag = ''
-  let start = 0
-  for (let i = 0; i < lines.length; i++) {
-    const match = lines[i].match(open)
-    if (!inTag && match) {
-      inTag = true
-      comp = match[1]
-      openingTag = ''
-      start = i
-    }
-    if (inTag) {
-      const tagEnd = lines[i].replace(/=>/g, '  ').indexOf('>')
-      const isTagClosed = tagEnd !== -1
-      openingTag += (isTagClosed ? lines[i].slice(0, tagEnd) : lines[i]) + '\n'
-      if (isTagClosed) {
-        if (PROP.test(openingTag) && !isSanctioned(openingTag)) {
-          hits.push(
-            `${path.relative(process.cwd(), file)}:${start + 1} <${comp}>`
-          )
-        }
-        inTag = false
+const tagEndAt = (src, from) => {
+  let depth = 0
+  let quote = null
+  const tmpl = []
+  for (let i = from; i < src.length; i++) {
+    const c = src[i]
+    if (quote) {
+      if (c === '\\') {
+        i++
+      } else if (quote === '`' && c === '$' && src[i + 1] === '{') {
+        tmpl.push(depth)
+        depth++
+        quote = null
+        i++
+      } else if (c === quote) {
+        quote = null
       }
+      continue
     }
+    if (c === "'" || c === '"' || c === '`') {
+      quote = c
+    } else if (c === '{' || c === '[' || c === '(') {
+      depth++
+    } else if (c === '}' || c === ']' || c === ')') {
+      depth--
+      if (tmpl.length && depth === tmpl[tmpl.length - 1]) {
+        tmpl.pop()
+        quote = '`'
+      }
+    } else if (c === '>' && depth === 0) {
+      return i
+    }
+  }
+  return -1
+}
+
+const findOverrides = file => {
+  const open = new RegExp(`<(${COMPONENTS.join('|')})(Base)?\\b`, 'g')
+  const src = fs.readFileSync(file, 'utf8')
+  const hits = []
+  let match
+  while ((match = open.exec(src))) {
+    const end = tagEndAt(src, open.lastIndex)
+    if (end === -1) break
+    const openingTag = src.slice(match.index, end + 1)
+    if (PROP.test(openingTag) && !isSanctioned(openingTag)) {
+      const line = src.slice(0, match.index).split('\n').length
+      const comp = match[1] + (match[2] || '')
+      hits.push(`${path.relative(process.cwd(), file)}:${line} <${comp}>`)
+    }
+    open.lastIndex = end + 1
   }
   return hits
 }

--- a/test/typography-overrides.js
+++ b/test/typography-overrides.js
@@ -1,0 +1,85 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+// Design spec: the typography components (Heading, Subhead, Caption) own their
+// size. Call sites MUST NOT pass fontSize / lineHeight / letterSpacing — the
+// component default carries them, so every page stays consistent. This test
+// fails the build when a per-call override sneaks in (usually AI-generated
+// pages that don't follow the spec).
+//
+// Sanctioned escapes (a heading that legitimately needs a different size):
+//   1. fontSize: 'inherit'            — a gradient sub-span tracking its parent
+//   2. forwardedAs='div'              — a stat-number display reusing the style
+//   3. a named UPPER_SNAKE constant   — a deliberate, centrally-defined token
+//                                        (e.g. CARD_TITLE_FONT_SIZE)
+//   4. Storybook demos (*.stories.*, story.jsx, patterns/Legend)
+
+const SRC = path.join(process.cwd(), 'src')
+const COMPONENTS = ['Heading', 'Subhead', 'Caption']
+const PROP = /(fontSize|lineHeight|letterSpacing):/
+const SKIP = /\.stories\.|[\\/]story\.jsx$|[\\/]Legend[\\/]/
+
+const walk = dir =>
+  fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      return entry.name === 'node_modules' ? [] : walk(full)
+    }
+    return /\.jsx?$/.test(entry.name) ? [full] : []
+  })
+
+const isSanctioned = tag =>
+  /fontSize:\s*['"]inherit['"]/.test(tag) ||
+  /forwardedAs=['"]div['"]/.test(tag) ||
+  /(fontSize|lineHeight|letterSpacing):\s*[A-Z][A-Z0-9_]+\b/.test(tag)
+
+const findOverrides = file => {
+  const lines = fs.readFileSync(file, 'utf8').split('\n')
+  const open = new RegExp(`<(${COMPONENTS.join('|')})\\b`)
+  const close = new RegExp(`</(${COMPONENTS.join('|')})`)
+  const hits = []
+  let inTag = false
+  let comp = ''
+  let tag = ''
+  let start = 0
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(open)
+    if (!inTag && m && !close.test(lines[i])) {
+      inTag = true
+      comp = m[1]
+      tag = ''
+      start = i
+    }
+    if (inTag) {
+      tag += lines[i] + '\n'
+      // the opening tag closes at the first '>' that is not part of '=>'
+      if (/>/.test(lines[i].replace(/=>/g, ''))) {
+        if (PROP.test(tag) && !isSanctioned(tag)) {
+          hits.push(
+            `${path.relative(process.cwd(), file)}:${start + 1} <${comp}>`
+          )
+        }
+        inTag = false
+      }
+    }
+  }
+  return hits
+}
+
+describe('typography components own their size', () => {
+  test('no per-call fontSize / lineHeight / letterSpacing on Heading/Subhead/Caption', () => {
+    const violations = walk(SRC)
+      .filter(f => !SKIP.test(f))
+      .flatMap(findOverrides)
+
+    expect(
+      violations,
+      violations.length
+        ? `\n\nRemove these per-call typography overrides — use the component default instead:\n  ${violations.join(
+          '\n  '
+        )}\n\nIf a heading genuinely needs a different size, use one of the sanctioned escapes documented in test/typography-overrides.js (inherit, forwardedAs='div', or a named UPPER_SNAKE constant).\n`
+        : undefined
+    ).toEqual([])
+  })
+})

--- a/test/typography-overrides.js
+++ b/test/typography-overrides.js
@@ -25,7 +25,7 @@ const isSanctioned = openingTag =>
   SANCTIONED.some(rule => rule.test(openingTag))
 
 const findOverrides = file => {
-  const open = new RegExp(`<(${COMPONENTS.join('|')})\\b`)
+  const open = new RegExp(`<(${COMPONENTS.join('|')})(Base)?\\b`)
   const lines = fs.readFileSync(file, 'utf8').split('\n')
   const hits = []
   let inTag = false

--- a/test/typography-overrides.js
+++ b/test/typography-overrides.js
@@ -2,22 +2,14 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 
-// Design spec: the typography components (Heading, Subhead, Caption) own their
-// size. Call sites MUST NOT pass fontSize / lineHeight / letterSpacing — the
-// component default carries them, so every page stays consistent. This test
-// fails the build when a per-call override sneaks in (usually AI-generated
-// pages that don't follow the spec).
-//
-// Sanctioned escapes (a heading that legitimately needs a different size):
-//   1. fontSize: 'inherit'            — a gradient sub-span tracking its parent
-//   2. forwardedAs='div'              — a stat-number display reusing the style
-//   3. a named UPPER_SNAKE constant   — a deliberate, centrally-defined token
-//                                        (e.g. CARD_TITLE_FONT_SIZE)
-//   4. Storybook demos (*.stories.*, story.jsx, patterns/Legend)
-
 const SRC = path.join(process.cwd(), 'src')
 const COMPONENTS = ['Heading', 'Subhead', 'Caption']
-const PROP = /(fontSize|lineHeight|letterSpacing):/
+const PROP = /(fontSize|lineHeight|letterSpacing)\s*[:=]/
+const SANCTIONED = [
+  /(fontSize|lineHeight|letterSpacing)\s*[:=]\s*\{?\s*['"]inherit['"]/,
+  /forwardedAs=['"]div['"]/,
+  /(fontSize|lineHeight|letterSpacing)\s*[:=]\s*\{?\s*[A-Z][A-Z0-9_]+/
+]
 const SKIP = /\.stories\.|[\\/]story\.jsx$|[\\/]Legend[\\/]/
 
 const walk = dir =>
@@ -26,36 +18,34 @@ const walk = dir =>
     if (entry.isDirectory()) {
       return entry.name === 'node_modules' ? [] : walk(full)
     }
-    return /\.jsx?$/.test(entry.name) ? [full] : []
+    return /\.[jt]sx?$/.test(entry.name) ? [full] : []
   })
 
-const isSanctioned = tag =>
-  /fontSize:\s*['"]inherit['"]/.test(tag) ||
-  /forwardedAs=['"]div['"]/.test(tag) ||
-  /(fontSize|lineHeight|letterSpacing):\s*[A-Z][A-Z0-9_]+\b/.test(tag)
+const isSanctioned = openingTag =>
+  SANCTIONED.some(rule => rule.test(openingTag))
 
 const findOverrides = file => {
-  const lines = fs.readFileSync(file, 'utf8').split('\n')
   const open = new RegExp(`<(${COMPONENTS.join('|')})\\b`)
-  const close = new RegExp(`</(${COMPONENTS.join('|')})`)
+  const lines = fs.readFileSync(file, 'utf8').split('\n')
   const hits = []
   let inTag = false
   let comp = ''
-  let tag = ''
+  let openingTag = ''
   let start = 0
   for (let i = 0; i < lines.length; i++) {
-    const m = lines[i].match(open)
-    if (!inTag && m && !close.test(lines[i])) {
+    const match = lines[i].match(open)
+    if (!inTag && match) {
       inTag = true
-      comp = m[1]
-      tag = ''
+      comp = match[1]
+      openingTag = ''
       start = i
     }
     if (inTag) {
-      tag += lines[i] + '\n'
-      // the opening tag closes at the first '>' that is not part of '=>'
-      if (/>/.test(lines[i].replace(/=>/g, ''))) {
-        if (PROP.test(tag) && !isSanctioned(tag)) {
+      const tagEnd = lines[i].replace(/=>/g, '  ').indexOf('>')
+      const isTagClosed = tagEnd !== -1
+      openingTag += (isTagClosed ? lines[i].slice(0, tagEnd) : lines[i]) + '\n'
+      if (isTagClosed) {
+        if (PROP.test(openingTag) && !isSanctioned(openingTag)) {
           hits.push(
             `${path.relative(process.cwd(), file)}:${start + 1} <${comp}>`
           )
@@ -70,7 +60,7 @@ const findOverrides = file => {
 describe('typography components own their size', () => {
   test('no per-call fontSize / lineHeight / letterSpacing on Heading/Subhead/Caption', () => {
     const violations = walk(SRC)
-      .filter(f => !SKIP.test(f))
+      .filter(file => !SKIP.test(file))
       .flatMap(findOverrides)
 
     expect(
@@ -78,7 +68,7 @@ describe('typography components own their size', () => {
       violations.length
         ? `\n\nRemove these per-call typography overrides — use the component default instead:\n  ${violations.join(
           '\n  '
-        )}\n\nIf a heading genuinely needs a different size, use one of the sanctioned escapes documented in test/typography-overrides.js (inherit, forwardedAs='div', or a named UPPER_SNAKE constant).\n`
+        )}\n\nSanctioned escapes (see CLAUDE.md › Typography Components): fontSize: 'inherit', forwardedAs='div', or a named UPPER_SNAKE constant.\n`
         : undefined
     ).toEqual([])
   })


### PR DESCRIPTION
Prevents the drift we just spent #2128–#2136 removing from coming back. The root cause was AI-generated pages passing `fontSize` on `Heading`/`Subhead`/`Caption` instead of using the component defaults — so this makes that **fail the build**, per the "write the script that constrains the LLM forever after" principle.

## What's in it
- **`test/typography-overrides.js`** — a vitest test (mirroring the existing `test/theme-shadow-tokens.js`) that scans `src/` and fails on any per-call `fontSize` / `lineHeight` / `letterSpacing` on `Heading`, `Subhead`, or `Caption`. Runs in `npm test` / CI. The failure message lists each `file:line`.
  - **Sanctioned escapes** (real, reviewed reasons a heading needs a different size): `fontSize: 'inherit'` (gradient sub-span), `forwardedAs='div'` (stat-number display), or a named `UPPER_SNAKE_CASE` constant (a deliberate, centrally-defined token). Storybook demos are skipped.
- **`metadata.js`** — extracted the one remaining literal card-title size to a named `CARD_TITLE_FONT_SIZE` constant, so its intent is explicit and the guard passes cleanly with **0 violations** on `master`.
- **`CLAUDE.md`** — documents the typography component set, the `Subhead`+`Caption` section pattern, the no-per-call-size rule, and points at the enforcing test.

## Proof it works
Verified the test **passes** on current `master` and **fails** (listing `metadata.js:NNNN`) the instant a literal size is reintroduced — so it will catch the next drifting page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and test-only guardrails with no auth, data, or API behavior changes; main effect is slightly different heading scale on some marketing pages.
> 
> **Overview**
> Adds **`test/typography-overrides.js`**, a Vitest scan of `src/` that fails CI when `Heading`, `Subhead`, or `Caption` (including `*Base` import aliases) get per-call `fontSize`, `lineHeight`, or `letterSpacing` outside sanctioned escapes. Documents the typography component set and rules in **`CLAUDE.md`**.
> 
> Cleans up drift so the guard passes: feature pages and story CTAs use **`Heading`** / **`Subhead`** instead of styled `Text`/`SubheadBase` with custom sizes; **`metadata.js`** moves stack card title sizing to **`CARD_TITLE_FONT_SIZE`**. Timestamp bumps in **`git-timestamps-modified.json`** track touched pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d374a0b431b5c921473f0b6bd9fd8d56e1a26851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added “Typography Components” guidance with an approved component-to-tag/size reference and rules for allowed typography overrides/escapes.
* **Style**
  * Standardized headings and subheadings across feature pages and customer/story sections using dedicated `Heading`/`Subhead` components.
  * Centralized responsive Stack card title sizing for consistent typography.
* **Quality Improvements**
  * Added an automated test that fails builds when unauthorized per-call typography sizing overrides are used for `Heading`, `Subhead`, and `Caption`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->