### PR TITLE
fix(blog): defer TimeAgo until after hydration

### DIFF
--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -6,6 +6,7 @@ import Box from 'components/elements/Box'
 import { PostFooter } from 'components/pages/blog/post-footer'
 import { PostTitle } from 'components/pages/blog/post-title'
 import { PostAuthor } from 'components/pages/blog/post-author'
+import { useMounted } from 'components/hook/use-mounted'
 import Layout from 'components/patterns/Layout'
 import Markdown, { H1, H2 } from 'components/markdown'
 import { textGradient, layout, theme } from 'theme'
@@ -23,6 +24,7 @@ const PageTemplate = ({
   content,
   lastEdited
 }) => {
+  const mounted = useMounted()
   const authorList = Array.isArray(authors) ? authors : []
   return (
     <Layout>
@@ -70,7 +72,13 @@ const PageTemplate = ({
                   color: 'black60'
                 })}
               >
-                {formatDate(date)} (<TimeAgo date={date} />)
+                {formatDate(date)}
+                {mounted && (
+                  <>
+                    {' '}
+                    (<TimeAgo date={date} />)
+                  </>
+                )}
               </Text>
             </Choose.When>
             <Choose.Otherwise>


### PR DESCRIPTION
## Summary
- Blog bylines SSR a `react-timeago` relative string that drifts from the client clock (e.g. “15 hours ago” vs “16 hours ago”), causing React hydration errors #425/#418/#423 on recent posts.
- Render `TimeAgo` only after mount via `useMounted`, keeping the absolute `formatDate` for SSR.

## Test plan
- [ ] Open https://microlink.io/blog/brand-logos-are-hiding-in-dns (or local production build) and confirm DevTools has no React #425/#418/#423
- [ ] Confirm byline still shows `August 4, 2026 (… ago)` after hydration
- [ ] Spot-check an older post (stable relative string) still looks correct


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date and relative-time display consistency when loading pages.
  * Ensured formatted dates appear immediately, with relative times shown once the page is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->