### PR TITLE
feat: add /features/security landing page

### DIFF
--- a/src/components/pages/security/cta.js
+++ b/src/components/pages/security/cta.js
@@ -1,0 +1,60 @@
+import { SECTION_VERTICAL_SPACING, layout, theme } from 'theme'
+import React from 'react'
+
+import Flex from 'components/elements/Flex'
+import Subhead from 'components/elements/Subhead'
+import { Link } from 'components/elements/Link'
+
+import ArrowLink from 'components/patterns/ArrowLink'
+import {
+  Caption,
+  Section,
+  SectionInner
+} from 'components/patterns/FeatureStory'
+
+export const Cta = () => (
+  <Section css={theme({ py: SECTION_VERTICAL_SPACING })}>
+    <SectionInner css={theme({ textAlign: 'center' })}>
+      <Subhead css={theme({ color: 'black' })}>
+        Isolated by default,{' '}
+        <span css={theme({ color: 'secondary' })}>
+          dedicated when you need it.
+        </span>
+      </Subhead>
+      <Caption
+        forwardedAs='p'
+        titleize={false}
+        css={theme({
+          color: 'black70',
+          pt: [3, 3, 4, 4],
+          maxWidth: layout.small,
+          mx: 'auto'
+        })}
+      >
+        Every plan runs on the same isolation model — one incognito browser per
+        request, SSRF screening on every URL. When your compliance team needs
+        physical separation, Enterprise puts the whole API on your own hardware.
+        Read our <Link href='/security'>security practices</Link> for the full
+        picture.
+      </Caption>
+      <Flex
+        css={theme({
+          py: [3, 4, 4, 4],
+          justifyContent: 'center',
+          alignItems: 'center'
+        })}
+      >
+        <ArrowLink
+          href='/enterprise'
+          css={theme({
+            color: 'link',
+            fontWeight: 'bold',
+            fontSize: [2, 2, 3, 3]
+          })}
+        >
+          Talk to us about Enterprise
+        </ArrowLink>
+      </Flex>
+    </SectionInner>
+  </Section>
+)

--- a/src/components/pages/security/enterprise.js
+++ b/src/components/pages/security/enterprise.js
@@ -1,0 +1,60 @@
+import { SECTION_VERTICAL_SPACING, theme } from 'theme'
+import React from 'react'
+
+import Box from 'components/elements/Box'
+
+import ArrowLink from 'components/patterns/ArrowLink'
+import {
+  BodyText,
+  ChipRow,
+  Section,
+  SectionInner
+} from 'components/patterns/FeatureStory'
+
+import { SectionIntro } from './shared'
+
+const ENTERPRISE_GUARANTEES = [
+  'dedicated endpoint',
+  'isolated browser pool',
+  '8 regions',
+  '99.9% uptime SLA',
+  'GDPR-compliant DPA'
+]
+
+export const Enterprise = () => (
+  <Section css={theme({ py: SECTION_VERTICAL_SPACING })}>
+    <SectionInner>
+      <SectionIntro
+        eyebrow='Beyond shared infrastructure'
+        title='Enterprise: isolation down to the hardware'
+      >
+        <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
+          Everything above is the default on the public API. Microlink
+          Enterprise moves the boundary one level down: your own API endpoint
+          running on hardware that serves only you, backed by a dedicated pool
+          of always-ready browsers. No shared capacity, no noisy neighbors — and
+          you choose which of 8 locations the hardware lives in.
+        </BodyText>
+        <ChipRow items={ENTERPRISE_GUARANTEES} />
+        <BodyText>
+          The data terms are just as explicit: your content is never used to
+          train or fine-tune AI models, you own what you process, and we delete
+          it within 60&nbsp;days of your request — all backed by a
+          GDPR-compliant Data Processing Agreement ready for your legal team.
+        </BodyText>
+        <Box css={theme({ pt: [3, 3, 4, 4] })}>
+          <ArrowLink
+            href='/enterprise'
+            css={theme({
+              color: 'link',
+              fontWeight: 'bold',
+              fontSize: [1, 1, 2, 2]
+            })}
+          >
+            Explore Microlink Enterprise
+          </ArrowLink>
+        </Box>
+      </SectionIntro>
+    </SectionInner>
+  </Section>
+)

