### PR TITLE
feat(security): RFC 9116 security.txt and disclosure policy

### DIFF
--- a/src/content/security.md
+++ b/src/content/security.md
@@ -72,16 +72,49 @@ For more information about our data processing practices, please see our [Data P
 
 For security-related questions or to report a vulnerability:
 
-**Email**: [hello@microlink.io](mailto:hello@microlink.io)  
+**Email**: [hello@microlink.io](mailto:hello@microlink.io?subject=Security%20Inquiry)  
 **Subject**: Security Inquiry
 
-### Responsible Disclosure
+## Responsible Disclosure
 
-If you discover a security vulnerability:
+We consider the security of our systems a top priority, but no matter how much effort we put into it, vulnerabilities can still be present. If you discover one, we want to know so we can address it as quickly as possible.
 
-1. Report it to [hello@microlink.io](mailto:hello@microlink.io).
-2. Allow reasonable time for investigation and resolution.
-3. Do not publicly disclose until resolved.
-4. Do not access or modify data that doesn't belong to you.
+**What we ask**
 
-We are committed to working with security researchers to address vulnerabilities quickly and responsibly.
+- Provide enough detail to reproduce the problem. The IP address or URL of the affected system and a description of the vulnerability is usually sufficient, though complex vulnerabilities may need more.
+- Do not run automated scanners against our infrastructure or dashboard. Contact us first and we will set up a sandbox for you.
+- Do not take advantage of the problem, for example by downloading more data than needed to demonstrate it, or by deleting or modifying data that belongs to someone else.
+- Do not reveal the problem to others until it has been resolved.
+- Do not use physical attacks, social engineering, distributed denial of service, spam, or third-party applications.
+
+**What we promise**
+
+- We respond within 3 business days with our evaluation of the report and an expected resolution date.
+- We take no legal action against you in regard to the report, provided you followed the above.
+- We handle your report confidentially, and do not pass your personal details to third parties without your permission.
+- We keep you informed of progress toward resolving the problem.
+- We credit you as the discoverer in any public information about the problem, unless you prefer otherwise.
+
+We resolve problems as quickly as we can, and we would like to play an active role in the eventual publication.
+
+**Out of scope**
+
+- Clickjacking on pages with no sensitive actions.
+- Unauthenticated, logout or login CSRF.
+- Attacks requiring MITM or physical access to a user's device.
+- Any activity that could lead to disruption of our service (DoS).
+- Content spoofing and text injection without a demonstrated attack vector or the ability to modify HTML/CSS.
+- Email spoofing.
+- Missing DNSSEC, CAA or CSP.
+- Lack of Secure or HttpOnly flag on non-sensitive cookies.
+- Dead links.
+- User enumeration.
+
+This policy is also published as [security.txt](/.well-known/security.txt), following [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116).
+
+## Acknowledgments
+
+Our thanks to the researchers who have reported vulnerabilities to us:
+
+- [Daniel Wang](https://danielwang.dev)
+- Haaris B

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,5 +1,5 @@
 Contact: mailto:hello@microlink.io?subject=Security%20Inquiry
-Expires: 2027-07-28T00:00:00.000Z
+Expires: 2027-07-28T00:00:00Z
 Canonical: https://microlink.io/.well-known/security.txt
 Preferred-Languages: en
 
@@ -19,15 +19,15 @@ Preferred-Languages: en
 # - Any activity that could lead to the disruption of our service (DoS).
 # - Content spoofing and text injection issues without showing an attack
 #   vector/without being able to modify HTML/CSS.
-# - Email spoofing
-# - Missing DNSSEC, CAA, CSP headers
-# - Lack of Secure or HTTP only flag on non-sensitive cookies
-# - Deadlinks
-# - User enumeration
+# - Email spoofing.
+# - Missing DNSSEC, CAA or CSP.
+# - Lack of Secure or HttpOnly flag on non-sensitive cookies.
+# - Dead links.
+# - User enumeration.
 #
 # Please do the following:
 #
-# - E-mail your findings to hello@microlink.io with the subject "Security Inquiry".
+# - E-mail your findings to hello@microlink.io.
 # - Do not run automated scanners on our infrastructure or dashboard. If you
 #   wish to do this, contact us and we will set up a sandbox for you.
 # - Do not take advantage of the vulnerability or problem you have discovered,
@@ -60,4 +60,4 @@ Preferred-Languages: en
 # Special Thanks
 #
 # - Daniel Wang (https://danielwang.dev)
-# - Haaris B (haaris.blacktech@gmail.com)
+# - Haaris B

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,43 +1,63 @@
-Contact: hello@microlink.io
+Contact: mailto:hello@microlink.io?subject=Security%20Inquiry
+Expires: 2027-07-28T00:00:00.000Z
 Canonical: https://microlink.io/.well-known/security.txt
+Preferred-Languages: en
 
-At Microlink, we consider the security of our systems a top priority. But no matter how much effort we put into system security, there can still be vulnerabilities present.
-
-If you discover a vulnerability, we would like to know about it so we can take steps to address it as quickly as possible. We would like to ask you to help us better protect our clients and our systems.
-
-Out of scope vulnerabilities:
-
-- Clickjacking on pages with no sensitive actions.
-- Unauthenticated/logout/login CSRF.
-- Attacks requiring MITM or physical access to a user's device.
-- Any activity that could lead to the disruption of our service (DoS).
-- Content spoofing and text injection issues without showing an attack vector/without being able to modify HTML/CSS.
-- Email spoofing
-- Missing DNSSEC, CAA, CSP headers
-- Lack of Secure or HTTP only flag on non-sensitive cookies
-- Deadlinks
-- User enumeration
-
-Please do the following:
-
-- E-mail your findings to hello@microlink.io.
-- Do not run automated scanners on our infrastructure or dashboard. If you wish to do this, contact us and we will set up a sandbox for you.
-- Do not take advantage of the vulnerability or problem you have discovered, for example by downloading more data than necessary to demonstrate the vulnerability or deleting or modifying other people's data,
-- Do not reveal the problem to others until it has been resolved,
-- Do not use attacks on physical security, social engineering, distributed denial of service, spam or applications of third parties, and
-- Do provide sufficient information to reproduce the problem, so we will be able to resolve it as quickly as possible. Usually, the IP address or the URL of the affected system and a description of the vulnerability will be sufficient, but complex vulnerabilities may require further explanation.
-
-What we promise:
-
-- We will respond to your report within 3 business days with our evaluation of the report and an expected resolution date,
-- If you have followed the instructions above, we will not take any legal action against you in regard to the report,
-- We will handle your report with strict confidentiality, and not pass on your personal details to third parties without your permission,
-- We will keep you informed of the progress towards resolving the problem,
-- In the public information concerning the problem reported, we will give your name as the discoverer of the problem (unless you desire otherwise), and
-
-We strive to resolve all problems as quickly as possible, and we would like to play an active role in the ultimate publication on the problem after it is resolved.
-
-Special Thanks
-
-- Daniel Wang (https://danielwang.dev)
-- Haaris B (haaris.blacktech@gmail.com)
+# At Microlink, we consider the security of our systems a top priority. But no
+# matter how much effort we put into system security, there can still be
+# vulnerabilities present.
+#
+# If you discover a vulnerability, we would like to know about it so we can take
+# steps to address it as quickly as possible. We would like to ask you to help
+# us better protect our clients and our systems.
+#
+# Out of scope vulnerabilities:
+#
+# - Clickjacking on pages with no sensitive actions.
+# - Unauthenticated/logout/login CSRF.
+# - Attacks requiring MITM or physical access to a user's device.
+# - Any activity that could lead to the disruption of our service (DoS).
+# - Content spoofing and text injection issues without showing an attack
+#   vector/without being able to modify HTML/CSS.
+# - Email spoofing
+# - Missing DNSSEC, CAA, CSP headers
+# - Lack of Secure or HTTP only flag on non-sensitive cookies
+# - Deadlinks
+# - User enumeration
+#
+# Please do the following:
+#
+# - E-mail your findings to hello@microlink.io with the subject "Security Inquiry".
+# - Do not run automated scanners on our infrastructure or dashboard. If you
+#   wish to do this, contact us and we will set up a sandbox for you.
+# - Do not take advantage of the vulnerability or problem you have discovered,
+#   for example by downloading more data than necessary to demonstrate the
+#   vulnerability or deleting or modifying other people's data.
+# - Do not reveal the problem to others until it has been resolved.
+# - Do not use attacks on physical security, social engineering, distributed
+#   denial of service, spam or applications of third parties.
+# - Do provide sufficient information to reproduce the problem, so we will be
+#   able to resolve it as quickly as possible. Usually, the IP address or the
+#   URL of the affected system and a description of the vulnerability will be
+#   sufficient, but complex vulnerabilities may require further explanation.
+#
+# What we promise:
+#
+# - We will respond to your report within 3 business days with our evaluation of
+#   the report and an expected resolution date.
+# - If you have followed the instructions above, we will not take any legal
+#   action against you in regard to the report.
+# - We will handle your report with strict confidentiality, and not pass on your
+#   personal details to third parties without your permission.
+# - We will keep you informed of the progress towards resolving the problem.
+# - In the public information concerning the problem reported, we will give your
+#   name as the discoverer of the problem (unless you desire otherwise).
+#
+# We strive to resolve all problems as quickly as possible, and we would like to
+# play an active role in the ultimate publication on the problem after it is
+# resolved.
+#
+# Special Thanks
+#
+# - Daniel Wang (https://danielwang.dev)
+# - Haaris B (haaris.blacktech@gmail.com)

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,63 +1,13 @@
 Contact: mailto:hello@microlink.io?subject=Security%20Inquiry
 Expires: 2027-07-28T00:00:00Z
 Canonical: https://microlink.io/.well-known/security.txt
+Policy: https://microlink.io/security#responsible-disclosure
+Acknowledgments: https://microlink.io/security#acknowledgments
 Preferred-Languages: en
 
-# At Microlink, we consider the security of our systems a top priority. But no
-# matter how much effort we put into system security, there can still be
-# vulnerabilities present.
+# We consider the security of our systems a top priority, but no matter how much
+# effort we put into it, vulnerabilities can still be present. If you discover
+# one, we want to know so we can address it as quickly as possible.
 #
-# If you discover a vulnerability, we would like to know about it so we can take
-# steps to address it as quickly as possible. We would like to ask you to help
-# us better protect our clients and our systems.
-#
-# Out of scope vulnerabilities:
-#
-# - Clickjacking on pages with no sensitive actions.
-# - Unauthenticated/logout/login CSRF.
-# - Attacks requiring MITM or physical access to a user's device.
-# - Any activity that could lead to the disruption of our service (DoS).
-# - Content spoofing and text injection issues without showing an attack
-#   vector/without being able to modify HTML/CSS.
-# - Email spoofing.
-# - Missing DNSSEC, CAA or CSP.
-# - Lack of Secure or HttpOnly flag on non-sensitive cookies.
-# - Dead links.
-# - User enumeration.
-#
-# Please do the following:
-#
-# - E-mail your findings to hello@microlink.io.
-# - Do not run automated scanners on our infrastructure or dashboard. If you
-#   wish to do this, contact us and we will set up a sandbox for you.
-# - Do not take advantage of the vulnerability or problem you have discovered,
-#   for example by downloading more data than necessary to demonstrate the
-#   vulnerability or deleting or modifying other people's data.
-# - Do not reveal the problem to others until it has been resolved.
-# - Do not use attacks on physical security, social engineering, distributed
-#   denial of service, spam or applications of third parties.
-# - Do provide sufficient information to reproduce the problem, so we will be
-#   able to resolve it as quickly as possible. Usually, the IP address or the
-#   URL of the affected system and a description of the vulnerability will be
-#   sufficient, but complex vulnerabilities may require further explanation.
-#
-# What we promise:
-#
-# - We will respond to your report within 3 business days with our evaluation of
-#   the report and an expected resolution date.
-# - If you have followed the instructions above, we will not take any legal
-#   action against you in regard to the report.
-# - We will handle your report with strict confidentiality, and not pass on your
-#   personal details to third parties without your permission.
-# - We will keep you informed of the progress towards resolving the problem.
-# - In the public information concerning the problem reported, we will give your
-#   name as the discoverer of the problem (unless you desire otherwise).
-#
-# We strive to resolve all problems as quickly as possible, and we would like to
-# play an active role in the ultimate publication on the problem after it is
-# resolved.
-#
-# Special Thanks
-#
-# - Daniel Wang (https://danielwang.dev)
-# - Haaris B
+# What we ask of you, what we promise in return, and what falls out of scope is
+# published in full at the Policy URL above.

--- a/test/security-txt.js
+++ b/test/security-txt.js
@@ -1,8 +1,11 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import GithubSlugger from 'github-slugger'
 import { describe, expect, test } from 'vitest'
 
 const FILE = path.join(process.cwd(), 'static/.well-known/security.txt')
+const POLICY_PAGE = path.join(process.cwd(), 'src/content/security.md')
+const POLICY_URL = /^https:\/\/microlink\.io\/security#(.+)$/
 
 const DAY = 24 * 60 * 60 * 1000
 const RENEWAL_LEAD_TIME = 30 * DAY
@@ -22,6 +25,14 @@ const valuesOf = name =>
 
 const expiresAt = () => Date.parse(valuesOf('Expires')[0])
 
+const headingAnchors = source => {
+  const slugger = new GithubSlugger()
+  return source
+    .split('\n')
+    .filter(line => /^#{1,6}\s/.test(line))
+    .map(line => slugger.slug(line.replace(/^#+\s*/, '').trim()))
+}
+
 describe('security.txt', () => {
   test('declares the fields RFC 9116 requires', () => {
     expect(valuesOf('Contact').length).toBeGreaterThan(0)
@@ -35,5 +46,21 @@ describe('security.txt', () => {
 
   test('expiry stays under the one year the RFC recommends', () => {
     expect(expiresAt()).toBeLessThan(Date.now() + MAX_LIFESPAN)
+  })
+
+  test('publishes a machine-readable policy and acknowledgments', () => {
+    expect(valuesOf('Policy').length).toBeGreaterThan(0)
+    expect(valuesOf('Acknowledgments').length).toBeGreaterThan(0)
+  })
+
+  test('every anchor it links to exists on the security page', () => {
+    const anchors = headingAnchors(fs.readFileSync(POLICY_PAGE, 'utf8'))
+    const linked = fields
+      .map(field => field.value.match(POLICY_URL))
+      .filter(Boolean)
+      .map(([, anchor]) => anchor)
+
+    expect(linked.length).toBeGreaterThan(0)
+    for (const anchor of linked) expect(anchors).toContain(anchor)
   })
 })

--- a/test/security-txt.js
+++ b/test/security-txt.js
@@ -1,0 +1,39 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+const FILE = path.join(process.cwd(), 'static/.well-known/security.txt')
+
+const DAY = 24 * 60 * 60 * 1000
+const RENEWAL_LEAD_TIME = 30 * DAY
+const MAX_LIFESPAN = 365 * DAY
+
+const fields = fs
+  .readFileSync(FILE, 'utf8')
+  .split('\n')
+  .reduce((acc, line) => {
+    const match = line.match(/^([A-Za-z-]+):\s*(.+?)\s*$/)
+    if (match) acc.push({ name: match[1], value: match[2] })
+    return acc
+  }, [])
+
+const valuesOf = name =>
+  fields.filter(field => field.name === name).map(field => field.value)
+
+const expiresAt = () => Date.parse(valuesOf('Expires')[0])
+
+describe('security.txt', () => {
+  test('declares the fields RFC 9116 requires', () => {
+    expect(valuesOf('Contact').length).toBeGreaterThan(0)
+    expect(valuesOf('Expires')).toHaveLength(1)
+    expect(expiresAt()).not.toBeNaN()
+  })
+
+  test('expiry leaves time to renew before it lapses', () => {
+    expect(expiresAt()).toBeGreaterThan(Date.now() + RENEWAL_LEAD_TIME)
+  })
+
+  test('expiry stays under the one year the RFC recommends', () => {
+    expect(expiresAt()).toBeLessThan(Date.now() + MAX_LIFESPAN)
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -323,6 +323,10 @@
       "destination": "/integrations/sdk"
     },
     {
+      "source": "/security.txt",
+      "destination": "/.well-known/security.txt"
+    },
+    {
       "source": "/timeout",
       "destination": "/docs/api/parameters/timeout"
     },


### PR DESCRIPTION
Makes `security.txt` conformant, reachable at the legacy path, and backed by a disclosure policy a researcher can cite.

### The problem

The old file was not merely unstructured, it was **invalid**. Bare prose lines are parse errors under RFC 9116, and `Expires` (mandatory since the RFC shipped) was absent, so a strict consumer could discard the whole file and never reach the contact address.

The terms had also drifted apart. `/security` carried a four-bullet disclosure section with no safe harbor, no SLA and no scope list, while `security.txt` had all three buried in comments that every conforming parser ignores. A researcher checking whether we would sue them got a different answer depending on which one they found.

### Changes

- **`vercel.json`** — `/security.txt` now 308s to `/.well-known/security.txt`. It was returning a 404.
- **`static/.well-known/security.txt`** — 63 lines down to 13. Now a field block: `Contact`, `Expires`, `Canonical`, `Policy`, `Acknowledgments`, `Preferred-Languages`. The file is the index; the page is the text.
- **`src/content/security.md`** — `## Responsible Disclosure` now holds what we ask, what we promise (safe harbor and the 3-business-day SLA included), and what is out of scope. Promoted from `###` so it keeps the `#responsible-disclosure` slug and no existing link breaks. Credits move to a new `## Acknowledgments`.
- **`test/security-txt.js`** — new, 5 tests.

Also removed a researcher's personal Gmail from the credits. It was being published to every scraper that reads this file. The name credit stays.

Two accuracy fixes in the out-of-scope list, which matters in a document that defines scope for researchers: DNSSEC and CAA are DNS records rather than headers, and the cookie attribute is `HttpOnly`.

### Why the test

`Expires` is a dead man's switch. Once the date passes, the RFC says consumers **MUST NOT** use the file, so it silently takes itself out of service on a date nothing in the repo was watching. The suite fails 30 days before expiry, and separately rejects pushing the date past a year, which closes the obvious escape hatch of silencing the first test by setting 2099. The only way back to green is a real renewal.

It also asserts every `microlink.io/security#…` anchor in the file resolves to a real heading, using `github-slugger`, the same library `src/plugins/rehype-slug-trim.js` uses at build time.

### Verification

Mutation-tested every guard rather than trusting it green:

| Mutation | Result |
| --- | --- |
| `Expires` near expiry | 1 failed |
| `Expires` pushed to 2099 | 1 failed |
| `Expires` malformed | 3 failed |
| `## Acknowledgments` renamed | 1 failed |
| `## Responsible Disclosure` renamed | 1 failed |
| unmutated | 5 passed |

Full suite green: 43 files, 278 tests. `standard` clean.

Confirmed live that `/.well-known/security.txt` already serves `200 text/plain; charset=utf-8`, so no `headers` entry is needed, and that `/security.txt` currently 404s, so the redirect fixes a real gap.

### Known limits

`headingAnchors` regex-scans `#` lines, so a `#` inside a fenced code block would register as a phantom anchor. `security.md` has no code fences today, and the failure direction is a false pass rather than a false alarm. The test reads markdown source, not rendered HTML, so it proves the heading exists, not that the page built.

### Before merging

Worth confirming `hello@microlink.io` actually reaches someone. Three published artifacts now promise a 3-business-day response to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uidm72PXMdtqNgJ6v4Fh7v

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, static assets, and redirects only; no application auth or data-path changes.
> 
> **Overview**
> Brings **responsible disclosure** onto one canonical page and makes **`security.txt`** a small RFC 9116 field block that points there, instead of duplicating policy in comments parsers ignore.
> 
> **`static/.well-known/security.txt`** is trimmed to structured fields (`Contact` with prefilled subject, mandatory **`Expires`**, `Policy`, `Acknowledgments`, etc.); long prose moves to **`/security`**. **`src/content/security.md`** expands **Responsible Disclosure** (researcher rules, safe harbor, 3-business-day response, out-of-scope list with wording fixes) and adds **Acknowledgments** (personal email removed from credits). **`vercel.json`** redirects **`/security.txt`** to **`/.well-known/security.txt`**.
> 
> **`test/security-txt.js`** guards `Expires` renewal window, RFC-ish field presence, and that `Policy` / `Acknowledgments` URLs match real heading slugs on the security page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d547a89524924c916845ae140831d660bea19778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the security contact and responsible disclosure policy.
  * Added guidance covering reporting expectations, commitments, and out-of-scope issues.
  * Added security researcher acknowledgments and RFC 9116 publication details.

* **New Features**
  * Added a redirect from `/security.txt` to the standard well-known security policy location.
  * Improved machine-readable security policy metadata and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->