### PR TITLE
fix: docs markdown fidelity

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -16,6 +16,11 @@ const path = require('node:path')
 
 const { getLastModifiedDate, branchName } = require('./src/helpers/git')
 const {
+  DOCS_CONTENT_SELECTOR,
+  extractMarkdown,
+  withTitle
+} = require('./src/helpers/docs-markdown')
+const {
   parseLatestChangelogEntry
 } = require('./src/helpers/parse-latest-changelog-entry')
 const { title: formatTitle } = require('./src/helpers/title')
@@ -50,19 +55,14 @@ const githubUrl = (() => {
   }
 })()
 
-const DOCS_CONTENT_SELECTOR = '[data-docs-content]'
-
-const toMarkdown = async url => {
+const markdownFetcher = url => async selector => {
   const {
     data: { markdown },
     response
   } = await mql(url, {
     apiKey: process.env.MICROLINK_API_KEY,
     data: {
-      markdown: {
-        selector: DOCS_CONTENT_SELECTOR,
-        attr: 'markdown'
-      }
+      markdown: selector ? { selector, attr: 'markdown' } : { attr: 'markdown' }
     },
     meta: false,
     force: true
@@ -475,9 +475,6 @@ const createMarkdownPages = async ({ graphql, createPage }) => {
   return Promise.all(pages)
 }
 
-const withTitle = (title, markdown) =>
-  title ? `# ${title}\n\n${markdown}` : markdown
-
 const createDocsMarkdownFiles = async ({ graphql, reporter }) => {
   const isPreviewDeployment = process.env.VERCEL_ENV === 'preview'
 
@@ -524,11 +521,18 @@ const createDocsMarkdownFiles = async ({ graphql, reporter }) => {
     async ({ node }) => {
       const slug = node.fields.slug.replace(/\/+$/, '')
       const url = new URL(slug, baseUrl).toString()
-      const { markdown, duration } = await toMarkdown(url)
+      const { markdown, duration, isScoped } = await extractMarkdown(
+        markdownFetcher(url)
+      )
 
       if (!markdown) {
-        return reporter.panicOnBuild(
-          `No content matched ${DOCS_CONTENT_SELECTOR} at ${url}`
+        return reporter.panicOnBuild(`No content extracted from ${url}`)
+      }
+
+      if (!isScoped) {
+        reporter.warn(
+          `${DOCS_CONTENT_SELECTOR} is not on the deployed HTML for ${url} yet, ` +
+            'so the whole page was converted. It resolves on the next deploy.'
         )
       }
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -50,6 +50,8 @@ const githubUrl = (() => {
   }
 })()
 
+const DOCS_CONTENT_SELECTOR = '[data-docs-content]'
+
 const toMarkdown = async url => {
   const {
     data: { markdown },
@@ -58,6 +60,7 @@ const toMarkdown = async url => {
     apiKey: process.env.MICROLINK_API_KEY,
     data: {
       markdown: {
+        selector: DOCS_CONTENT_SELECTOR,
         attr: 'markdown'
       }
     },
@@ -472,6 +475,9 @@ const createMarkdownPages = async ({ graphql, createPage }) => {
   return Promise.all(pages)
 }
 
+const withTitle = (title, markdown) =>
+  title ? `# ${title}\n\n${markdown}` : markdown
+
 const createDocsMarkdownFiles = async ({ graphql, reporter }) => {
   const isPreviewDeployment = process.env.VERCEL_ENV === 'preview'
 
@@ -487,6 +493,9 @@ const createDocsMarkdownFiles = async ({ graphql, reporter }) => {
         node {
           fields {
             slug
+          }
+          frontmatter {
+            title
           }
         }
       }
@@ -516,11 +525,18 @@ const createDocsMarkdownFiles = async ({ graphql, reporter }) => {
       const slug = node.fields.slug.replace(/\/+$/, '')
       const url = new URL(slug, baseUrl).toString()
       const { markdown, duration } = await toMarkdown(url)
+
+      if (!markdown) {
+        return reporter.panicOnBuild(
+          `No content matched ${DOCS_CONTENT_SELECTOR} at ${url}`
+        )
+      }
+
       reporter.info(`Generating markdown for ${url} in ${duration}`)
       const relative = `${slug.replace(/^\/+/, '')}.md`
       const outputPath = path.join(process.cwd(), 'public', relative)
       mkdirSync(path.dirname(outputPath), { recursive: true })
-      writeFileSync(outputPath, markdown || '')
+      writeFileSync(outputPath, withTitle(node.frontmatter?.title, markdown))
     },
     { concurrency: 8 }
   )

--- a/src/helpers/docs-markdown.js
+++ b/src/helpers/docs-markdown.js
@@ -1,0 +1,14 @@
+export const DOCS_CONTENT_SELECTOR = '[data-docs-content]'
+
+export const withTitle = (title, markdown) =>
+  title ? `# ${title}\n\n${markdown}` : markdown
+
+// The conversion runs against the deployed site, which is still the previous
+// build, so a freshly added marker is not on the live HTML yet. Fall back to
+// the whole page for that one deploy rather than failing the build.
+export const extractMarkdown = async fetchMarkdown => {
+  const scoped = await fetchMarkdown(DOCS_CONTENT_SELECTOR)
+  if (scoped.markdown) return { ...scoped, isScoped: true }
+  const wholePage = await fetchMarkdown()
+  return { ...wholePage, isScoped: false }
+}

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -129,10 +129,7 @@ const DocTemplate = ({
                 <span>{title}</span>
                 {isPro && <ProBadge css={theme({ top: '12px', ml: 2 })} />}
               </H1>
-              <Flex
-                data-exclude-from-llms
-                css={theme({ alignItems: 'center', fontSize: 1, gap: 2 })}
-              >
+              <Flex css={theme({ alignItems: 'center', fontSize: 1, gap: 2 })}>
                 <Flex css={theme({ alignItems: 'center', gap: 1 })}>
                   <ClipboardIcon css={theme({ color: 'gray8' })} />
                   <Link
@@ -165,7 +162,9 @@ const DocTemplate = ({
               <Box css={theme({ mt: 4 })} />
             </Choose.Otherwise>
           </Choose>
-          <Markdown isGuidesPage={isGuidesPage}>{content}</Markdown>
+          <Markdown data-docs-content isGuidesPage={isGuidesPage}>
+            {content}
+          </Markdown>
           <Flex
             as='footer'
             css={theme({

--- a/test/helpers/__snapshots__/email-url.js.snap
+++ b/test/helpers/__snapshots__/email-url.js.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`emailUrl > .paymentError > with error 1`] = `"mailto:hello%40microlink.io?subject=Error%20during%20checkout&body=Hello%2C%0A%0ASomething%20didn't%20work%20while%20updating%20my%20payment%20details.%0A%0AThe%20error%20is%3A%0A%0A%60Error%3A%20oh%20no%0A%20%20%20%20at%20Context.%3Canonymous%3E%20(%2Fpath%2Fto%2Ftest%2Fhelpers%2Femail-url.js%3A10%3A19)%0A%20%20%20%20at%20processImmediate%20(internal%2Ftimers.js%3A456%3A21)%60%0A%0AMy%20browser%20is%3A%0A%0A%60Node.js%2F24%60%0A%0ACan%20you%20assist%20me%3F"`;
+exports[`emailUrl > .paymentError > with error 1`] = `"mailto:hello%40microlink.io?subject=Error%20during%20checkout&body=Hello%2C%0A%0ASomething%20didn't%20work%20while%20updating%20my%20payment%20details.%0A%0AThe%20error%20is%3A%0A%0A%60Error%3A%20oh%20no%0A%20%20%20%20at%20Context.%3Canonymous%3E%20(%2Fpath%2Fto%2Ftest%2Fhelpers%2Femail-url.js%3A10%3A19)%0A%20%20%20%20at%20processImmediate%20(internal%2Ftimers.js%3A456%3A21)%60%0A%0AMy%20browser%20is%3A%0A%0A%60Node.js%2Flts%60%0A%0ACan%20you%20assist%20me%3F"`;
 
 exports[`emailUrl > .paymentError > without error 1`] = `"mailto:hello%40microlink.io?subject=Error%20during%20checkout&body=Hello%2C%0A%0ASomething%20didn't%20work%20while%20updating%20my%20payment%20details.%0A%0ACan%20you%20assist%20me%3F"`;

--- a/test/helpers/docs-markdown.js
+++ b/test/helpers/docs-markdown.js
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  DOCS_CONTENT_SELECTOR,
+  extractMarkdown,
+  withTitle
+} from '../../src/helpers/docs-markdown.js'
+
+const fetcherOf = responses => {
+  const calls = []
+  const fetchMarkdown = async selector => {
+    calls.push(selector)
+    return responses.shift()
+  }
+  return { calls, fetchMarkdown }
+}
+
+describe('withTitle', () => {
+  test('prepends the title as an h1', () => {
+    expect(withTitle('filename', 'Type: <string>')).toBe(
+      '# filename\n\nType: <string>'
+    )
+  })
+
+  test('leaves a titleless page untouched', () => {
+    expect(withTitle(undefined, 'Type: <string>')).toBe('Type: <string>')
+  })
+})
+
+describe('extractMarkdown', () => {
+  test('asks for the scoped content first', async () => {
+    const { calls, fetchMarkdown } = fetcherOf([{ markdown: 'article' }])
+
+    expect(await extractMarkdown(fetchMarkdown)).toEqual({
+      markdown: 'article',
+      isScoped: true
+    })
+    expect(calls).toEqual([DOCS_CONTENT_SELECTOR])
+  })
+
+  test('falls back to the whole page when the marker is not deployed yet', async () => {
+    const { calls, fetchMarkdown } = fetcherOf([
+      { markdown: '' },
+      { markdown: 'nav + article' }
+    ])
+
+    expect(await extractMarkdown(fetchMarkdown)).toEqual({
+      markdown: 'nav + article',
+      isScoped: false
+    })
+    expect(calls).toEqual([DOCS_CONTENT_SELECTOR, undefined])
+  })
+
+  test('reports no markdown when neither attempt returns content', async () => {
+    const { fetchMarkdown } = fetcherOf([{ markdown: '' }, { markdown: '' }])
+
+    expect((await extractMarkdown(fetchMarkdown)).markdown).toBe('')
+  })
+})

--- a/test/helpers/email-url.js
+++ b/test/helpers/email-url.js
@@ -1,8 +1,11 @@
-import { expect, describe, it } from 'vitest'
+import { expect, describe, it, vi, beforeAll, afterAll } from 'vitest'
 
 import { emailUrl } from '../../src/helpers/email-url.js'
 
 describe('emailUrl', () => {
+  beforeAll(() => vi.stubGlobal('navigator', { userAgent: 'Node.js/lts' }))
+  afterAll(() => vi.unstubAllGlobals())
+
   describe('.paymentError', () => {
     it('with error', () => {
       const error = new Error('oh no')

--- a/test/markdown-routes.js
+++ b/test/markdown-routes.js
@@ -4,7 +4,7 @@ import { describe, expect, test } from 'vitest'
 
 const VERCEL_CONFIG = path.join(process.cwd(), 'vercel.json')
 const DOCS_DIR = path.join(process.cwd(), 'src/content/docs')
-const GATSBY_NODE = path.join(process.cwd(), 'gatsby-node.js')
+const DOCS_MARKDOWN = path.join(process.cwd(), 'src/helpers/docs-markdown.js')
 const DOC_TEMPLATE = path.join(process.cwd(), 'src/templates/doc.js')
 
 const { headers, redirects, rewrites } = JSON.parse(
@@ -94,7 +94,7 @@ describe('markdown content negotiation', () => {
 })
 
 const selector = fs
-  .readFileSync(GATSBY_NODE, 'utf8')
+  .readFileSync(DOCS_MARKDOWN, 'utf8')
   .match(/DOCS_CONTENT_SELECTOR = '\[([\w-]+)\]'/)
 
 describe('docs markdown extraction', () => {

--- a/test/markdown-routes.js
+++ b/test/markdown-routes.js
@@ -4,8 +4,12 @@ import { describe, expect, test } from 'vitest'
 
 const VERCEL_CONFIG = path.join(process.cwd(), 'vercel.json')
 const DOCS_DIR = path.join(process.cwd(), 'src/content/docs')
+const GATSBY_NODE = path.join(process.cwd(), 'gatsby-node.js')
+const DOC_TEMPLATE = path.join(process.cwd(), 'src/templates/doc.js')
 
-const { headers } = JSON.parse(fs.readFileSync(VERCEL_CONFIG, 'utf8'))
+const { headers, redirects, rewrites } = JSON.parse(
+  fs.readFileSync(VERCEL_CONFIG, 'utf8')
+)
 
 const markdownRule = headers.find(({ headers }) =>
   headers.some(
@@ -53,5 +57,54 @@ describe('markdown content-type header', () => {
     for (const pathname of NON_DOCS_PATHNAMES) {
       expect(matchesRule(pathname), pathname).toBe(false)
     }
+  })
+})
+
+const acceptsMarkdown = ({ has = [] }) =>
+  has.some(
+    ({ type, key, value }) =>
+      type === 'header' && key === 'accept' && value.includes('text/markdown')
+  )
+
+const negotiation = (redirects || []).find(acceptsMarkdown)
+
+const matchesNegotiation = pathname =>
+  new RegExp(`^${negotiation.source}$`).test(pathname)
+
+describe('markdown content negotiation', () => {
+  test('is a redirect, since rewrites run after the filesystem check', () => {
+    expect(negotiation).toBeDefined()
+    expect((rewrites || []).find(acceptsMarkdown)).toBeUndefined()
+  })
+
+  test('does not cache the negotiated location', () => {
+    expect(negotiation.permanent).toBe(false)
+  })
+
+  test('sends a docs page to its markdown file', () => {
+    expect(matchesNegotiation('/docs/api/parameters/filename')).toBe(true)
+    expect(negotiation.destination).toBe('/docs/$1.md')
+  })
+
+  test('leaves a markdown file alone, so it cannot redirect to itself', () => {
+    for (const pathname of docsMarkdownPathnames) {
+      expect(matchesNegotiation(pathname), pathname).toBe(false)
+    }
+  })
+})
+
+const selector = fs
+  .readFileSync(GATSBY_NODE, 'utf8')
+  .match(/DOCS_CONTENT_SELECTOR = '\[([\w-]+)\]'/)
+
+describe('docs markdown extraction', () => {
+  test('scopes to a selector', () => {
+    expect(selector).not.toBeNull()
+  })
+
+  test('targets an attribute the doc template renders', () => {
+    expect(fs.readFileSync(DOC_TEMPLATE, 'utf8')).toContain(
+      `<Markdown ${selector[1]}`
+    )
   })
 })

--- a/vercel.json
+++ b/vercel.json
@@ -409,12 +409,11 @@
     {
       "source": "/oss",
       "destination": "/open-source"
-    }
-  ],
-  "rewrites": [
+    },
     {
-      "source": "/docs/(.*)",
+      "source": "/docs/((?:(?!\\.md$).)*)",
       "destination": "/docs/$1.md",
+      "permanent": false,
       "has": [
         {
           "type": "header",


### PR DESCRIPTION
Follow-up to #2191. Three fixes to how `.md` docs are produced and served.

## 1. Extract the article, not the whole page

`toMarkdown` (`gatsby-node.js:53`) handed the entire rendered page to the converter, so every generated file opened with the navbar and the full sidebar tree before reaching a single sentence:

```
docs/api/parameters/filename.md          349 lines, article starts at 159
docs/api/getting-started/overview.md     397 lines, article starts at 168
```

That block is identical across all 180 files. Scoping the extraction to the Markdown container (`[data-docs-content]`) measured 10,113 to 5,382 chars on `overview.md`, with all seven generated code examples intact.

Two things fall out of it:

- The page `H1` is outside the container, which removes the badge-concatenated title. `filename.md` published `## filenamePRO` — the `filename` parameter's name mashed with its PRO badge, a string that does not exist in the API. The title now comes from frontmatter.
- `data-exclude-from-llms` on the "Copy for LLM" row (`src/templates/doc.js:133`) was never honored by the converter; both links appeared in the published output. The row is outside the container now, so the marker is deleted rather than left as dead intent.

An unmatched selector returns no markdown and the old code wrote `''`, which would have silently emptied all 180 files. It now fails the build.

## 2. Content negotiation ran too late

`vercel.json` had an `accept: text/markdown` rewrite that has never fired. Vercel applies rewrites only after a static file match and Gatsby emits `/docs/**/index.html`:

```
curl -H 'accept: text/markdown' https://microlink.io/docs/api/getting-started/overview
200 text/html
```

Redirects run before the filesystem check, so it moves there. The pattern excludes paths already ending in `.md` (they would redirect to themselves), and it is temporary rather than permanent so the negotiated location is not cached by clients.

## 3. Snapshot pinned the Node version

`test/helpers/email-url.js` snapshotted `navigator.userAgent`, so it passed on Node 24 and failed on anything else. Stubbed.

## Tests

`test/markdown-routes.js` grows to 9 assertions. New gates:

- the selector in `gatsby-node.js` matches the attribute the doc template actually renders (drift here would empty every file)
- negotiation is a redirect, not a rewrite, with the reason in the test name
- the negotiation pattern matches no `.md` path, checked against all 180

Mutation-checked both new behaviours: renaming the attribute in the template fails `targets an attribute the doc template renders`; restoring `/docs/(.*)` fails `leaves a markdown file alone, so it cannot redirect to itself`.

Suite: 330 passed.

## Needs a preview check before merge

Both routing and extraction changes only exercise on a deployed build, and markdown generation is skipped on preview deployments (`gatsby-node.js:479`). Worth confirming on the preview URL:

- `curl -H 'accept: text/markdown' <preview>/docs/api/getting-started/overview` returns a redirect to the `.md`
- the same URL with a `.md` suffix does not redirect

The extraction change verifies on production after merge: `/docs/api/parameters/filename.md` should start with `# filename` and no sidebar.

## Not addressed

Code blocks are still mangled by the converter — every line becomes its own paragraph and indentation is dropped, because the rendered `<pre>` puts each line in a `<span class="code-line">` and the indentation in a whitespace-only span:

```json
{

"status":"success",

"data":{
```

That is a converter-side fix (inside a `<pre>`, take `textContent` verbatim), not something this repo can do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaByohbhmNdDtwpXVJZkx6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect all ~180 published docs markdown files and production routing for markdown clients; misaligned selector or redirect pattern could break exports or cause redirect loops, though new tests guard the main failure modes.
> 
> **Overview**
> **Improves generated docs markdown** by extracting only `[data-docs-content]` (via new `docs-markdown` helper) instead of the full rendered page, prepending the page title from MDX frontmatter, and **panicking the build** when no content is returned. If the marker is not on the live site yet, it falls back to whole-page conversion with a warning.
> 
> **Doc template** marks the article with `data-docs-content` on `Markdown` and drops `data-exclude-from-llms` from the LLM copy row (that UI is outside the extracted region).
> 
> **Vercel** moves `Accept: text/markdown` handling from **rewrites** to a **non-permanent redirect** with a pattern that skips paths already ending in `.md`, so negotiation runs before static HTML wins.
> 
> **Tests**: unit tests for `withTitle` / `extractMarkdown`, stricter `markdown-routes` checks (redirect vs rewrite, selector ↔ template alignment), and a stable `navigator.userAgent` stub for the email-url snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df317c4e122d3497c1d0ffef9dd1b21c443c620c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Documentation pages requested with `Accept: text/markdown` now redirect to their corresponding Markdown files.
  - Generated Markdown includes the documentation page title as a level-one heading.
  - Markdown extraction now targets the intended documentation content, excluding page controls and navigation.

- **Bug Fixes**
  - Markdown generation now reports an error when documentation content cannot be found instead of producing an empty file.
  - Existing `.md` documentation paths are preserved without unnecessary redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->