--- a/src/components/pages/security/faq.js
+++ b/src/components/pages/security/faq.js
@@ -1,0 +1,151 @@
+import { theme } from 'theme'
+import React from 'react'
+
+import Box from 'components/elements/Box'
+import { Link } from 'components/elements/Link'
+
+import { CodeInline } from 'components/markdown/CodeInline'
+
+import Faq from 'components/patterns/Faq/Faq'
+import {
+  SECTION_MAX_WIDTH,
+  SECTION_PX,
+  SECTION_PY
+} from 'components/patterns/FeatureStory'
+
+export const FAQ_ITEMS = [
+  {
+    question: 'Does every request really get its own browser?',
+    text: 'Yes. Each request is assigned its own incognito browser context, created when the request starts and destroyed when it finishes — on success, timeout, or client disconnect. Contexts are never shared or reused across requests, so cookies, caches, profiles, and session state cannot leak between them.',
+    answer: (
+      <>
+        <div>
+          Yes. Each request is assigned its own incognito browser context,
+          created when the request starts and destroyed when it finishes — on
+          success, timeout, or client disconnect.
+        </div>
+        <div>
+          Contexts are never shared or reused across requests, so cookies,
+          caches, profiles, and session state cannot leak between them.
+        </div>
+      </>
+    )
+  },
+  {
+    question: 'How does Microlink prevent SSRF?',
+    text: 'At two layers. Before the fetch, the hostname is resolved via DNS and refused with EFORBIDDENURL if it points at a reserved range — loopback, private networks, link-local, or cloud metadata endpoints — with redirects re-checked hop by hop. During rendering, a Chromium request interceptor validates every origin the page touches and aborts the request if it navigates into a reserved range mid-render.',
+    answer: (
+      <>
+        <div>
+          At two layers. Before the fetch, the hostname is resolved via DNS and
+          refused with <CodeInline>EFORBIDDENURL</CodeInline> if it points at a
+          reserved range — loopback, private networks, link-local, or cloud
+          metadata endpoints — with redirects re-checked hop by hop.
+        </div>
+        <div>
+          During rendering, a Chromium request interceptor validates every
+          origin the page touches and aborts the request if it navigates into a
+          reserved range mid-render.
+        </div>
+      </>
+    )
+  },
+  {
+    question: 'Are cookies, cache, or sessions shared between requests?',
+    text: 'No. All browser state lives inside the request’s own incognito context and is destroyed with it. Cached API responses are keyed by SHA-512 hashes that incorporate the headers a request was made with, so a response fetched with your credentials is never served to a request without them.',
+    answer: (
+      <>
+        <div>
+          No. All browser state lives inside the request&rsquo;s own incognito
+          context and is destroyed with it.
+        </div>
+        <div>
+          Cached API responses are keyed by SHA-512 hashes that incorporate the
+          headers a request was made with, so a response fetched with your
+          credentials is never served to a request without them.
+        </div>
+      </>
+    )
+  },
+  {
+    question: 'What limits apply to user-supplied code?',
+    text: 'Code passed through the function parameter runs inside a VM with an execution timeout and a memory ceiling. On the free plan, code size is capped and cross-origin fetch, XHR, and WebSocket calls are blocked. Every request, with or without code, is subject to hard time limits and concurrency caps.',
+    answer: (
+      <>
+        <div>
+          Code passed through the <CodeInline>function</CodeInline> parameter
+          runs inside a VM with an execution timeout and a memory ceiling. On
+          the free plan, code size is capped and cross-origin{' '}
+          <CodeInline>fetch</CodeInline>, <CodeInline>xhr</CodeInline>, and{' '}
+          <CodeInline>websocket</CodeInline> calls are blocked.
+        </div>
+        <div>
+          Every request, with or without code, is subject to hard time limits
+          and concurrency caps — see{' '}
+          <Link href='/features/function'>browser functions</Link> for the full
+          execution model.
+        </div>
+      </>
+    )
+  },
+  {
+    question: 'What additional security does Enterprise provide?',
+    text: 'Microlink Enterprise runs the full API on hardware that serves only you: a dedicated endpoint backed by an isolated pool of always-ready browsers, deployable in 8 locations, with a 99.9% uptime SLA. Your content is never used to train AI models, and it is deleted within 60 days of your request, backed by a GDPR-compliant Data Processing Agreement.',
+    answer: (
+      <>
+        <div>
+          <Link href='/enterprise'>Microlink Enterprise</Link> runs the full API
+          on hardware that serves only you: a dedicated endpoint backed by an
+          isolated pool of always-ready browsers, deployable in
+          8&nbsp;locations, with a 99.9% uptime SLA.
+        </div>
+        <div>
+          Your content is never used to train AI models, and it is deleted
+          within 60&nbsp;days of your request — backed by a GDPR-compliant{' '}
+          <Link href='/dpa'>Data Processing Agreement</Link>.
+        </div>
+      </>
+    )
+  },
+  {
+    question: 'Where can I read about compliance and data processing?',
+    text: 'The security practices page covers infrastructure security, encryption, monitoring, and GDPR compliance. The Data Processing Agreement, subprocessors list, and privacy policy cover the legal side. For vulnerability reports, email hello@microlink.io with the subject "Security Inquiry".',
+    answer: (
+      <>
+        <div>
+          The <Link href='/security'>security practices</Link> page covers
+          infrastructure security, encryption, monitoring, and GDPR compliance.
+          The <Link href='/dpa'>Data Processing Agreement</Link>,{' '}
+          <Link href='/subprocessors'>subprocessors list</Link>, and{' '}
+          <Link href='/privacy'>privacy policy</Link> cover the legal side.
+        </div>
+        <div>
+          For vulnerability reports, email{' '}
+          <Link href='mailto:hello@microlink.io'>hello@microlink.io</Link> with
+          the subject &ldquo;Security Inquiry&rdquo;.
+        </div>
+      </>
+    )
+  }
+]
+
+export const FaqSection = () => (
+  <Box
+    css={theme({
+      bg: 'pinky',
+      borderTop: 1,
+      borderTopColor: 'pinkest',
+      width: '100%'
+    })}
+  >
+    <Box css={theme({ maxWidth: SECTION_MAX_WIDTH, mx: 'auto' })}>
+      <Faq
+        css={theme({
+          py: SECTION_PY,
+          px: SECTION_PX
+        })}
+        questions={FAQ_ITEMS}
+      />
+    </Box>
+  </Box>
+)

