### PR TITLE
fix(typography): shrink mobile Heading/Subhead scale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,8 @@ The typography components own their size. Compose pages from them; do not restyl
 
 | Component | Tag | Size (mobile → desktop) | Role |
 | --- | --- | --- | --- |
-| `Heading` | `h1` | 52 → 64 | Page title (gradient) |
-| `Subhead` | `h2` | 52 | Section title |
+| `Heading` | `h1` | 36 → 52 → 64 | Page title (gradient) |
+| `Subhead` | `h2` | 28 → 52 | Section title |
 | `Caption` | `h3` | 20 → 28 | Section/hero supporting text (the lead under a heading) |
 | `Text` | `div`/`p` | 16 → 20 | Body copy, card/inline text, meta lines |
 | `Caps` | `span` | 16 | Uppercase micro-labels |

--- a/src/components/elements/Heading.js
+++ b/src/components/elements/Heading.js
@@ -16,7 +16,7 @@ const StyledHeading = styled(Text)(
   theme({
     ...commonHeadingStyles,
     textWrap: 'balance',
-    fontSize: [4, 4, 5, 5]
+    fontSize: ['36px', 4, 5, 5]
   })
 )
 

--- a/src/components/elements/Subhead.js
+++ b/src/components/elements/Subhead.js
@@ -8,7 +8,7 @@ const StyledSubhead = styled(Text)(
   theme({
     ...commonHeadingStyles,
     textWrap: 'balance',
-    fontSize: 4
+    fontSize: [3, 4, 4, 4]
   })
 )
 

--- a/src/components/pages/home/analytics.js
+++ b/src/components/pages/home/analytics.js
@@ -15,7 +15,7 @@ import analyticsData from '../../../../data/analytics.json'
 
 const GLOBE_SRC = '/images/globe.webp'
 
-const FAST_TITLE_FONT_SIZE = 'clamp(64px, 12vw, 128px)'
+const FAST_TITLE_FONT_SIZE = 'clamp(28px, 12vw, 128px)'
 
 const [{ reqs_pretty: reqsPretty, bytes_pretty: bytesPretty }] = analyticsData
 


### PR DESCRIPTION
## Summary
- Scale mobile `Heading` to 36px and `Subhead` to 28px (&lt;600px), keeping 52/64 from tablet up
- Lower the “Fast anywhere” clamp floor so the decorative title isn’t clipped on phones
- Update the typography size table in `CLAUDE.md` / `AGENTS.md`

## Test plan
- [ ] Homepage on ~390px width: “Build features, not infrastructure” wraps without an orphaned `e`
- [ ] Hero `Heading` reads larger than section `Subhead`s on mobile
- [ ] “Fast anywhere” fully visible (not cropped at the edges)
- [ ] ≥600px / desktop: Heading/Subhead sizes unchanged (52 / 64)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive typography for headings and subheadings across screen sizes.
  * Updated heading sizing for more consistent visual hierarchy.
  * Added responsive scaling to subheadings for improved readability.
  * Reduced the minimum size of the analytics page’s “Fast anywhere” title on smaller screens, improving layout and legibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->