### PR TITLE
fix: only label real docs paths as markdown

### DIFF
--- a/test/markdown-routes.js
+++ b/test/markdown-routes.js
@@ -1,0 +1,57 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+const VERCEL_CONFIG = path.join(process.cwd(), 'vercel.json')
+const DOCS_DIR = path.join(process.cwd(), 'src/content/docs')
+
+const { headers } = JSON.parse(fs.readFileSync(VERCEL_CONFIG, 'utf8'))
+
+const markdownRule = headers.find(({ headers }) =>
+  headers.some(
+    ({ key, value }) =>
+      key === 'content-type' && value.startsWith('text/markdown')
+  )
+)
+
+const matchesRule = pathname =>
+  new RegExp(`^${markdownRule.source}$`).test(pathname)
+
+const toMarkdownPathname = file =>
+  `/docs/${file.replace(/\.md$/, '').replace(/\/?index$/, '')}`.replace(
+    /\/$/,
+    ''
+  ) + '.md'
+
+const docsMarkdownPathnames = fs
+  .readdirSync(DOCS_DIR, { recursive: true })
+  .filter(entry => entry.endsWith('.md'))
+  .map(entry => entry.split(path.sep).join('/'))
+  .map(toMarkdownPathname)
+
+const NON_DOCS_PATHNAMES = [
+  '/screenshot/php.md',
+  '/screenshot.md',
+  '/pricing.md',
+  '/index.md',
+  '/blog/some-post.md'
+]
+
+describe('markdown content-type header', () => {
+  test('is declared', () => {
+    expect(markdownRule).toBeDefined()
+  })
+
+  test('covers every generated docs markdown file', () => {
+    expect(docsMarkdownPathnames.length).toBeGreaterThan(0)
+    for (const pathname of docsMarkdownPathnames) {
+      expect(matchesRule(pathname), pathname).toBe(true)
+    }
+  })
+
+  test('never labels a page without a markdown file as markdown', () => {
+    for (const pathname of NON_DOCS_PATHNAMES) {
+      expect(matchesRule(pathname), pathname).toBe(false)
+    }
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -47,7 +47,7 @@
       ]
     },
     {
-      "source": "/(.*)\\.md",
+      "source": "/docs/(.*)\\.md",
       "headers": [
         {
           "key": "content-type",


### PR DESCRIPTION
## Problem

`https://microlink.io/screenshot/php.md` returns the 404 HTML page with `content-type: text/markdown; charset=utf-8`.

```
$ curl -sI https://microlink.io/screenshot/php.md
HTTP/2 404
content-type: text/markdown; charset=utf-8

body → <!DOCTYPE html>… "Page not found — Microlink"
```

Vercel header rules match on path pattern only, never on the filesystem. The rule at `vercel.json:50` used `/(.*)\.md`, so *any* guessed `.md` path got stamped as markdown — including every path with no file behind it. Anything fetching a `.md` URL (agents, LLM clients, the `View as Markdown` links) receives HTML labeled as markdown instead of a clean 404.

## Fix

Markdown files are generated only for docs pages (`gatsby-node.js:483` filters `allMdx` by `slug: { regex: "//docs//" }`). Verified the output matches: 180 sources in `src/content/docs`, 180 `.md` files in `public`, all under `public/docs/`.

Narrowing the header source to `/docs/(.*)\.md` makes the rule cover exactly the files that exist. `/screenshot/php.md` now 404s as `text/html`.

## Test

`test/markdown-routes.js` asserts the rule matches all 180 docs pathnames and none of `/screenshot/php.md`, `/screenshot.md`, `/pricing.md`, `/index.md`, `/blog/some-post.md`. Mutation-checked: restoring `/(.*)\.md` fails it with `/screenshot/php.md: expected true to be false`.

Suite is green apart from a pre-existing `test/helpers/email-url.js` snapshot that pins `Node.js/24` (fails on Node 26, unrelated — confirmed by stashing this branch's changes).

## Out of scope

Two related issues found while testing, not touched here:

- The Accept-header rewrite at `vercel.json:414-425` never fires. Vercel runs rewrites *after* the filesystem check and Gatsby already emits `/docs/**/index.html`, so `curl -H "accept: text/markdown" …/docs/api/getting-started/overview` returns `200 text/html`.
- `data-exclude-from-llms` at `src/templates/doc.js:133` is not honored by the markdown converter — the "Copy for LLM" and "View as Markdown" links appear in the published `.md` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaByohbhmNdDtwpXVJZkx6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deployment header routing change with regression tests; no auth, data, or business logic impact.
> 
> **Overview**
> Fixes incorrect **`text/markdown`** headers on paths that have no markdown file (e.g. `/screenshot/php.md` 404 HTML served as markdown).
> 
> The Vercel header rule source changes from **`/(.*)\.md`** to **`/docs/(.*)\.md`**, aligning with generated docs markdown only under `/docs/`. Non-docs `.md` guesses now get normal **`text/html`** 404 responses.
> 
> Adds **`test/markdown-routes.js`** to assert the rule matches every docs `.md` pathname derived from `src/content/docs` and does not match representative non-docs paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca164d3ae18df0a6ade4c95726a68c6dc5d12b7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted the Markdown content type header to documentation pages only.
  * Prevented unrelated Markdown paths from receiving documentation-specific headers.

* **Tests**
  * Added coverage to verify the header rule matches all generated documentation Markdown paths.
  * Added checks confirming non-documentation paths are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->