--- a/src/components/pages/security/hero.js
+++ b/src/components/pages/security/hero.js
@@ -1,0 +1,59 @@
+import { SECTION_VERTICAL_SPACING, layout, theme } from 'theme'
+import React from 'react'
+
+import Box from 'components/elements/Box'
+import Flex from 'components/elements/Flex'
+import Heading from 'components/elements/Heading'
+
+import ArrowLink from 'components/patterns/ArrowLink'
+import {
+  Caption,
+  PlanTag,
+  Section,
+  SectionInner
+} from 'components/patterns/FeatureStory'
+
+export const Hero = () => (
+  <Section
+    as='header'
+    css={theme({ pt: [3, 3, 4, 4], pb: SECTION_VERTICAL_SPACING })}
+  >
+    <SectionInner>
+      <Flex css={theme({ alignItems: 'center', gap: 2, pb: [3, 3, 4, 4] })}>
+        <PlanTag>Every plan</PlanTag>
+      </Flex>
+      <Heading variant={null} css={theme({ textAlign: 'left' })}>
+        <span css={theme({ color: 'secondary' })}>Request security:</span> one
+        isolated browser per request
+      </Heading>
+      <Caption
+        forwardedAs='p'
+        titleize={false}
+        css={theme({
+          pt: [3, 3, 4, 4],
+          textAlign: 'left',
+          maxWidth: layout.large,
+          mx: 0
+        })}
+      >
+        Every API call gets its own incognito browser context — created for that
+        request, destroyed when it finishes. No cookies, caches, or profiles are
+        ever shared between requests, and every URL is screened against reserved
+        IP ranges before and during rendering, so a request can never reach a
+        private network.
+      </Caption>
+      <Box css={theme({ pt: [3, 3, 4, 4] })}>
+        <ArrowLink
+          href='/pricing'
+          css={theme({
+            color: 'link',
+            fontWeight: 'bold',
+            fontSize: [2, 2, 3, 3]
+          })}
+        >
+          Isolation included on every plan
+        </ArrowLink>
+      </Box>
+    </SectionInner>
+  </Section>
+)

