### PR TITLE
docs(errors): document EPDFTOOLARGE

### DIFF
--- a/src/content/docs/api/basics/error-codes.md
+++ b/src/content/docs/api/basics/error-codes.md
@@ -235,6 +235,18 @@ The target URL reached the maximum number of redirect after 10 times.
 
 Ensure the [url](/docs/api/parameters/url) provided reaches the destination URL in less than 10 hops.
 
+## EPDFTOOLARGE
+
+**Message**
+
+The target document is too large to render as a PDF within the time budget.
+
+**Solution**
+
+The [pdf](/docs/api/parameters/pdf) rendering could not finish before the request [timeout](/docs/api/parameters/timeout), even after splitting the document into parallel page ranges.
+
+Reduce the amount of content to rasterize with a smaller [pdf.scale](/docs/api/parameters/pdf), or split the source into shorter pages, and try again.
+
 ## EPRO
 
 **Message**

--- a/src/helpers/api-error.js
+++ b/src/helpers/api-error.js
@@ -2,6 +2,7 @@ const ERROR_META = {
   ERATE: { title: 'Rate limit reached', showRetry: false },
   ETIMEOUT: { title: 'Request timed out', showRetry: true },
   EFATAL: { title: 'Processing failed', showRetry: true },
+  EPDFTOOLARGE: { title: 'Document too large', showRetry: false },
   EPROXYNEEDED: { title: 'Antibot detected', showRetry: false },
   EMPTY_MARKDOWN: {
     title: 'This URL couldn\u2019t be analyzed',

--- a/vercel.json
+++ b/vercel.json
@@ -227,6 +227,10 @@
       "destination": "/docs/api/parameters/emulation"
     },
     {
+      "source": "/epdftoolarge",
+      "destination": "/docs/api/basics/error-codes#epdftoolarge"
+    },
+    {
       "source": "/epro",
       "destination": "/docs/api/basics/error-codes#epro"
     },


### PR DESCRIPTION
The API returns a new typed error, **`EPDFTOOLARGE` (422)**, when a document is too large to render as a PDF within the request budget — even after splitting into parallel page ranges. Its `more` link is `https://microlink.io/epdftoolarge`, which needs a destination.

- **error-codes.md** — new `## EPDFTOOLARGE` entry (message + solution: lower `pdf.scale` or split the source). This creates the `#epdftoolarge` anchor.
- **vercel.json** — `/epdftoolarge` → `/docs/api/basics/error-codes#epdftoolarge`, matching the API's `more` URL, consistent with every other `E*` short-link.
- **api-error.js** — UI meta: title "Document too large", `showRetry: false` (a retry can't make the document smaller).

Paired with the API change (microlink/api!1715) that introduces the error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, redirect, and display metadata only; no API or auth behavior changes in this repo.
> 
> **Overview**
> Documents the new **`EPDFTOOLARGE`** API error (document too large to finish PDF rendering within the request budget, including after parallel page splits).
> 
> Adds a **error-codes** section with message and remediation (`pdf.scale`, shorter pages, timeout context). Registers **`/epdftoolarge`** in **vercel.json** so the API `more` URL lands on `#epdftoolarge`, matching other `E*` short-links. Maps **`EPDFTOOLARGE`** in **api-error.js** to the title "Document too large" and **`showRetry: false`** so the UI does not suggest retrying the same oversized job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb51d496c5f87762cb3388bba06a2b2134e05bb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->