### PR TITLE
chore: update changelog

### DIFF
--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -230,7 +230,7 @@
   "src/content/fragments/changelog.md": "2026-07-06T00:00:00.000Z",
   "src/content/fragments/enterprise.md": "2026-07-28T00:00:00.000Z",
   "src/content/privacy.md": "2026-01-13T00:00:00.000Z",
-  "src/content/security.md": "2026-01-10T00:00:00.000Z",
+  "src/content/security.md": "2026-07-28T00:00:00.000Z",
   "src/content/styleguide.md": "2026-01-10T00:00:00.000Z",
   "src/content/subprocessors.md": "2026-07-11T00:00:00.000Z",
   "src/content/tos.md": "2026-01-10T00:00:00.000Z",

--- a/src/content/fragments/changelog.md
+++ b/src/content/fragments/changelog.md
@@ -1,3 +1,20 @@
+### July 2026
+
+- [Microlink](/): Redesigned [features](/features) with a unified showcase across all capability pages.
+- [Microlink](/): Published RFC 9116 [security.txt](/security.txt) and expanded the [security](/security) disclosure policy.
+- [Browserless v13.6](https://browserless.js.org): Fixed screenshots failing when `quality` is set without jpeg/webp.
+- [Microlink API](/docs/api/getting-started/overview): Improved [pdf](/docs/api/parameters/pdf) for SPA pages, tall documents, and [pageRanges](/docs/api/parameters/pdf/pageRanges).
+- [Microlink](/): Added [antibot](/features/antibot) and [security](/features/security) feature landings.
+- [Microlink API](/docs/api/getting-started/overview): Added [EPDFTOOLARGE](/docs/api/basics/error-codes#epdftoolarge) when a document is too large to render as PDF.
+- [Microlink](/): Redesigned [skills](/skills) page.
+- [Microlink](/): Added [Handinger](/use-cases/handinger) customer story.
+- [unavatar.io](https://unavatar.io): Improved DuckDuckGo favicon resolution for www/apex host variants.
+- [Microlink](/): New homepage hero with an interactive natural-language API console.
+- [Microlink](/): Added [Chrome extensions](/extensions) landings for website screenshot and PDF.
+- [Browserless v13.6](https://browserless.js.org): Improved cookie consent dismissal across multilingual CMPs.
+- [Microlink](/): Updated [MCP](/integrations/mcp) integrations page to the full 20-tool surface.
+- [Microlink API](/docs/api/getting-started/overview): Improved YouTube caption and [transcript](/docs/guides/content-conversion/url-to-markdown) resolution.
+
 ### June 2026
 
 - [Microlink](/): Added [builder](/integrations/builder) to generate link preview component code.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Content-only changelog and metadata timestamp updates with no application logic changes.
> 
> **Overview**
> Adds a **July 2026** section to the public changelog fragment (`changelog.md`) that ships on `/changelog`.
> 
> The new entries cover Microlink marketing and product work (features redesign, homepage hero, antibot/security landings, skills page, Chrome extension landings, Handinger use case, MCP page), API changes (PDF/SPA improvements, `EPDFTOOLARGE`, YouTube transcript), security (`security.txt` and policy), plus Browserless v13.6 fixes and a small unavatar.io favicon tweak.
> 
> Also bumps the `git-timestamps-modified.json` last-modified date for `src/content/security.md` to align with the security disclosure changelog line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdcbde0862b6de9fe682d2115be1818522ea7ced. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->