--- a/src/components/pages/security/isolation.js
+++ b/src/components/pages/security/isolation.js
@@ -1,0 +1,102 @@
+import { SECTION_VERTICAL_SPACING, theme } from 'theme'
+import React from 'react'
+
+import Flex from 'components/elements/Flex'
+import Box from 'components/elements/Box'
+
+import {
+  BodyText,
+  Card,
+  CardBody,
+  CardKicker,
+  CardMain,
+  CardSide,
+  CardTitle,
+  ChipRow,
+  Section,
+  SectionInner
+} from 'components/patterns/FeatureStory'
+
+import { SectionIntro } from './shared'
+
+const CONTEXT_SCOPE = ['dedicated context', 'keyed by request id']
+
+const NEVER_SHARED = ['cookies', 'localStorage', 'cache', 'profile', 'sessions']
+
+const TEARDOWN_TRIGGERS = ['on completion', 'on timeout', 'on disconnect']
+
+export const Isolation = () => (
+  <Section css={theme({ py: SECTION_VERTICAL_SPACING })}>
+    <SectionInner>
+      <Box css={theme({ pb: [4, 4, 5, 5] })}>
+        <SectionIntro
+          eyebrow='One request, one browser'
+          title='Request isolation by construction'
+        >
+          <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
+            Isolation is not a setting you enable — it is how the engine
+            allocates browsers. Every request gets a context that exists only
+            for that request, and the engine tears it down the moment the
+            request ends, whichever way it ends.
+          </BodyText>
+        </SectionIntro>
+      </Box>
+
+      <Flex
+        css={theme({
+          gap: 3,
+          flexDirection: 'column',
+          alignItems: 'stretch'
+        })}
+      >
+        <Card>
+          <CardSide>
+            <CardKicker>01 · allocation</CardKicker>
+            <CardTitle>One browser context per request</CardTitle>
+          </CardSide>
+          <CardMain>
+            <CardBody>
+              Each request is assigned its own browser context, keyed by its
+              request identifier. The context is created when the request starts
+              and is never handed to another request — there is no sharing model
+              to configure and no sharing model to get wrong.
+            </CardBody>
+            <ChipRow items={CONTEXT_SCOPE} />
+          </CardMain>
+        </Card>
+
+        <Card>
+          <CardSide>
+            <CardKicker>02 · state</CardKicker>
+            <CardTitle>Incognito, always</CardTitle>
+          </CardSide>
+          <CardMain>
+            <CardBody>
+              Every context is incognito. Cookies, local storage, caches, and
+              profile state live and die with the request that created them.
+              Nothing a page sets during one render is visible to any other
+              render — yours or anyone else&rsquo;s.
+            </CardBody>
+            <ChipRow items={NEVER_SHARED} />
+          </CardMain>
+        </Card>
+
+        <Card>
+          <CardSide>
+            <CardKicker>03 · teardown</CardKicker>
+            <CardTitle>Destroyed, not recycled</CardTitle>
+          </CardSide>
+          <CardMain>
+            <CardBody>
+              When the request finishes — success, timeout, or client disconnect
+              — its context is destroyed. A per-session watchdog force-closes
+              anything that outlives its deadline, so state cannot linger even
+              when a render goes sideways.
+            </CardBody>
+            <ChipRow items={TEARDOWN_TRIGGERS} />
+          </CardMain>
+        </Card>
+      </Flex>
+    </SectionInner>
+  </Section>
+)

