### PR TITLE
feat(home): add viewport bottom gradual blur

### DIFF
--- a/src/components/pages/home/gradual-blur.js
+++ b/src/components/pages/home/gradual-blur.js
@@ -1,0 +1,70 @@
+import { theme } from 'theme'
+import React from 'react'
+import styled from 'styled-components'
+
+const LAYERS = [
+  {
+    blur: '0.218rem',
+    mask: 'transparent 0%, black 20%, black 40%, transparent 60%'
+  },
+  {
+    blur: '0.379rem',
+    mask: 'transparent 20%, black 40%, black 60%, transparent 80%'
+  },
+  {
+    blur: '0.66rem',
+    mask: 'transparent 40%, black 60%, black 80%, transparent 100%'
+  },
+  {
+    blur: '1.149rem',
+    mask: 'transparent 60%, black 80%, black 100%'
+  },
+  {
+    blur: '2rem',
+    mask: 'transparent 80%, black 100%'
+  }
+]
+
+const Root = styled.div.attrs({
+  'aria-hidden': true,
+  className: 'hidden-print'
+})`
+  pointer-events: none;
+
+  ${theme({
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    width: '100%',
+    height: ['80px', '80px', '140px', '140px'],
+    zIndex: 10
+  })};
+`
+
+const Inner = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`
+
+const Layer = styled.div`
+  position: absolute;
+  inset: 0;
+  backdrop-filter: blur(${props => props.$blur});
+  -webkit-backdrop-filter: blur(${props => props.$blur});
+  mask-image: linear-gradient(to bottom, ${props => props.$mask});
+  -webkit-mask-image: linear-gradient(to bottom, ${props => props.$mask});
+`
+
+const GradualBlur = () => (
+  <Root>
+    <Inner>
+      {LAYERS.map(({ blur, mask }) => (
+        <Layer key={blur} $blur={blur} $mask={mask} />
+      ))}
+    </Inner>
+  </Root>
+)
+
+export default GradualBlur

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
 import Analytics from 'components/pages/home/analytics'
 import Examples from 'components/pages/home/examples'
 import Faqs, { getFaqQuestions } from 'components/pages/home/faqs'
+import GradualBlur from 'components/pages/home/gradual-blur'
 import Hero from 'components/pages/home/hero'
 import OpenSource from 'components/pages/home/open-source'
 import Products from 'components/pages/home/products'
@@ -74,6 +75,7 @@ const HomePage = () => {
         <Production />
         <OpenSource />
         <Faqs />
+        <GradualBlur />
       </Layout>
     </CurrencyProvider>
   )


### PR DESCRIPTION
## Summary
- Add a fixed bottom gradual-blur overlay on the homepage (stacked `backdrop-filter` layers with progressive masks)
- Matches the tuyo.com fold-edge softener: content blurs as it exits the viewport, without blocking clicks

## Test plan
- [ ] Open `/` and confirm a soft blur band at the bottom of the viewport
- [ ] Scroll through hero → products and confirm content softens under the band
- [ ] Click through chips/CTAs near the bottom edge (overlay is `pointer-events: none`)
- [ ] Check mobile (~80px band) and desktop (~140px band)
- [ ] Confirm print styles hide the overlay (`hidden-print`)


Made with [Cursor](https://cursor.com)