### PR TITLE
refactor(pricing): split Plans into per-card components

### DIFF
--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -557,7 +557,7 @@
   "src/pages/payment/success.js": "2019-08-29T00:00:00.000Z",
   "src/pages/payment/update.js": "2026-07-11T00:00:00.000Z",
   "src/pages/pdf.js": "2026-07-22T00:00:00.000Z",
-  "src/pages/pricing.js": "2026-07-22T00:00:00.000Z",
+  "src/pages/pricing.js": "2026-08-01T00:00:00.000Z",
   "src/pages/privacy.js": "2018-10-08T00:00:00.000Z",
   "src/pages/privacy.md": "2025-07-01T00:00:00.000Z",
   "src/pages/recipes.js": "2026-07-11T00:00:00.000Z",

--- a/src/components/elements/PricePicker.js
+++ b/src/components/elements/PricePicker.js
@@ -184,8 +184,6 @@ const PricePicker = ({ onChange }) => {
         >
           {plan.reqsPerMonth}
         </Text>{' '}
-        {/* The gap is `pl`, so without this the text reads "46,000requests".
-            Flex drops whitespace-only children, so it costs no layout. */}
         <Text
           as='span'
           css={theme({ fontSize: [0, 0, 1, 1], color: 'black70', pl: 1 })}

--- a/src/components/elements/PricePicker.js
+++ b/src/components/elements/PricePicker.js
@@ -23,6 +23,7 @@ const createReqsLabels = reqsPerDay => {
 
   return {
     reqsPerMonth,
+    reqsPerMonthTotal: total,
     reqsPerMonthPretty,
     monthlyPrice: calculateMonthlyPrice(reqsPerDay)
   }
@@ -35,6 +36,7 @@ const overrideReqsPerMonth = (plan, reqsPerMonth) => {
   return {
     ...plan,
     reqsPerMonth,
+    reqsPerMonthTotal: total,
     reqsPerMonthPretty: `${formatNumber(pretty)}K`,
     monthlyPrice: calculateMonthlyPrice(reqsPerDay)
   }

--- a/src/components/elements/PricePicker.js
+++ b/src/components/elements/PricePicker.js
@@ -15,39 +15,22 @@ const calculateMonthlyPrice = reqsPerDay => ({
   USD: Math.round((reqsPerDay / 1000) * BASE_PLAN_PRICE.USD)
 })
 
-const createReqsLabels = reqsPerDay => {
-  const total = reqsPerDay * MONTH_DAYS
-  const reqsPerMonth = formatNumber(total)
-  const pretty = Math.round(total / 1000)
-  const reqsPerMonthPretty = `${formatNumber(pretty)}K`
+const createPlanFromMonthly = reqsPerMonthTotal => ({
+  reqsPerMonth: formatNumber(reqsPerMonthTotal),
+  reqsPerMonthTotal,
+  reqsPerMonthPretty: `${formatNumber(Math.round(reqsPerMonthTotal / 1000))}K`,
+  monthlyPrice: calculateMonthlyPrice(reqsPerMonthTotal / MONTH_DAYS)
+})
 
-  return {
-    reqsPerMonth,
-    reqsPerMonthTotal: total,
-    reqsPerMonthPretty,
-    monthlyPrice: calculateMonthlyPrice(reqsPerDay)
-  }
-}
-
-const overrideReqsPerMonth = (plan, reqsPerMonth) => {
-  const total = Number(reqsPerMonth.replace(/,/g, ''))
-  const reqsPerDay = total / MONTH_DAYS
-  const pretty = Math.round(total / 1000)
-  return {
-    ...plan,
-    reqsPerMonth,
-    reqsPerMonthTotal: total,
-    reqsPerMonthPretty: `${formatNumber(pretty)}K`,
-    monthlyPrice: calculateMonthlyPrice(reqsPerDay)
-  }
-}
+const createPlanFromDaily = reqsPerDay =>
+  createPlanFromMonthly(reqsPerDay * MONTH_DAYS)
 
 export const PLANS = [
-  overrideReqsPerMonth({ id: 'pro-1_625k-v4' }, '46,000'),
-  { id: 'pro-3k-v4', ...createReqsLabels(3000) },
-  { id: 'pro-5k-v4', ...createReqsLabels(5000) },
-  { id: 'pro-10k-v4', ...createReqsLabels(10000) },
-  { id: 'pro-15k-v4', ...createReqsLabels(15000) }
+  { id: 'pro-1_625k-v4', ...createPlanFromMonthly(46000) },
+  { id: 'pro-3k-v4', ...createPlanFromDaily(3000) },
+  { id: 'pro-5k-v4', ...createPlanFromDaily(5000) },
+  { id: 'pro-10k-v4', ...createPlanFromDaily(10000) },
+  { id: 'pro-15k-v4', ...createPlanFromDaily(15000) }
 ]
 
 export const DEFAULT_PLAN = PLANS[0]

--- a/src/components/elements/PricePicker.js
+++ b/src/components/elements/PricePicker.js
@@ -43,10 +43,7 @@ const overrideReqsPerMonth = (plan, reqsPerMonth) => {
 }
 
 export const PLANS = [
-  overrideReqsPerMonth(
-    { id: 'pro-1_625k-v4', ...createReqsLabels(1625) },
-    '46,000'
-  ),
+  overrideReqsPerMonth({ id: 'pro-1_625k-v4' }, '46,000'),
   { id: 'pro-3k-v4', ...createReqsLabels(3000) },
   { id: 'pro-5k-v4', ...createReqsLabels(5000) },
   { id: 'pro-10k-v4', ...createReqsLabels(10000) },
@@ -151,9 +148,14 @@ const TickLabel = styled(Text)`
 
 const DEFAULT_INDEX = PLANS.indexOf(DEFAULT_PLAN)
 
+const MAX_INDEX = PLANS.length - 1
+
+const indexPct = index => (MAX_INDEX > 0 ? (index / MAX_INDEX) * 100 : 0)
+
+const TICK_STYLES = PLANS.map((_, i) => ({ left: `${indexPct(i)}%` }))
+
 const PricePicker = ({ onChange }) => {
   const [index, setIndex] = useState(DEFAULT_INDEX)
-  const max = PLANS.length - 1
 
   const handleChange = useCallback(
     e => {
@@ -164,7 +166,7 @@ const PricePicker = ({ onChange }) => {
     [onChange]
   )
 
-  const fillPct = max > 0 ? (index / max) * 100 : 0
+  const fillPct = indexPct(index)
   const plan = PLANS[index]
 
   return (
@@ -202,7 +204,7 @@ const PricePicker = ({ onChange }) => {
           <SliderInput
             type='range'
             min={0}
-            max={max}
+            max={MAX_INDEX}
             step={1}
             value={index}
             onChange={handleChange}
@@ -220,7 +222,7 @@ const PricePicker = ({ onChange }) => {
               key={p.id}
               as='span'
               data-active={i === index}
-              style={{ left: `${max > 0 ? (i / max) * 100 : 0}%` }}
+              style={TICK_STYLES[i]}
             >
               {p.reqsPerMonthPretty}
             </TickLabel>

--- a/src/components/patterns/OpenSource/OpenSource.js
+++ b/src/components/patterns/OpenSource/OpenSource.js
@@ -25,6 +25,8 @@ import Text from 'components/elements/Text'
 import ArrowLink from 'components/patterns/ArrowLink'
 import Caption from 'components/patterns/Caption/Caption'
 
+import { formatCompactNumber } from 'helpers/format-number'
+
 import ossData from '../../../../data/oss.json'
 
 const LAYOUT = {
@@ -33,14 +35,6 @@ const LAYOUT = {
   secondaryWidth: '45%',
   gap: [3, 3, 4, 5]
 }
-
-const COMPACT_NUMBER_FORMATTER = new Intl.NumberFormat('en-US', {
-  notation: 'compact',
-  maximumFractionDigits: 1
-})
-
-const formatCompactCount = number =>
-  COMPACT_NUMBER_FORMATTER.format(number).toLowerCase()
 
 const LANGUAGE_COLORS = {
   JavaScript: '#f1e05a',
@@ -75,7 +69,7 @@ export const getRepoStars = name => REPOS_BY_NAME.get(name)?.stars
 
 export const OSS_STATS = {
   repos: ossData.length,
-  stars: formatCompactCount(
+  stars: formatCompactNumber(
     ossData.reduce((total, { stars }) => total + stars, 0)
   )
 }
@@ -239,7 +233,7 @@ const RepoCardItem = ({ repo, tile, primary, ...props }) => (
       </Flex>
       <Flex css={theme({ alignItems: 'center', gap: 1 })}>
         <StarIcon size={primary ? 16 : 14} aria-hidden='true' />
-        {formatCompactCount(repo.stars)}
+        {formatCompactNumber(repo.stars)}
       </Flex>
     </RepoMeta>
   </RepoCard>

--- a/src/components/patterns/Plans/EnterprisePlanCard.js
+++ b/src/components/patterns/Plans/EnterprisePlanCard.js
@@ -1,0 +1,64 @@
+import React from 'react'
+
+import Box from 'components/elements/Box'
+import Flex from 'components/elements/Flex'
+import { Link } from 'components/elements/Link'
+import Text from 'components/elements/Text'
+import ArrowLink from 'components/patterns/ArrowLink'
+import { theme } from 'theme'
+
+import {
+  PlanAction,
+  PlanCheck,
+  PlanCheckList,
+  PlanName,
+  PlanTagline,
+  PricingCard,
+  planDisplay
+} from './shared'
+
+const EnterprisePlanCard = ({ activePlan }) => (
+  <PricingCard
+    id='panel-enterprise'
+    css={theme({ display: planDisplay(activePlan, 'enterprise') })}
+  >
+    <PlanName>Enterprise</PlanName>
+    <PlanTagline>Dedicated infra for high-volume.</PlanTagline>
+    <Box css={theme({ pt: [3, 3, 4, 4] })}>
+      <Flex css={theme({ alignItems: 'baseline', gap: 1 })}>
+        <Text
+          as='span'
+          css={theme({
+            fontSize: [2, 2, 3, 3],
+            fontWeight: 'bold',
+            color: 'black',
+            lineHeight: 0
+          })}
+        >
+          Custom
+        </Text>
+      </Flex>
+      <Text css={theme({ pt: 2, fontSize: 0, color: 'black70' })}>
+        Tailored to your volume
+      </Text>
+    </Box>
+    <PlanCheckList as='ul' css={theme({ pt: [3, 3, 4, 4] })}>
+      <PlanCheck>Everything in Pro</PlanCheck>
+      <PlanCheck>
+        <Link href='/enterprise'>Custom API endpoint</Link>
+      </PlanCheck>
+      <PlanCheck>
+        <Link href='/enterprise'>Dedicated CDN distribution</Link>
+      </PlanCheck>
+      <PlanCheck>
+        <Link href='/enterprise'>S3-like storage integration</Link>
+      </PlanCheck>
+      <PlanCheck>Custom SLA & DPA available</PlanCheck>
+    </PlanCheckList>
+    <PlanAction>
+      <ArrowLink href='/enterprise'>Explore Enterprise</ArrowLink>
+    </PlanAction>
+  </PricingCard>
+)
+
+export default EnterprisePlanCard

--- a/src/components/patterns/Plans/EnterprisePlanCard.js
+++ b/src/components/patterns/Plans/EnterprisePlanCard.js
@@ -42,7 +42,7 @@ const EnterprisePlanCard = ({ activePlan }) => (
         Tailored to your volume
       </Text>
     </Box>
-    <PlanCheckList as='ul' css={theme({ pt: [3, 3, 4, 4] })}>
+    <PlanCheckList css={theme({ pt: [3, 3, 4, 4] })}>
       <PlanCheck>Everything in Pro</PlanCheck>
       <PlanCheck>
         <Link href='/enterprise'>Custom API endpoint</Link>

--- a/src/components/patterns/Plans/FreePlanCard.js
+++ b/src/components/patterns/Plans/FreePlanCard.js
@@ -39,7 +39,7 @@ const FreePlanCard = ({ activePlan }) => (
         {FREE_PLAN_RATE_LIMIT} requests per day
       </Text>
     </Box>
-    <PlanCheckList as='ul' css={theme({ pt: [3, 3, 4, 4] })}>
+    <PlanCheckList css={theme({ pt: [3, 3, 4, 4] })}>
       <PlanCheck>{FREE_PLAN_RATE_LIMIT} requests / day</PlanCheck>
       <PlanCheck>
         <Link href='/screenshot'>Screenshot</Link>, <Link href='/pdf'>PDF</Link>

--- a/src/components/patterns/Plans/FreePlanCard.js
+++ b/src/components/patterns/Plans/FreePlanCard.js
@@ -7,7 +7,6 @@ import ArrowLink from 'components/patterns/ArrowLink'
 import { theme } from 'theme'
 
 import {
-  FREE_PLAN_RATE_LIMIT,
   PlanAction,
   PlanCheck,
   PlanCheckList,
@@ -18,6 +17,10 @@ import {
   planDisplay
 } from './shared'
 
+const FREE_PLAN_RATE_LIMIT = 25
+
+const FREE_PLAN_PRICES = { EUR: 0, USD: 0 }
+
 const FreePlanCard = ({ activePlan }) => (
   <PricingCard
     id='panel-free'
@@ -26,7 +29,7 @@ const FreePlanCard = ({ activePlan }) => (
     <PlanName>Free</PlanName>
     <PlanTagline>Try the API in seconds. No card.</PlanTagline>
     <Box css={theme({ pt: [3, 3, 4, 4] })}>
-      <PriceTag prices={{ EUR: 0, USD: 0 }} />
+      <PriceTag prices={FREE_PLAN_PRICES} />
       <Text
         css={theme({
           pt: 2,

--- a/src/components/patterns/Plans/FreePlanCard.js
+++ b/src/components/patterns/Plans/FreePlanCard.js
@@ -1,0 +1,69 @@
+import React from 'react'
+
+import Box from 'components/elements/Box'
+import { Link } from 'components/elements/Link'
+import Text from 'components/elements/Text'
+import ArrowLink from 'components/patterns/ArrowLink'
+import { theme } from 'theme'
+
+import {
+  FREE_PLAN_RATE_LIMIT,
+  PlanAction,
+  PlanCheck,
+  PlanCheckList,
+  PlanName,
+  PlanTagline,
+  PriceTag,
+  PricingCard,
+  planDisplay
+} from './shared'
+
+const FreePlanCard = ({ activePlan }) => (
+  <PricingCard
+    id='panel-free'
+    css={theme({ display: planDisplay(activePlan, 'free') })}
+  >
+    <PlanName>Free</PlanName>
+    <PlanTagline>Try the API in seconds. No card.</PlanTagline>
+    <Box css={theme({ pt: [3, 3, 4, 4] })}>
+      <PriceTag prices={{ EUR: 0, USD: 0 }} />
+      <Text
+        css={theme({
+          pt: 2,
+          fontSize: 0,
+          color: 'black70',
+          fontVariantNumeric: 'tabular-nums'
+        })}
+      >
+        {FREE_PLAN_RATE_LIMIT} requests per day
+      </Text>
+    </Box>
+    <PlanCheckList as='ul' css={theme({ pt: [3, 3, 4, 4] })}>
+      <PlanCheck>{FREE_PLAN_RATE_LIMIT} requests / day</PlanCheck>
+      <PlanCheck>
+        <Link href='/screenshot'>Screenshot</Link>, <Link href='/pdf'>PDF</Link>
+        , <Link href='/integrations/sdk'>SDK</Link>
+      </PlanCheck>
+      <PlanCheck>
+        <Link href='/metadata'>Metadata</Link>, <Link href='/logo'>Logo</Link>,{' '}
+        <Link href='/insights'>Insights</Link>
+      </PlanCheck>
+      <PlanCheck>
+        <Link href='/blog/edge-cdn'>Global edge cache</Link>
+      </PlanCheck>
+      <PlanCheck>
+        <Link href='/docs/api/parameters/adblock'>
+          Adblock & cookie banners
+        </Link>
+      </PlanCheck>
+      <PlanCheck>
+        <Link href='/community'>Community support</Link>
+      </PlanCheck>
+    </PlanCheckList>
+    <PlanAction>
+      <ArrowLink href='/docs/guides'>Get started free</ArrowLink>
+    </PlanAction>
+  </PricingCard>
+)
+
+export default FreePlanCard

--- a/src/components/patterns/Plans/FreePlanCard.js
+++ b/src/components/patterns/Plans/FreePlanCard.js
@@ -19,8 +19,6 @@ import {
 
 const FREE_PLAN_RATE_LIMIT = 25
 
-const FREE_PLAN_PRICES = { EUR: 0, USD: 0 }
-
 const FreePlanCard = ({ activePlan }) => (
   <PricingCard
     id='panel-free'
@@ -29,7 +27,7 @@ const FreePlanCard = ({ activePlan }) => (
     <PlanName>Free</PlanName>
     <PlanTagline>Try the API in seconds. No card.</PlanTagline>
     <Box css={theme({ pt: [3, 3, 4, 4] })}>
-      <PriceTag prices={FREE_PLAN_PRICES} />
+      <PriceTag prices={0} />
       <Text
         css={theme({
           pt: 2,

--- a/src/components/patterns/Plans/Plans.js
+++ b/src/components/patterns/Plans/Plans.js
@@ -16,8 +16,10 @@ const PLAN_TABS = [
   { id: 'enterprise', node: 'Enterprise' }
 ]
 
+const DEFAULT_PLAN_TAB = 'pro'
+
 const Plans = ({ canonicalUrl, stripeKey, footer = 'none' }) => {
-  const [activePlan, setActivePlan] = useState('pro')
+  const [activePlan, setActivePlan] = useState(DEFAULT_PLAN_TAB)
 
   return (
     <Container
@@ -40,7 +42,7 @@ const Plans = ({ canonicalUrl, stripeKey, footer = 'none' }) => {
       >
         <Toggle
           aria-label='Pricing plans'
-          defaultValue='pro'
+          defaultValue={DEFAULT_PLAN_TAB}
           onChange={setActivePlan}
           css={theme({ width: 'auto' })}
         >

--- a/src/components/patterns/Plans/Plans.js
+++ b/src/components/patterns/Plans/Plans.js
@@ -1,21 +1,17 @@
 import React, { useState } from 'react'
-import styled from 'styled-components'
-import { Check as CheckIcon } from 'react-feather'
 
-import Box from 'components/elements/Box'
 import Container from 'components/elements/Container'
 import Flex from 'components/elements/Flex'
-import Highlight from 'components/elements/Highlight'
-import { Link } from 'components/elements/Link'
-import PricePicker, { DEFAULT_PLAN } from 'components/elements/PricePicker'
-import Text from 'components/elements/Text'
+import { DEFAULT_PLAN } from 'components/elements/PricePicker'
 import Toggle from 'components/elements/Toggle/Toggle'
-import FeatherIcon from 'components/icons/Feather'
-import { useCurrencyContext } from 'components/hook/use-currency'
-import { useOssTotalStars } from 'components/hook/use-oss-total-stars'
-import ArrowLink from 'components/patterns/ArrowLink'
-import Checkout from 'components/patterns/Checkout'
-import { colors, gradient, layout, theme } from 'theme'
+import { theme } from 'theme'
+
+import EnterprisePlanCard from './EnterprisePlanCard'
+import FreePlanCard from './FreePlanCard'
+import PlansFooter from './PlansFooter'
+import ProPlanCard from './ProPlanCard'
+
+export { CURRENCIES, formatPrice } from './shared'
 
 const PLAN_TABS = [
   { id: 'free', node: 'Free' },
@@ -23,163 +19,9 @@ const PLAN_TABS = [
   { id: 'enterprise', node: 'Enterprise' }
 ]
 
-const planDisplay = (activePlan, id) =>
-  activePlan === id ? 'flex' : ['none', 'none', 'flex', 'flex']
-
-const FREE_PLAN_RATE_LIMIT = 25
-
-const COMPACT_NUMBER_FORMATTER = new Intl.NumberFormat('en-US', {
-  notation: 'compact',
-  maximumFractionDigits: 1
-})
-
-export const CURRENCIES = {
-  USD: { code: 'USD', symbol: '$', label: 'USD', word: 'dollars' },
-  EUR: { code: 'EUR', symbol: '€', label: 'EUR', word: 'euros' }
-}
-
-const formatCompact = n => COMPACT_NUMBER_FORMATTER.format(n).toLowerCase()
-
-export const formatPrice = (prices, currencyCode, { decimals = 0 } = {}) => {
-  const value = typeof prices === 'number' ? prices : prices[currencyCode]
-  return value.toFixed(decimals)
-}
-
-const Dot = () => (
-  <Text
-    as='span'
-    aria-hidden='true'
-    css={theme({ color: 'black30', px: [2, 2, 3, 3], display: 'inline-block' })}
-  >
-    ·
-  </Text>
-)
-
-const PricingCard = styled(Flex)`
-  ${theme({
-    flexDirection: 'column',
-    borderRadius: 3,
-    bg: 'white',
-    px: [3, 3, 4, 4],
-    py: [3, 3, 4, 4],
-    flex: 1,
-    minWidth: 0,
-    maxWidth: ['100%', '100%', '380px', '380px']
-  })}
-  border: solid 1px ${colors.gray4};
-`
-
-const ProPricingCard = styled(PricingCard)`
-  border: 2px solid transparent;
-  background: linear-gradient(${colors.white}, ${colors.white}) padding-box,
-    ${gradient} border-box;
-  position: relative;
-  @media (min-width: 1200px) {
-    transform: translateY(-12px);
-  }
-`
-
-const PlanCheckList = styled(Box)`
-  ${theme({ m: 0, p: 0 })}
-  list-style: none;
-`
-
-const PlanCheck = ({ children }) => (
-  <Flex as='li' css={theme({ alignItems: 'center', gap: 2, pt: 2 })}>
-    <FeatherIcon
-      data-icon='check'
-      css={theme({
-        display: 'inline-flex',
-        color: 'pink7',
-        flexShrink: 0
-      })}
-      icon={CheckIcon}
-      size='16px'
-    />
-    <Text as='span' css={theme({ fontSize: [1, 1, '17px', '17px'] })}>
-      {children}
-    </Text>
-  </Flex>
-)
-
-const PriceTag = ({ prices, suffix = '/month', highlight = false }) => {
-  const [currency] = useCurrencyContext()
-  const { symbol, word } = CURRENCIES[currency]
-  const amount = formatPrice(prices, currency)
-  const ariaLabel = `${amount} ${word} per month`
-  const amountNode = highlight
-    ? (
-      <Highlight as='span'>{amount}</Highlight>
-      )
-    : (
-        amount
-      )
-
-  return (
-    <Flex
-      css={theme({
-        alignItems: 'baseline',
-        justifyContent: 'flex-start',
-        gap: 1
-      })}
-      aria-label={ariaLabel}
-    >
-      <Text
-        as='span'
-        css={theme({
-          fontSize: [2, 2, 3, 3],
-          fontWeight: 'bold',
-          color: 'black',
-          lineHeight: 0,
-          position: 'relative',
-          top: '-12px'
-        })}
-      >
-        {symbol}
-      </Text>
-      <Text
-        as='span'
-        css={theme({
-          fontSize: ['32px', '32px', '42px', '42px'],
-          fontWeight: 'bold',
-          color: 'black',
-          lineHeight: 0,
-          fontVariantNumeric: 'tabular-nums'
-        })}
-      >
-        {amountNode}
-      </Text>
-      <Text as='span' css={theme({ fontSize: [0, 0, 1, 1], color: 'black70' })}>
-        {suffix}
-      </Text>
-    </Flex>
-  )
-}
-
-const PlanName = ({ children }) => (
-  <Text
-    as='h3'
-    css={theme({
-      fontSize: ['20px', '20px', '24px', '24px'],
-      fontWeight: 'bold',
-      color: 'black',
-      lineHeight: 1
-    })}
-  >
-    {children}
-  </Text>
-)
-
 const Plans = ({ canonicalUrl, stripeKey, footer = 'none' }) => {
   const [plan, setPlan] = useState(DEFAULT_PLAN)
   const [activePlan, setActivePlan] = useState('pro')
-  const [currency] = useCurrencyContext()
-  const { monthlyPrice, id: planId, reqsPerMonth } = plan
-  const reqsPerMonthNumber = Number(reqsPerMonth.replace(/,/g, ''))
-  const pricePer1k = monthlyPrice[currency] / (reqsPerMonthNumber / 1000)
-  const pricePer1kDisplay = pricePer1k.toFixed(2)
-  const { symbol: currencySymbol } = CURRENCIES[currency]
-  const totalStars = useOssTotalStars()
 
   return (
     <Container
@@ -218,262 +60,18 @@ const Plans = ({ canonicalUrl, stripeKey, footer = 'none' }) => {
           width: '100%'
         })}
       >
-        <PricingCard
-          id='panel-free'
-          css={theme({ display: planDisplay(activePlan, 'free') })}
-        >
-          <PlanName>Free</PlanName>
-          <Text
-            css={theme({ pt: 2, fontSize: [1, 1, 2, 2], color: 'black70' })}
-          >
-            Try the API in seconds. No card.
-          </Text>
-          <Box css={theme({ pt: [3, 3, 4, 4] })}>
-            <PriceTag prices={{ EUR: 0, USD: 0 }} />
-            <Text
-              css={theme({
-                pt: 2,
-                fontSize: 0,
-                color: 'black70',
-                fontVariantNumeric: 'tabular-nums'
-              })}
-            >
-              {FREE_PLAN_RATE_LIMIT} requests per day
-            </Text>
-          </Box>
-          <PlanCheckList as='ul' css={theme({ pt: [3, 3, 4, 4] })}>
-            <PlanCheck>{FREE_PLAN_RATE_LIMIT} requests / day</PlanCheck>
-            <PlanCheck>
-              <Link href='/screenshot'>Screenshot</Link>,{' '}
-              <Link href='/pdf'>PDF</Link>,{' '}
-              <Link href='/integrations/sdk'>SDK</Link>
-            </PlanCheck>
-            <PlanCheck>
-              <Link href='/metadata'>Metadata</Link>,{' '}
-              <Link href='/logo'>Logo</Link>,{' '}
-              <Link href='/insights'>Insights</Link>
-            </PlanCheck>
-            <PlanCheck>
-              <Link href='/blog/edge-cdn'>Global edge cache</Link>
-            </PlanCheck>
-            <PlanCheck>
-              <Link href='/docs/api/parameters/adblock'>
-                Adblock & cookie banners
-              </Link>
-            </PlanCheck>
-            <PlanCheck>
-              <Link href='/community'>Community support</Link>
-            </PlanCheck>
-          </PlanCheckList>
-          <Box
-            css={theme({
-              pt: [4, 4, 5, 5],
-              mt: 'auto',
-              display: 'flex',
-              justifyContent: 'center',
-              fontSize: [1, 1, 2, 2]
-            })}
-          >
-            <ArrowLink href='/docs/guides'>Get started free</ArrowLink>
-          </Box>
-        </PricingCard>
-
-        <ProPricingCard
-          id='panel-pro'
-          css={theme({ display: planDisplay(activePlan, 'pro') })}
-        >
-          <PlanName>Pro</PlanName>
-          <Text
-            css={theme({ pt: 2, fontSize: [1, 1, 2, 2], color: 'black70' })}
-          >
-            For production workloads.
-          </Text>
-          <Box css={theme({ pt: [3, 3, 4, 4] })}>
-            <PriceTag prices={monthlyPrice} highlight />
-            <Text
-              css={theme({
-                pt: 2,
-                fontSize: 0,
-                color: 'pink7',
-                fontWeight: 'bold',
-                fontVariantNumeric: 'tabular-nums'
-              })}
-            >
-              ≈ {currencySymbol}
-              {pricePer1kDisplay} per 1,000 requests
-            </Text>
-          </Box>
-          <Box css={theme({ pt: [3, 3, 4, 4] })}>
-            <PricePicker onChange={setPlan} />
-          </Box>
-          <PlanCheckList as='ul' css={theme({ pt: [3, 3, 4, 4] })}>
-            <PlanCheck>Everything in Free</PlanCheck>
-            <PlanCheck>
-              <Link href='/features/proxy'>Automatic proxy resolution</Link>
-            </PlanCheck>
-            <PlanCheck>
-              <Link href='/features/ttl'>Configurable TTL</Link>
-            </PlanCheck>
-            <PlanCheck>
-              <Link href='/features/headers'>Custom HTTP headers</Link>
-            </PlanCheck>
-            <PlanCheck>
-              <Link href='/docs/api/parameters/cacheKey'>Custom cache key</Link>
-            </PlanCheck>
-            <PlanCheck>Priority email support</PlanCheck>
-          </PlanCheckList>
-          <Box css={theme({ pt: [4, 4, 5, 5], mt: 'auto' })}>
-            <Checkout
-              variant='gradient'
-              planId={planId}
-              canonicalUrl={canonicalUrl}
-              stripeKey={stripeKey}
-              css={theme({ width: '100%' })}
-            />
-            <Text
-              css={theme({
-                pt: 2,
-                fontSize: 0,
-                color: 'black70',
-                textAlign: 'center'
-              })}
-            >
-              Cancel anytime · No setup fees
-            </Text>
-          </Box>
-        </ProPricingCard>
-
-        <PricingCard
-          id='panel-enterprise'
-          css={theme({ display: planDisplay(activePlan, 'enterprise') })}
-        >
-          <PlanName>Enterprise</PlanName>
-          <Text
-            css={theme({ pt: 2, fontSize: [1, 1, 2, 2], color: 'black70' })}
-          >
-            Dedicated infra for high-volume.
-          </Text>
-          <Box css={theme({ pt: [3, 3, 4, 4] })}>
-            <Flex css={theme({ alignItems: 'baseline', gap: 1 })}>
-              <Text
-                as='span'
-                css={theme({
-                  fontSize: [2, 2, 3, 3],
-                  fontWeight: 'bold',
-                  color: 'black',
-                  lineHeight: 0
-                })}
-              >
-                Custom
-              </Text>
-            </Flex>
-            <Text css={theme({ pt: 2, fontSize: 0, color: 'black70' })}>
-              Tailored to your volume
-            </Text>
-          </Box>
-          <PlanCheckList as='ul' css={theme({ pt: [3, 3, 4, 4] })}>
-            <PlanCheck>Everything in Pro</PlanCheck>
-            <PlanCheck>
-              <Link href='/enterprise'>Custom API endpoint</Link>
-            </PlanCheck>
-            <PlanCheck>
-              <Link href='/enterprise'>Dedicated CDN distribution</Link>
-            </PlanCheck>
-            <PlanCheck>
-              <Link href='/enterprise'>S3-like storage integration</Link>
-            </PlanCheck>
-            <PlanCheck>Custom SLA & DPA available</PlanCheck>
-          </PlanCheckList>
-          <Box
-            css={theme({
-              pt: [4, 4, 5, 5],
-              mt: 'auto',
-              display: 'flex',
-              justifyContent: 'center',
-              fontSize: [1, 1, 2, 2]
-            })}
-          >
-            <ArrowLink href='/enterprise'>Explore Enterprise</ArrowLink>
-          </Box>
-        </PricingCard>
+        <FreePlanCard activePlan={activePlan} />
+        <ProPlanCard
+          activePlan={activePlan}
+          plan={plan}
+          onPlanChange={setPlan}
+          canonicalUrl={canonicalUrl}
+          stripeKey={stripeKey}
+        />
+        <EnterprisePlanCard activePlan={activePlan} />
       </Flex>
 
-      {footer !== 'none' && (
-        <>
-          <Box
-            aria-hidden='true'
-            css={`
-              margin-top: 32px;
-              width: 100%;
-              max-width: ${layout.normal};
-              height: 1px;
-              background: linear-gradient(
-                90deg,
-                transparent,
-                ${colors.black10},
-                transparent
-              );
-            `}
-          />
-
-          {footer === 'stats' && (
-            <Flex
-              css={theme({
-                pt: [3, 3, 4, 4],
-                flexWrap: 'wrap',
-                justifyContent: 'center',
-                alignItems: 'center',
-                fontSize: [0, 0, 1, 1],
-                color: 'black70',
-                fontWeight: 'bold',
-                letterSpacing: 1
-              })}
-            >
-              <Text as='span'>
-                <Text as='span' css={theme({ color: 'black' })}>
-                  {formatCompact(totalStars)}
-                </Text>{' '}
-                GitHub stars
-              </Text>
-              <Dot />
-              <Text as='span'>
-                <Text as='span' css={theme({ color: 'black' })}>
-                  641M+
-                </Text>{' '}
-                requests last month
-              </Text>
-              <Dot />
-              <Text as='span'>
-                <Text as='span' css={theme({ color: 'black' })}>
-                  99.9%
-                </Text>{' '}
-                SLA
-              </Text>
-            </Flex>
-          )}
-
-          {footer === 'compare' && (
-            <Flex
-              css={theme({
-                pt: [3, 3, 4, 4],
-                flexDirection: ['column', 'row', 'row', 'row'],
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: [1, 2, 2, 2],
-                textAlign: 'center',
-                fontSize: [1, 1, 2, 2]
-              })}
-            >
-              <Text as='span' css={theme({ color: 'black70' })}>
-                Need more details?
-              </Text>
-              <ArrowLink href='/pricing'>
-                Compare every plan side by side
-              </ArrowLink>
-            </Flex>
-          )}
-        </>
-      )}
+      {footer !== 'none' && <PlansFooter footer={footer} />}
     </Container>
   )
 }

--- a/src/components/patterns/Plans/Plans.js
+++ b/src/components/patterns/Plans/Plans.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 
 import Container from 'components/elements/Container'
 import Flex from 'components/elements/Flex'
-import { DEFAULT_PLAN } from 'components/elements/PricePicker'
 import Toggle from 'components/elements/Toggle/Toggle'
 import { theme } from 'theme'
 
@@ -11,8 +10,6 @@ import FreePlanCard from './FreePlanCard'
 import PlansFooter from './PlansFooter'
 import ProPlanCard from './ProPlanCard'
 
-export { CURRENCIES, formatPrice } from './shared'
-
 const PLAN_TABS = [
   { id: 'free', node: 'Free' },
   { id: 'pro', node: 'Pro' },
@@ -20,7 +17,6 @@ const PLAN_TABS = [
 ]
 
 const Plans = ({ canonicalUrl, stripeKey, footer = 'none' }) => {
-  const [plan, setPlan] = useState(DEFAULT_PLAN)
   const [activePlan, setActivePlan] = useState('pro')
 
   return (
@@ -63,8 +59,6 @@ const Plans = ({ canonicalUrl, stripeKey, footer = 'none' }) => {
         <FreePlanCard activePlan={activePlan} />
         <ProPlanCard
           activePlan={activePlan}
-          plan={plan}
-          onPlanChange={setPlan}
           canonicalUrl={canonicalUrl}
           stripeKey={stripeKey}
         />

--- a/src/components/patterns/Plans/PlansFooter.js
+++ b/src/components/patterns/Plans/PlansFooter.js
@@ -1,0 +1,100 @@
+import React from 'react'
+
+import Box from 'components/elements/Box'
+import Flex from 'components/elements/Flex'
+import Text from 'components/elements/Text'
+import { useOssTotalStars } from 'components/hook/use-oss-total-stars'
+import ArrowLink from 'components/patterns/ArrowLink'
+import { colors, layout, theme } from 'theme'
+
+const COMPACT_NUMBER_FORMATTER = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 1
+})
+
+const formatCompact = n => COMPACT_NUMBER_FORMATTER.format(n).toLowerCase()
+
+const Dot = () => (
+  <Text
+    as='span'
+    aria-hidden='true'
+    css={theme({ color: 'black30', px: [2, 2, 3, 3], display: 'inline-block' })}
+  >
+    ·
+  </Text>
+)
+
+const Stat = ({ value, children }) => (
+  <Text as='span'>
+    <Text as='span' css={theme({ color: 'black' })}>
+      {value}
+    </Text>{' '}
+    {children}
+  </Text>
+)
+
+const PlansFooter = ({ footer }) => {
+  const totalStars = useOssTotalStars()
+
+  return (
+    <>
+      <Box
+        aria-hidden='true'
+        css={`
+          margin-top: 32px;
+          width: 100%;
+          max-width: ${layout.normal};
+          height: 1px;
+          background: linear-gradient(
+            90deg,
+            transparent,
+            ${colors.black10},
+            transparent
+          );
+        `}
+      />
+
+      {footer === 'stats' && (
+        <Flex
+          css={theme({
+            pt: [3, 3, 4, 4],
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+            alignItems: 'center',
+            fontSize: [0, 0, 1, 1],
+            color: 'black70',
+            fontWeight: 'bold',
+            letterSpacing: 1
+          })}
+        >
+          <Stat value={formatCompact(totalStars)}>GitHub stars</Stat>
+          <Dot />
+          <Stat value='641M+'>requests last month</Stat>
+          <Dot />
+          <Stat value='99.9%'>SLA</Stat>
+        </Flex>
+      )}
+
+      {footer === 'compare' && (
+        <Flex
+          css={theme({
+            pt: [3, 3, 4, 4],
+            flexDirection: ['column', 'row', 'row', 'row'],
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: [1, 2, 2, 2],
+            textAlign: 'center',
+            fontSize: [1, 1, 2, 2]
+          })}
+        >
+          <Text as='span' css={theme({ color: 'black70' })}>
+            Need more details?
+          </Text>
+          <ArrowLink href='/pricing'>Compare every plan side by side</ArrowLink>
+        </Flex>
+      )}
+    </>
+  )
+}
+
+export default PlansFooter

--- a/src/components/patterns/Plans/PlansFooter.js
+++ b/src/components/patterns/Plans/PlansFooter.js
@@ -5,16 +5,10 @@ import Flex from 'components/elements/Flex'
 import Text from 'components/elements/Text'
 import { useOssTotalStars } from 'components/hook/use-oss-total-stars'
 import ArrowLink from 'components/patterns/ArrowLink'
+import { formatCompactNumber } from 'helpers/format-number'
 import { colors, layout, theme } from 'theme'
 
-const COMPACT_NUMBER_FORMATTER = new Intl.NumberFormat('en-US', {
-  notation: 'compact',
-  maximumFractionDigits: 1
-})
-
-const formatCompact = n => COMPACT_NUMBER_FORMATTER.format(n).toLowerCase()
-
-const Dot = () => (
+const Separator = () => (
   <Text
     as='span'
     aria-hidden='true'
@@ -67,10 +61,10 @@ const PlansFooter = ({ footer }) => {
             letterSpacing: 1
           })}
         >
-          <Stat value={formatCompact(totalStars)}>GitHub stars</Stat>
-          <Dot />
+          <Stat value={formatCompactNumber(totalStars)}>GitHub stars</Stat>
+          <Separator />
           <Stat value='641M+'>requests last month</Stat>
-          <Dot />
+          <Separator />
           <Stat value='99.9%'>SLA</Stat>
         </Flex>
       )}

--- a/src/components/patterns/Plans/ProPlanCard.js
+++ b/src/components/patterns/Plans/ProPlanCard.js
@@ -1,0 +1,100 @@
+import React from 'react'
+
+import Box from 'components/elements/Box'
+import { Link } from 'components/elements/Link'
+import PricePicker from 'components/elements/PricePicker'
+import Text from 'components/elements/Text'
+import { useCurrencyContext } from 'components/hook/use-currency'
+import Checkout from 'components/patterns/Checkout'
+import { theme } from 'theme'
+
+import {
+  CURRENCIES,
+  PlanCheck,
+  PlanCheckList,
+  PlanName,
+  PlanTagline,
+  PriceTag,
+  ProPricingCard,
+  planDisplay
+} from './shared'
+
+const ProPlanCard = ({
+  activePlan,
+  plan,
+  onPlanChange,
+  canonicalUrl,
+  stripeKey
+}) => {
+  const [currency] = useCurrencyContext()
+  const { monthlyPrice, id: planId, reqsPerMonth } = plan
+  const reqsPerMonthNumber = Number(reqsPerMonth.replace(/,/g, ''))
+  const pricePer1k = monthlyPrice[currency] / (reqsPerMonthNumber / 1000)
+  const pricePer1kDisplay = pricePer1k.toFixed(2)
+  const { symbol: currencySymbol } = CURRENCIES[currency]
+
+  return (
+    <ProPricingCard
+      id='panel-pro'
+      css={theme({ display: planDisplay(activePlan, 'pro') })}
+    >
+      <PlanName>Pro</PlanName>
+      <PlanTagline>For production workloads.</PlanTagline>
+      <Box css={theme({ pt: [3, 3, 4, 4] })}>
+        <PriceTag prices={monthlyPrice} highlight />
+        <Text
+          css={theme({
+            pt: 2,
+            fontSize: 0,
+            color: 'pink7',
+            fontWeight: 'bold',
+            fontVariantNumeric: 'tabular-nums'
+          })}
+        >
+          ≈ {currencySymbol}
+          {pricePer1kDisplay} per 1,000 requests
+        </Text>
+      </Box>
+      <Box css={theme({ pt: [3, 3, 4, 4] })}>
+        <PricePicker onChange={onPlanChange} />
+      </Box>
+      <PlanCheckList as='ul' css={theme({ pt: [3, 3, 4, 4] })}>
+        <PlanCheck>Everything in Free</PlanCheck>
+        <PlanCheck>
+          <Link href='/features/proxy'>Automatic proxy resolution</Link>
+        </PlanCheck>
+        <PlanCheck>
+          <Link href='/features/ttl'>Configurable TTL</Link>
+        </PlanCheck>
+        <PlanCheck>
+          <Link href='/features/headers'>Custom HTTP headers</Link>
+        </PlanCheck>
+        <PlanCheck>
+          <Link href='/docs/api/parameters/cacheKey'>Custom cache key</Link>
+        </PlanCheck>
+        <PlanCheck>Priority email support</PlanCheck>
+      </PlanCheckList>
+      <Box css={theme({ pt: [4, 4, 5, 5], mt: 'auto' })}>
+        <Checkout
+          variant='gradient'
+          planId={planId}
+          canonicalUrl={canonicalUrl}
+          stripeKey={stripeKey}
+          css={theme({ width: '100%' })}
+        />
+        <Text
+          css={theme({
+            pt: 2,
+            fontSize: 0,
+            color: 'black70',
+            textAlign: 'center'
+          })}
+        >
+          Cancel anytime · No setup fees
+        </Text>
+      </Box>
+    </ProPricingCard>
+  )
+}
+
+export default ProPlanCard

--- a/src/components/patterns/Plans/ProPlanCard.js
+++ b/src/components/patterns/Plans/ProPlanCard.js
@@ -1,8 +1,8 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import Box from 'components/elements/Box'
 import { Link } from 'components/elements/Link'
-import PricePicker from 'components/elements/PricePicker'
+import PricePicker, { DEFAULT_PLAN } from 'components/elements/PricePicker'
 import Text from 'components/elements/Text'
 import { useCurrencyContext } from 'components/hook/use-currency'
 import Checkout from 'components/patterns/Checkout'
@@ -19,18 +19,14 @@ import {
   planDisplay
 } from './shared'
 
-const ProPlanCard = ({
-  activePlan,
-  plan,
-  onPlanChange,
-  canonicalUrl,
-  stripeKey
-}) => {
+const ProPlanCard = ({ activePlan, canonicalUrl, stripeKey }) => {
+  const [plan, setPlan] = useState(DEFAULT_PLAN)
   const [currency] = useCurrencyContext()
-  const { monthlyPrice, id: planId, reqsPerMonth } = plan
-  const reqsPerMonthNumber = Number(reqsPerMonth.replace(/,/g, ''))
-  const pricePer1k = monthlyPrice[currency] / (reqsPerMonthNumber / 1000)
-  const pricePer1kDisplay = pricePer1k.toFixed(2)
+  const { monthlyPrice, id: planId, reqsPerMonthTotal } = plan
+  const pricePer1k = (
+    monthlyPrice[currency] /
+    (reqsPerMonthTotal / 1000)
+  ).toFixed(2)
   const { symbol: currencySymbol } = CURRENCIES[currency]
 
   return (
@@ -52,11 +48,11 @@ const ProPlanCard = ({
           })}
         >
           ≈ {currencySymbol}
-          {pricePer1kDisplay} per 1,000 requests
+          {pricePer1k} per 1,000 requests
         </Text>
       </Box>
       <Box css={theme({ pt: [3, 3, 4, 4] })}>
-        <PricePicker onChange={onPlanChange} />
+        <PricePicker onChange={setPlan} />
       </Box>
       <PlanCheckList as='ul' css={theme({ pt: [3, 3, 4, 4] })}>
         <PlanCheck>Everything in Free</PlanCheck>

--- a/src/components/patterns/Plans/ProPlanCard.js
+++ b/src/components/patterns/Plans/ProPlanCard.js
@@ -54,7 +54,7 @@ const ProPlanCard = ({ activePlan, canonicalUrl, stripeKey }) => {
       <Box css={theme({ pt: [3, 3, 4, 4] })}>
         <PricePicker onChange={setPlan} />
       </Box>
-      <PlanCheckList as='ul' css={theme({ pt: [3, 3, 4, 4] })}>
+      <PlanCheckList css={theme({ pt: [3, 3, 4, 4] })}>
         <PlanCheck>Everything in Free</PlanCheck>
         <PlanCheck>
           <Link href='/features/proxy'>Automatic proxy resolution</Link>

--- a/src/components/patterns/Plans/shared.js
+++ b/src/components/patterns/Plans/shared.js
@@ -10,16 +10,14 @@ import FeatherIcon from 'components/icons/Feather'
 import { useCurrencyContext } from 'components/hook/use-currency'
 import { colors, gradient, theme } from 'theme'
 
-export const FREE_PLAN_RATE_LIMIT = 25
-
 export const CURRENCIES = {
-  USD: { code: 'USD', symbol: '$', label: 'USD', word: 'dollars' },
-  EUR: { code: 'EUR', symbol: '€', label: 'EUR', word: 'euros' }
+  USD: { symbol: '$', word: 'dollars' },
+  EUR: { symbol: '€', word: 'euros' }
 }
 
-export const formatPrice = (prices, currencyCode, { decimals = 0 } = {}) => {
+export const formatPrice = (prices, currencyCode) => {
   const value = typeof prices === 'number' ? prices : prices[currencyCode]
-  return value.toFixed(decimals)
+  return value.toFixed(0)
 }
 
 export const planDisplay = (activePlan, id) =>
@@ -72,18 +70,11 @@ export const PlanCheck = ({ children }) => (
   </Flex>
 )
 
-export const PriceTag = ({ prices, suffix = '/month', highlight = false }) => {
+export const PriceTag = ({ prices, highlight = false }) => {
   const [currency] = useCurrencyContext()
   const { symbol, word } = CURRENCIES[currency]
   const amount = formatPrice(prices, currency)
   const ariaLabel = `${amount} ${word} per month`
-  const amountNode = highlight
-    ? (
-      <Highlight as='span'>{amount}</Highlight>
-      )
-    : (
-        amount
-      )
 
   return (
     <Flex
@@ -117,10 +108,10 @@ export const PriceTag = ({ prices, suffix = '/month', highlight = false }) => {
           fontVariantNumeric: 'tabular-nums'
         })}
       >
-        {amountNode}
+        {highlight ? <Highlight as='span'>{amount}</Highlight> : amount}
       </Text>
       <Text as='span' css={theme({ fontSize: [0, 0, 1, 1], color: 'black70' })}>
-        {suffix}
+        /month
       </Text>
     </Flex>
   )

--- a/src/components/patterns/Plans/shared.js
+++ b/src/components/patterns/Plans/shared.js
@@ -138,15 +138,14 @@ export const PlanTagline = ({ children }) => (
 )
 
 export const PlanAction = ({ children }) => (
-  <Box
+  <Flex
     css={theme({
       pt: [4, 4, 5, 5],
       mt: 'auto',
-      display: 'flex',
       justifyContent: 'center',
       fontSize: [1, 1, 2, 2]
     })}
   >
     {children}
-  </Box>
+  </Flex>
 )

--- a/src/components/patterns/Plans/shared.js
+++ b/src/components/patterns/Plans/shared.js
@@ -1,0 +1,161 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Check as CheckIcon } from 'react-feather'
+
+import Box from 'components/elements/Box'
+import Flex from 'components/elements/Flex'
+import Highlight from 'components/elements/Highlight'
+import Text from 'components/elements/Text'
+import FeatherIcon from 'components/icons/Feather'
+import { useCurrencyContext } from 'components/hook/use-currency'
+import { colors, gradient, theme } from 'theme'
+
+export const FREE_PLAN_RATE_LIMIT = 25
+
+export const CURRENCIES = {
+  USD: { code: 'USD', symbol: '$', label: 'USD', word: 'dollars' },
+  EUR: { code: 'EUR', symbol: '€', label: 'EUR', word: 'euros' }
+}
+
+export const formatPrice = (prices, currencyCode, { decimals = 0 } = {}) => {
+  const value = typeof prices === 'number' ? prices : prices[currencyCode]
+  return value.toFixed(decimals)
+}
+
+export const planDisplay = (activePlan, id) =>
+  activePlan === id ? 'flex' : ['none', 'none', 'flex', 'flex']
+
+export const PricingCard = styled(Flex)`
+  ${theme({
+    flexDirection: 'column',
+    borderRadius: 3,
+    bg: 'white',
+    px: [3, 3, 4, 4],
+    py: [3, 3, 4, 4],
+    flex: 1,
+    minWidth: 0,
+    maxWidth: ['100%', '100%', '380px', '380px']
+  })}
+  border: solid 1px ${colors.gray4};
+`
+
+export const ProPricingCard = styled(PricingCard)`
+  border: 2px solid transparent;
+  background: linear-gradient(${colors.white}, ${colors.white}) padding-box,
+    ${gradient} border-box;
+  position: relative;
+  @media (min-width: 1200px) {
+    transform: translateY(-12px);
+  }
+`
+
+export const PlanCheckList = styled(Box)`
+  ${theme({ m: 0, p: 0 })}
+  list-style: none;
+`
+
+export const PlanCheck = ({ children }) => (
+  <Flex as='li' css={theme({ alignItems: 'center', gap: 2, pt: 2 })}>
+    <FeatherIcon
+      data-icon='check'
+      css={theme({
+        display: 'inline-flex',
+        color: 'pink7',
+        flexShrink: 0
+      })}
+      icon={CheckIcon}
+      size='16px'
+    />
+    <Text as='span' css={theme({ fontSize: [1, 1, '17px', '17px'] })}>
+      {children}
+    </Text>
+  </Flex>
+)
+
+export const PriceTag = ({ prices, suffix = '/month', highlight = false }) => {
+  const [currency] = useCurrencyContext()
+  const { symbol, word } = CURRENCIES[currency]
+  const amount = formatPrice(prices, currency)
+  const ariaLabel = `${amount} ${word} per month`
+  const amountNode = highlight
+    ? (
+      <Highlight as='span'>{amount}</Highlight>
+      )
+    : (
+        amount
+      )
+
+  return (
+    <Flex
+      css={theme({
+        alignItems: 'baseline',
+        justifyContent: 'flex-start',
+        gap: 1
+      })}
+      aria-label={ariaLabel}
+    >
+      <Text
+        as='span'
+        css={theme({
+          fontSize: [2, 2, 3, 3],
+          fontWeight: 'bold',
+          color: 'black',
+          lineHeight: 0,
+          position: 'relative',
+          top: '-12px'
+        })}
+      >
+        {symbol}
+      </Text>
+      <Text
+        as='span'
+        css={theme({
+          fontSize: ['32px', '32px', '42px', '42px'],
+          fontWeight: 'bold',
+          color: 'black',
+          lineHeight: 0,
+          fontVariantNumeric: 'tabular-nums'
+        })}
+      >
+        {amountNode}
+      </Text>
+      <Text as='span' css={theme({ fontSize: [0, 0, 1, 1], color: 'black70' })}>
+        {suffix}
+      </Text>
+    </Flex>
+  )
+}
+
+export const PlanName = ({ children }) => (
+  <Text
+    as='h3'
+    css={theme({
+      fontSize: ['20px', '20px', '24px', '24px'],
+      fontWeight: 'bold',
+      color: 'black',
+      lineHeight: 1
+    })}
+  >
+    {children}
+  </Text>
+)
+
+export const PlanTagline = ({ children }) => (
+  <Text css={theme({ pt: 2, fontSize: [1, 1, 2, 2], color: 'black70' })}>
+    {children}
+  </Text>
+)
+
+export const PlanAction = ({ children }) => (
+  <Box
+    css={theme({
+      pt: [4, 4, 5, 5],
+      mt: 'auto',
+      display: 'flex',
+      justifyContent: 'center',
+      fontSize: [1, 1, 2, 2]
+    })}
+  >
+    {children}
+  </Box>
+)

--- a/src/components/patterns/Plans/shared.js
+++ b/src/components/patterns/Plans/shared.js
@@ -47,7 +47,7 @@ export const ProPricingCard = styled(PricingCard)`
   }
 `
 
-export const PlanCheckList = styled(Box)`
+export const PlanCheckList = styled(Box).attrs({ as: 'ul' })`
   ${theme({ m: 0, p: 0 })}
   list-style: none;
 `

--- a/src/helpers/format-number.js
+++ b/src/helpers/format-number.js
@@ -1,1 +1,9 @@
 export const formatNumber = n => Number(n).toLocaleString('en-US')
+
+const COMPACT_NUMBER_FORMATTER = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 1
+})
+
+export const formatCompactNumber = n =>
+  COMPACT_NUMBER_FORMATTER.format(n).toLowerCase()

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -25,7 +25,8 @@ import {
   CurrencyProvider,
   useCurrencyContext
 } from 'components/hook/use-currency'
-import Plans, { CURRENCIES, formatPrice } from 'components/patterns/Plans/Plans'
+import Plans from 'components/patterns/Plans/Plans'
+import { CURRENCIES, formatPrice } from 'components/patterns/Plans/shared'
 import { trackEvent } from 'helpers/plausible'
 import { CDN_EDGES } from 'helpers/cdn-edges'
 import {


### PR DESCRIPTION
Splits the 440-line `Plans.js` into one file per card, following the section-per-file layout used elsewhere in the repo.

- `FreePlanCard.js`, `ProPlanCard.js`, `EnterprisePlanCard.js` — one card each
- `PlansFooter.js` — the footer band
- `shared.js` — cross-card primitives (`PricingCard`, `PlanName`, `PlanCheck`, `PriceTag`, …)
- `Plans.js` — state, the mobile plan tabs, and composition

No behavior change. The semantic markup and mobile tabs from #2174 are preserved: `PLAN_TABS`, `planDisplay`, `panel-free`/`panel-pro`/`panel-enterprise`, the `Pricing plans` toggle label, and the named check icon.

Also drops a stale comment in `PricePicker.js`.

`npm test` — lint clean, 299 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLN7v4vgJssmycKyq7MAh4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly file moves and shared utilities; Stripe checkout still uses the same plan IDs from PricePicker, and the PR description reports tests passing with no intended UX change.
> 
> **Overview**
> **Refactors the pricing Plans UI** by breaking the large `Plans.js` module into **Free**, **Pro**, and **Enterprise** card components, a **`PlansFooter`**, and a **`shared.js`** module for cards, checks, price display, and currency helpers. `Plans.js` now only handles mobile tab state and composes those pieces.
> 
> **`PricePicker`** plan math is simplified: monthly totals are built via `createPlanFromMonthly` / `createPlanFromDaily`, plans expose a numeric **`reqsPerMonthTotal`** (used for per-1k pricing in **`ProPlanCard`** instead of parsing the formatted string), and slider tick positions are precomputed. A stale comment was removed.
> 
> **`formatCompactNumber`** is added in `helpers/format-number.js` and reused in **Open Source** stats and the plans stats footer. **`pricing.js`** imports `CURRENCIES` and `formatPrice` from **`Plans/shared`** rather than from `Plans`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebdd60a2c0ecd52a40fff60f2825cfcbb9d6b642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated Free, Pro, and Enterprise pricing cards with plan details, feature links, and relevant actions.
  * Added currency-aware Pro pricing and checkout options.
  * Added pricing statistics, comparison links, and improved plan navigation.
* **Improvements**
  * Improved pricing slider calculations and plan display consistency.
  * Standardized compact number formatting across pricing and open-source metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->