--- a/src/components/pages/security/privacy.js
+++ b/src/components/pages/security/privacy.js
@@ -1,0 +1,49 @@
+import { SECTION_VERTICAL_SPACING, theme } from 'theme'
+import React from 'react'
+
+import { Link } from 'components/elements/Link'
+
+import { CodeInline } from 'components/markdown/CodeInline'
+
+import {
+  BodyText,
+  Section,
+  SectionInner
+} from 'components/patterns/FeatureStory'
+
+import { SectionIntro } from './shared'
+
+export const Privacy = () => (
+  <Section css={theme({ py: SECTION_VERTICAL_SPACING })}>
+    <SectionInner>
+      <SectionIntro
+        eyebrow='Secrets & privacy'
+        title='Your secrets stay secret'
+      >
+        <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
+          Credentials never reach the logs. <CodeInline>x-api-key</CodeInline>{' '}
+          and <CodeInline>authorization</CodeInline> values are redacted before
+          anything is written, and every forwarded{' '}
+          <CodeInline>x-api-header-*</CodeInline> secret is masked the same way.
+        </BodyText>
+        <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
+          Cached responses cannot cross credential boundaries either: cache keys
+          are SHA-512 hashes that incorporate the headers a request was made
+          with, so a page fetched with your session cookie is never served to a
+          request without it. Cache lifetime is under your control, from
+          1&nbsp;minute to 31&nbsp;days.
+        </BodyText>
+        <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
+          On the way out, every request carries{' '}
+          <CodeInline>sec-gpc: 1</CodeInline> and{' '}
+          <CodeInline>dnt: 1</CodeInline>, forwarding Global Privacy Control and
+          Do-Not-Track signals to the sites being rendered. For the compliance
+          side — GDPR, data processing, subprocessors — see our{' '}
+          <Link href='/security'>security practices</Link>,{' '}
+          <Link href='/dpa'>DPA</Link>, and{' '}
+          <Link href='/privacy'>privacy policy</Link>.
+        </BodyText>
+      </SectionIntro>
+    </SectionInner>
+  </Section>
+)

