### PR TITLE
feat: show function memory attributable to the function

### DIFF
--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -143,7 +143,7 @@
   "src/content/docs/guides/function/npm-packages.md": "2026-05-24T00:00:00.000Z",
   "src/content/docs/guides/function/page-interaction.md": "2026-05-24T00:00:00.000Z",
   "src/content/docs/guides/function/profiling-and-performance.md": "2026-07-17T00:00:00.000Z",
-  "src/content/docs/guides/function/troubleshooting.md": "2026-06-02T00:00:00.000Z",
+  "src/content/docs/guides/function/troubleshooting.md": "2026-07-17T00:00:00.000Z",
   "src/content/docs/guides/function/writing-functions.md": "2026-05-24T00:00:00.000Z",
   "src/content/docs/guides/index.md": "2026-07-05T00:00:00.000Z",
   "src/content/docs/guides/insights/caching-and-performance.md": "2026-05-21T00:00:00.000Z",

--- a/src/components/pages/home/output.js
+++ b/src/components/pages/home/output.js
@@ -974,6 +974,13 @@ const fmtBytes = bytes => {
     : `${Math.max(1, Math.round(bytes / 1024))} KB`
 }
 
+// `profiling.memory` used to be a lone RSS number, which included the ~43MB
+// Node.js baseline and so never approached zero. It is now a breakdown, and
+// `used` is the part the function is accountable for. The live API and cached
+// demo payloads can still carry the old shape, so accept both.
+const fmtMemory = memory =>
+  fmtBytes(typeof memory === 'number' ? memory : memory?.used)
+
 const Stat = ({ label, value }) => (
   <Box css={theme({ textAlign: 'center' })}>
     <Box
@@ -1022,7 +1029,7 @@ const Profiling = ({ profiling }) => {
       >
         <Stat label='Total' value={fmtMs(total)} />
         <Stat label='CPU' value={fmtMs(cpu)} />
-        <Stat label='Memory' value={fmtBytes(memory)} />
+        <Stat label='Memory' value={fmtMemory(memory)} />
         <Stat label='Size' value={fmtBytes(size)} />
       </Flex>
 

--- a/src/content/docs/api/parameters/function.md
+++ b/src/content/docs/api/parameters/function.md
@@ -106,7 +106,7 @@ The result is wrapped under `data.function`:
       "profiling": {
         "phases": { "install": 0, "build": 120, "spawn": 45, "run": 890, "total": 1055 },
         "cpu": 234,
-        "memory": 69996544,
+        "memory": { "total": 69996544, "used": 2359296, "heap": 4410880, "external": 1742574 },
         "size": 156
       },
       "logging": {}
@@ -119,7 +119,7 @@ The result is wrapped under `data.function`:
 | ------------- | ----------------------------------------------------------------------------------------------- |
 | `isFulfilled` | `true` when the function completed without errors                                               |
 | `value`       | The return value on success, or `{ name, message }` on failure                                  |
-| `profiling`   | Execution metrics: phase durations (ms), CPU time (ms), resident memory at return (bytes), and code size (bytes) |
+| `profiling`   | Execution metrics: phase durations (ms), CPU time (ms), a memory breakdown (bytes), and code size (bytes) |
 | `logging`     | Captured console output from the function runtime                                               |
 
 The profiling phases are:

--- a/src/content/docs/guides/function/profiling-and-performance.md
+++ b/src/content/docs/guides/function/profiling-and-performance.md
@@ -20,7 +20,7 @@ console.log(result.profiling)
 // {
 //   phases: { install: 0, build: 120, spawn: 45, run: 890, total: 1055 },
 //   cpu: 234,
-//   memory: 69996544,
+//   memory: { total: 69996544, used: 2359296, heap: 4410880, external: 1742574 },
 //   size: 156
 // }
 ```
@@ -33,7 +33,10 @@ console.log(result.profiling)
 | `phases.run`     | Time spent executing the function                               |
 | `phases.total`   | Wall-clock time from start to finish                            |
 | `cpu`            | Peak CPU time in milliseconds                                   |
-| `memory`         | Resident memory (RSS) when the function returned, in bytes      |
+| `memory.total`   | Resident memory of the sandbox, Node.js baseline included, in bytes |
+| `memory.used`    | Resident memory attributable to your function, in bytes         |
+| `memory.heap`    | V8 heap in use, in bytes. The only field the memory limit bounds |
+| `memory.external`| Off-heap `Buffer`/`ArrayBuffer` memory, in bytes                 |
 | `size`           | Bundled code size in bytes                                      |
 
 Use profiling to understand where time is spent. If install is high, your dependencies are being installed for the first time — subsequent runs use the cache. If run is high, the function itself is doing heavy work.

--- a/src/content/docs/guides/function/troubleshooting.md
+++ b/src/content/docs/guides/function/troubleshooting.md
@@ -69,11 +69,13 @@ Each error message is plan-aware:
 2. Avoid CPU-intensive operations like large JSON parsing or complex regular expressions.
 3. Move heavy processing to your own server and use the function only for data extraction.
 
-**MemoryError** — the function exceeded its memory limit (16 MB free, 32 MB pro):
+**MemoryError** — the function exceeded its memory limit (16 MB free, 32 MB pro). The limit applies to the JavaScript heap, which is where objects, arrays, and strings live, and it is reported as `profiling.memory.heap`:
 
 1. Reduce the amount of data held in memory at once.
 2. Avoid loading entire pages into memory when you only need a small part.
 3. Use streaming or pagination patterns when dealing with large datasets.
+
+Binary data such as `Buffer` and typed arrays is allocated off the heap and is reported separately as `profiling.memory.external`. It does not count toward this limit, so a function returning large screenshots or PDFs is unlikely to hit `MemoryError`.
 
 **CodeSizeError** — the function code exceeds the 1024 bytes free plan limit:
 

--- a/test/components/home-output-profiling-memory.js
+++ b/test/components/home-output-profiling-memory.js
@@ -8,8 +8,10 @@ const source = fs.readFileSync(
 )
 
 describe('home output renders profiling memory as bytes', () => {
-  test('memory goes through the byte formatter', () => {
-    expect(source).toContain("<Stat label='Memory' value={fmtBytes(memory)} />")
+  test('memory goes through the memory formatter', () => {
+    expect(source).toContain(
+      "<Stat label='Memory' value={fmtMemory(memory)} />"
+    )
   })
 
   test('no formatter treats the raw value as megabytes', () => {
@@ -20,5 +22,11 @@ describe('home output renders profiling memory as bytes', () => {
     expect(source).toContain('const fmtBytes = bytes => {')
     expect(source).toContain('bytes >= 1048576')
     expect(source).toContain('(bytes / 1048576).toFixed(1)')
+  })
+
+  test('reads .used from the breakdown, and tolerates the legacy number', () => {
+    expect(source).toContain(
+      "typeof memory === 'number' ? memory : memory?.used"
+    )
   })
 })


### PR DESCRIPTION
`isolated-function` now returns `profiling.memory` as a breakdown. The widget showed total RSS, which carries the ~43MB Node.js baseline, so a function that allocated nothing still read tens of MB.

Show `used` instead. The live API and cached demo payloads still send the old flat number, so both shapes are accepted.

Split out of #2149, where it was sitting unrelated to the skills redesign. Rebased onto `master` and unchanged from the original commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mtduh97b8PNXzMcPw7giLw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and a small display helper change only; backward-compatible handling of old profiling payloads.
> 
> **Overview**
> Aligns the site with **`profiling.memory` as an object** (`total`, `used`, `heap`, `external`) instead of a single RSS byte count.
> 
> The home **function profiling** panel now displays **`memory.used`** (function-attributable RSS) via `fmtMemory`, while still accepting the legacy numeric shape from live API or cached demos. API and guide docs update examples and field tables; **MemoryError** troubleshooting now ties limits to **`profiling.memory.heap`** and clarifies that **`external`** (buffers) is off-heap. Tests assert the new formatter and backward compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95fa18255a86d3a99a1be016b3789062ead9fe8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->