--- a/src/components/pages/security/sandbox.js
+++ b/src/components/pages/security/sandbox.js
@@ -1,0 +1,62 @@
+import { SECTION_VERTICAL_SPACING, theme } from 'theme'
+import React from 'react'
+
+import Box from 'components/elements/Box'
+
+import { CodeInline } from 'components/markdown/CodeInline'
+
+import ArrowLink from 'components/patterns/ArrowLink'
+import {
+  BodyText,
+  ChipRow,
+  Section,
+  SectionInner
+} from 'components/patterns/FeatureStory'
+
+import { SectionIntro } from './shared'
+
+const EXECUTION_CEILINGS = [
+  'execution timeout',
+  'memory ceiling',
+  'code size cap',
+  'cross-origin egress blocked'
+]
+
+export const Sandbox = () => (
+  <Section css={theme({ py: SECTION_VERTICAL_SPACING })}>
+    <SectionInner>
+      <SectionIntro
+        eyebrow='Untrusted code, contained'
+        title='Sandboxed execution with hard ceilings'
+      >
+        <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
+          The <CodeInline>function</CodeInline> parameter runs your JavaScript
+          against the live page — inside a VM with an execution timeout and a
+          memory ceiling. On the free plan, code size is capped and cross-origin{' '}
+          <CodeInline>fetch</CodeInline>, <CodeInline>xhr</CodeInline>, and{' '}
+          <CodeInline>websocket</CodeInline> calls are blocked, so anonymous
+          code cannot use the platform as an egress proxy.
+        </BodyText>
+        <ChipRow items={EXECUTION_CEILINGS} />
+        <BodyText>
+          The same discipline applies to every request, code or no code: hard
+          time limits and concurrency caps mean one heavy render can never
+          starve another customer&rsquo;s traffic, and anonymous traffic is
+          rate-limited per client IP.
+        </BodyText>
+        <Box css={theme({ pt: [3, 3, 4, 4] })}>
+          <ArrowLink
+            href='/features/function'
+            css={theme({
+              color: 'link',
+              fontWeight: 'bold',
+              fontSize: [1, 1, 2, 2]
+            })}
+          >
+            See how browser functions work
+          </ArrowLink>
+        </Box>
+      </SectionIntro>
+    </SectionInner>
+  </Section>
+)

--- a/src/components/pages/security/shared.js
+++ b/src/components/pages/security/shared.js
@@ -1,0 +1,15 @@
+import { layout, theme } from 'theme'
+import React from 'react'
+
+import Box from 'components/elements/Box'
+import Subhead from 'components/elements/Subhead'
+
+import { Eyebrow } from 'components/patterns/FeatureStory'
+
+export const SectionIntro = ({ eyebrow, title, children }) => (
+  <Box css={theme({ maxWidth: layout.large })}>
+    <Eyebrow css={theme({ pb: 2, display: 'block' })}>{eyebrow}</Eyebrow>
+    <Subhead css={theme({ textAlign: 'left' })}>{title}</Subhead>
+    {children}
+  </Box>
+)

--- a/src/components/pages/security/ssrf.js
+++ b/src/components/pages/security/ssrf.js
@@ -1,0 +1,96 @@
+import { SECTION_VERTICAL_SPACING, theme } from 'theme'
+import React from 'react'
+
+import Flex from 'components/elements/Flex'
+import Box from 'components/elements/Box'
+
+import { CodeInline } from 'components/markdown/CodeInline'
+
+import {
+  BodyText,
+  Card,
+  CardBody,
+  CardKicker,
+  CardMain,
+  CardSide,
+  CardTitle,
+  ChipRow,
+  Section,
+  SectionInner
+} from 'components/patterns/FeatureStory'
+
+import { SectionIntro } from './shared'
+
+const BLOCKED_RANGES = [
+  '127.0.0.1',
+  '10.0.0.0/8',
+  '172.16.0.0/12',
+  '192.168.0.0/16',
+  '169.254.169.254'
+]
+
+const RENDER_CHECKS = ['redirects', 'subresources', 'in-page navigations']
+
+export const Ssrf = () => (
+  <Section css={theme({ py: SECTION_VERTICAL_SPACING })}>
+    <SectionInner>
+      <Box css={theme({ pb: [4, 4, 5, 5] })}>
+        <SectionIntro
+          eyebrow='Server-side request forgery'
+          title='SSRF protection at two layers'
+        >
+          <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
+            Checking the input URL once is not enough — a page can redirect or
+            load resources into places its URL never mentioned. Microlink
+            validates the destination before the fetch and keeps validating
+            while the page renders.
+          </BodyText>
+        </SectionIntro>
+      </Box>
+
+      <Flex
+        css={theme({
+          gap: 3,
+          flexDirection: 'column',
+          alignItems: 'stretch'
+        })}
+      >
+        <Card>
+          <CardSide>
+            <CardKicker>01 · before the fetch</CardKicker>
+            <CardTitle>Resolved before it&rsquo;s fetched</CardTitle>
+          </CardSide>
+          <CardMain>
+            <CardBody>
+              The hostname is resolved via DNS and its IP address is checked
+              against reserved ranges. Anything that does not resolve to a
+              public unicast address — loopback, private networks, link-local,
+              cloud metadata endpoints — is refused with{' '}
+              <CodeInline>EFORBIDDENURL</CodeInline> before a single byte is
+              fetched. HTTP redirects are re-checked hop by hop, so a URL cannot
+              302 its way into an internal address.
+            </CardBody>
+            <ChipRow items={BLOCKED_RANGES} />
+          </CardMain>
+        </Card>
+
+        <Card>
+          <CardSide>
+            <CardKicker>02 · during rendering</CardKicker>
+            <CardTitle>Enforced while it renders</CardTitle>
+          </CardSide>
+          <CardMain>
+            <CardBody>
+              A Chromium request interceptor validates every origin the page
+              touches while it renders. If the page navigates or is redirected
+              into a reserved range mid-render, the request is aborted on the
+              spot — the same guarantee holds for what the page does, not just
+              for the URL you sent.
+            </CardBody>
+            <ChipRow items={RENDER_CHECKS} />
+          </CardMain>
+        </Card>
+      </Flex>
+    </SectionInner>
+  </Section>
+)

--- a/src/components/pages/security/why.js
+++ b/src/components/pages/security/why.js
@@ -1,0 +1,75 @@
+import { SECTION_VERTICAL_SPACING, theme } from 'theme'
+import React from 'react'
+
+import Box from 'components/elements/Box'
+
+import {
+  BodyText,
+  ChipRow,
+  Node,
+  NodeActive,
+  NodeLabel,
+  NodeSub,
+  ScenarioHeader,
+  ScenarioRow,
+  Section,
+  SectionInner
+} from 'components/patterns/FeatureStory'
+
+import { SectionIntro } from './shared'
+
+const ATTACK_SURFACES = [
+  'other tenants',
+  'internal networks',
+  'cloud metadata',
+  'leftover state'
+]
+
+export const Why = () => (
+  <Section css={theme({ py: SECTION_VERTICAL_SPACING })}>
+    <SectionInner>
+      <SectionIntro
+        eyebrow='URLs are untrusted input'
+        title='A cloud browser is a security boundary'
+      >
+        <BodyText css={theme({ pt: [3, 3, 4, 4] })}>
+          When you send a URL to a browser API, that page runs real JavaScript
+          inside a real Chromium on someone else&rsquo;s infrastructure. It can
+          redirect, load subresources, open WebSockets — everything any web page
+          can do. Which makes every request a set of questions worth asking
+          about what that page can reach:
+        </BodyText>
+        <ChipRow items={ATTACK_SURFACES} />
+        <BodyText>
+          Microlink&rsquo;s answer is structural: the blast radius of a request
+          is the request itself. Isolation and network screening are enforced
+          inside the rendering engine on every request — not by policy, not by
+          plan tier.
+        </BodyText>
+      </SectionIntro>
+
+      <Box css={theme({ pt: [4, 4, 5, 5] })}>
+        <ScenarioHeader
+          title='Every request, contained'
+          status='isolation · every request'
+        />
+        <ScenarioRow>
+          <Node>
+            <NodeLabel>Other requests</NodeLabel>
+            <NodeSub>separate browser contexts — nothing shared</NodeSub>
+          </Node>
+          <Node>
+            <NodeLabel>Private networks</NodeLabel>
+            <NodeSub>reserved IP ranges blocked at fetch and render</NodeSub>
+          </Node>
+          <NodeActive>
+            <NodeLabel css={theme({ color: 'secondary' })}>
+              Your request
+            </NodeLabel>
+            <NodeSub>its own incognito browser, destroyed at the end</NodeSub>
+          </NodeActive>
+        </ScenarioRow>
+      </Box>
+    </SectionInner>
+  </Section>
+)

--- a/src/components/patterns/FeatureStory/features.js
+++ b/src/components/patterns/FeatureStory/features.js
@@ -87,5 +87,16 @@ export const FEATURES = [
     oneLiner:
       'Forward cookies, tokens, and any header to the target page — secrets never touch the URL.',
     snippet: "headers: { 'x-api-header-cookie': 'session=…' }"
+  },
+  {
+    slug: 'security',
+    name: 'Request Security',
+    footerLabel: 'Security',
+    tag: 'Free + Pro',
+    category: 'Trust & isolation',
+    param: 'url',
+    oneLiner:
+      'Every request runs in its own browser — isolated, SSRF-protected, with no shared cookies or cache.',
+    snippet: "url: 'http://169.254.169.254' → EFORBIDDENURL"
   }
 ]

--- a/src/pages/features/security.js
+++ b/src/pages/features/security.js
@@ -1,0 +1,59 @@
+import { theme } from 'theme'
+import React from 'react'
+
+import Box from 'components/elements/Box'
+import Meta from 'components/elements/Meta/Meta'
+
+import { DashedGridOverlay } from 'components/patterns/FeatureStory'
+import Layout from 'components/patterns/Layout'
+
+import { Cta } from 'components/pages/security/cta'
+import { Enterprise } from 'components/pages/security/enterprise'
+import { FAQ_ITEMS, FaqSection } from 'components/pages/security/faq'
+import { Hero } from 'components/pages/security/hero'
+import { Isolation } from 'components/pages/security/isolation'
+import { Privacy } from 'components/pages/security/privacy'
+import { Sandbox } from 'components/pages/security/sandbox'
+import { Ssrf } from 'components/pages/security/ssrf'
+import { Why } from 'components/pages/security/why'
+
+const SecurityFeaturePage = () => (
+  <Layout css={theme({ position: 'relative' })}>
+    <DashedGridOverlay aria-hidden='true' />
+    <Box css={theme({ position: 'relative', zIndex: 1 })}>
+      <Hero />
+      <Why />
+      <Isolation />
+      <Ssrf />
+      <Sandbox />
+      <Privacy />
+      <Enterprise />
+      <Cta />
+      <FaqSection />
+    </Box>
+  </Layout>
+)
+
+export const Head = () => (
+  <Meta
+    title='Request Security: One Isolated Browser per Request'
+    description='Every Microlink API request runs in its own incognito browser context — no shared cookies, caches, or profiles — with dual-layer SSRF protection that blocks private and reserved IP ranges before and during rendering. Enterprise adds dedicated hardware.'
+    schemaType='WebPage'
+    structured={[
+      {
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        mainEntity: FAQ_ITEMS.map(({ question, text }) => ({
+          '@type': 'Question',
+          name: question,
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text
+          }
+        }))
+      }
+    ]}
+  />
+)
+
+export default SecurityFeaturePage


### PR DESCRIPTION
## Summary
- Add `/features/security` marketing page (antibot-style thin page + one-file-per-section) covering request isolation, SSRF protection, function sandboxing, privacy/cache safety, and Enterprise dedicated infra
- Register `security` in the shared `FEATURES` list so it appears in the `/features` grid, carousel, and footer
- Link out to `/security`, `/dpa`, `/privacy`, and `/enterprise` for compliance and dedicated-hardware details (legal `/security` page left unchanged)

## Test plan
- [ ] Open `/features/security` on desktop and mobile — hero, isolation, SSRF, sandbox, privacy, enterprise, CTA, and FAQ all render
- [ ] Confirm `/features` grid shows the new Request Security card and footer Features column includes Security
- [ ] Spot-check FAQ JSON-LD in page source (`FAQPage`)
- [ ] Click through to `/enterprise`, `/security`, `/dpa`, `/privacy`, `/features/function`
- [ ] `npm test` / typography-overrides still pass


Made with [Cursor](https://cursor.com)