### PR TITLE
chore: add code examples on the sdk methods

### DIFF
--- a/src/content/docs/sdk/getting-started/options.md
+++ b/src/content/docs/sdk/getting-started/options.md
@@ -1,13 +1,13 @@
 ---
 title: 'Options'
-description: 'Learn how the Microlink SDK routes options. Product-specific keys nest automatically, headers travel as HTTP headers, and everything else maps to API query parameters.'
+description: 'How the Microlink SDK routes options, plus the shared options every method accepts: browser emulation, page lifecycle, cache, and request controls.'
 ---
 
 Every method accepts an options object as its last argument. Its keys are routed automatically so you never have to remember how the underlying API call is shaped:
 
-- **Product-specific keys** — such as `fullPage` for screenshot, `format` for pdf, or `selector` for markdown — are nested under the right product parameter.
+- **Method-specific keys** — such as `fullPage` for screenshot, `format` for pdf, or `selector` for markdown — are nested under the right product parameter. Each [method page](/docs/sdk/getting-started/overview#methods) lists its own keys.
 - **`headers`** — sent as HTTP request headers, never serialized into the URL.
-- **Everything else** — passed through as top-level [API query parameters](/docs/api/getting-started/overview).
+- **Everything else** — passed through as top-level API query parameters. The useful ones are listed below.
 
 ```js
 const { url } = await microlink.screenshot('https://example.com', {
@@ -17,6 +17,91 @@ const { url } = await microlink.screenshot('https://example.com', {
 ```
 
 Here `fullPage` nests under [`screenshot`](/docs/api/parameters/screenshot) while `device` stays a top-level [query parameter](/docs/api/parameters/device).
+
+## Shared options
+
+Any method can combine its own keys with these. They control the browser session, the page lifecycle, and the cache behind every call.
+
+### Browser
+
+- [device](/docs/api/parameters/device) `<string>` — emulates a device preset: viewport, user agent, and capabilities (default: `'macbook pro 13'`).
+- [viewport](/docs/api/parameters/viewport) `<object>` — sets the browser visible area and device capabilities directly.
+- [colorScheme](/docs/api/parameters/colorScheme) `<string>` — sets the CSS color scheme preference: `'light'`, `'dark'`, or `'no-preference'` (default).
+- [mediaType](/docs/api/parameters/mediaType) `<string>` — sets the CSS media type, e.g. `'print'` (default: `'screen'`).
+- [javascript](/docs/api/parameters/javascript) `<boolean>` — enables or disables JavaScript execution in the page (default: `true`).
+- [animations](/docs/api/parameters/animations) `<boolean>` — enables or disables CSS animations and transitions (default: `false`).
+- [adblock](/docs/api/parameters/adblock) `<boolean>` — blocks ads, trackers, and cookie consent services (default: `true`).
+
+A retina-density mobile capture in dark mode:
+
+```js
+const { url } = await microlink.screenshot('https://example.com', {
+  colorScheme: 'dark',
+  viewport: {
+    width: 640,
+    height: 400,
+    deviceScaleFactor: 2,
+    isMobile: true
+  }
+})
+```
+
+### Page
+
+- [prerender](/docs/api/parameters/prerender) `<boolean> | <string>` — controls whether the content is fetched with a headless browser (default: `'auto'`).
+- [waitForSelector](/docs/api/parameters/waitForSelector) `<string>` — waits until the element matching the CSS selector appears.
+- [waitForTimeout](/docs/api/parameters/waitForTimeout) `<string> | <number>` — waits a fixed amount of time before processing the content.
+- [waitUntil](/docs/api/parameters/waitUntil) `<string> | <string[]>` — the browser lifecycle events to wait for (default: `'auto'`).
+- [click](/docs/api/parameters/click) `<string> | <string[]>` — clicks the elements matching the CSS selectors.
+- [scroll](/docs/api/parameters/scroll) `<string>` — scrolls to the element matching the CSS selector.
+- [scripts](/docs/api/parameters/scripts) `<string> | <string[]>` — injects scripts into the page, as code or URLs.
+- [styles](/docs/api/parameters/styles) `<string> | <string[]>` — injects styles into the page, as CSS rules or URLs.
+- [modules](/docs/api/parameters/modules) `<string> | <string[]>` — injects ES modules into the page.
+
+Dismiss a consent dialog, hide the promo banner, and wait for the chart to render before capturing:
+
+```js
+const { url } = await microlink.screenshot('https://example.com/dashboard', {
+  click: '.cookie-accept',
+  styles: ['.promo-banner { display: none }'],
+  waitForSelector: '.chart'
+})
+```
+
+### Cache
+
+- [ttl](/docs/api/parameters/ttl) `<string> | <number>` — how long the response stays cached (default: `'24h'`).
+- [staleTtl](/docs/api/parameters/staleTtl) `<string> | <number> | <boolean>` — serves a stale copy while a fresh one regenerates in the background (default: `false`).
+- [force](/docs/api/parameters/force) `<boolean>` — bypasses the cache to get a fresh copy (default: `false`).
+- [cacheKey](/docs/api/parameters/cacheKey) `<string>` — extends the cache key with a custom identifier.
+
+Cache for a week, serving stale copies instantly while a fresh one regenerates behind the scenes:
+
+```js
+const metadata = await microlink.metadata('https://example.com', {
+  ttl: '7d',
+  staleTtl: '1d'
+})
+```
+
+### Request
+
+- [timeout](/docs/api/parameters/timeout) `<string> | <number>` — the maximum time allowed for the request lifecycle (default: `'28s'`).
+- [retry](/docs/api/parameters/retry) `<number>` — how many retries to perform under an internal browser error (default: `2`).
+- [proxy](/docs/api/parameters/proxy) `<string> | <object>` — resolves any sub-request through an HTTP proxy server.
+- [filename](/docs/api/parameters/filename) `<string>` — the filename associated with a generated asset.
+- [ping](/docs/api/parameters/ping) `<boolean> | <object>` — verifies every URL in the payload is publicly reachable (default: `true`).
+- [palette](/docs/api/parameters/palette) `<boolean>` — adds dominant colors and accessible color pairs to every image field (default: `false`).
+
+Give a slow page more room to render, retry harder, and name the resulting document:
+
+```js
+const { url } = await microlink.pdf('https://example.com/report', {
+  timeout: '60s',
+  retry: 3,
+  filename: 'report.pdf'
+})
+```
 
 ## Headers
 

--- a/src/content/docs/sdk/methods/collections.md
+++ b/src/content/docs/sdk/methods/collections.md
@@ -3,11 +3,18 @@ title: 'Collections'
 description: 'Sweep any page with the Microlink SDK and get every matching resource back as an array: links, images, videos, audios, and email addresses.'
 ---
 
-The collection methods sweep a page and return every matching resource as a deduplicated array of absolute URLs. Use `selectorAll` to scope the sweep to a region of the page.
+The collection methods sweep a page and return every matching resource as a deduplicated array of absolute URLs. Each method ships a sensible default rule — which elements to sweep and which attribute to read — and the same four options override it:
+
+- [selectorAll](/docs/mql/data/selectorAll) `<string> | <string[]>` — the CSS selector(s) whose every match gets swept.
+- [selector](/docs/mql/data/selector) `<string>` — sweeps only the first element matching the CSS selector.
+- [attr](/docs/mql/data/attr) `<string>` — the attribute read from each matched element.
+- [type](/docs/mql/data/type) `<string>` — how each value is validated and normalized, e.g. `'url'` or `'email'`.
+
+Any [shared option](/docs/sdk/getting-started/options) applies too — `prerender`, `waitForSelector`, and friends.
 
 ## links
 
-Matching hrefs as absolute, deduped URLs:
+Sweeps every `a` element and returns each `href` as an absolute, deduped URL. Scope it with `selectorAll`:
 
 ```js
 const links = await microlink.links('https://example.com', {
@@ -17,15 +24,24 @@ const links = await microlink.links('https://example.com', {
 
 ## images
 
-Image assets collected from the page:
+Sweeps every `img` element and returns each `src`:
 
 ```js
 const images = await microlink.images('https://example.com')
 ```
 
+When a gallery lazy-loads, point `attr` at the attribute carrying the real source:
+
+```js
+const images = await microlink.images('https://example.com/gallery', {
+  selectorAll: 'img[data-src]',
+  attr: 'data-src'
+})
+```
+
 ## videos
 
-Video sources collected from the page:
+Sweeps `video` elements and their `source` children, returning each `src`:
 
 ```js
 const videos = await microlink.videos('https://example.com')
@@ -33,7 +49,7 @@ const videos = await microlink.videos('https://example.com')
 
 ## audios
 
-Audio sources collected from the page:
+Sweeps `audio` elements and their `source` children, returning each `src`:
 
 ```js
 const audios = await microlink.audios('https://example.com')
@@ -41,7 +57,7 @@ const audios = await microlink.audios('https://example.com')
 
 ## emails
 
-Addresses found in `mailto:` links and plain text:
+Scans the whole document — `mailto:` links and plain text — and returns every address found:
 
 ```js
 const emails = await microlink.emails('https://microlink.io')

--- a/src/content/docs/sdk/methods/collections.md
+++ b/src/content/docs/sdk/methods/collections.md
@@ -3,7 +3,7 @@ title: 'Collections'
 description: 'Sweep any page with the Microlink SDK and get every matching resource back as an array: links, images, videos, audios, and email addresses.'
 ---
 
-The collection methods sweep a page and return every matching resource as a deduplicated array of absolute URLs. Each method ships a sensible default rule — which elements to sweep and which attribute to read — and the same four options override it:
+The collection methods sweep a page and return every matching resource as a deduplicated array. `links`, `images`, `videos`, and `audios` resolve their values to absolute URLs; `emails` returns bare address strings. Each method ships a sensible default rule — which elements to sweep and which attribute to read — and the same four options override it:
 
 - [selectorAll](/docs/mql/data/selectorAll) `<string> | <string[]>` — the CSS selector(s) whose every match gets swept.
 - [selector](/docs/mql/data/selector) `<string>` — sweeps only the first element matching the CSS selector.
@@ -57,8 +57,11 @@ const audios = await microlink.audios('https://example.com')
 
 ## emails
 
-Scans the whole document — `mailto:` links and plain text — and returns every address found:
+Scans the whole document — `mailto:` links and plain text — and returns every address found as a bare string, with any `mailto:` prefix stripped:
 
 ```js
 const emails = await microlink.emails('https://microlink.io')
+
+console.log(emails)
+// => ['hello@microlink.io', 'you@domain.com']
 ```

--- a/src/content/docs/sdk/methods/content.md
+++ b/src/content/docs/sdk/methods/content.md
@@ -3,7 +3,7 @@ title: 'Content'
 description: 'Turn any URL into rendered output with the Microlink SDK: unified metadata, Markdown, HTML, plain text, screenshots, PDFs, logos, and embeds.'
 ---
 
-The content methods turn a URL into rendered output — structured data, documents, and hosted assets. Every method follows the same `method(url, options)` shape, and [options are routed automatically](/docs/sdk/getting-started/options).
+The content methods turn a URL into rendered output — structured data, documents, and hosted assets. Every method follows the same `method(url, options)` shape: the options listed under each method nest under the right API parameter automatically, and any [shared option](/docs/sdk/getting-started/options) — `device`, `ttl`, `prerender`, and friends — can ride along with them.
 
 ## metadata
 
@@ -13,11 +13,21 @@ Unified metadata from Open Graph, Twitter Cards, JSON-LD, and HTML:
 const { title, description, image } = await microlink.metadata('https://vercel.com')
 ```
 
+It has no method-specific options, but the shared ones shine here — for instance, [palette](/docs/api/parameters/palette) adds dominant colors and accessible color pairs to every image field:
+
+```js
+const { image } = await microlink.metadata('https://vercel.com', {
+  palette: true
+})
+
+console.log(image.background_color, image.color)
+```
+
 See [data fields](/docs/api/getting-started/data-fields) for everything the response can carry.
 
 ## markdown
 
-The page as clean Markdown, ready for LLM context windows. Use `selector` to scope what gets converted:
+The page as clean Markdown, ready for LLM context windows:
 
 ```js
 const markdown = await microlink.markdown('https://example.com', {
@@ -25,17 +35,25 @@ const markdown = await microlink.markdown('https://example.com', {
 })
 ```
 
+Options:
+
+- [selector](/docs/mql/data/selector) `<string>` — scopes the conversion to the first element matching the CSS selector.
+- [selectorAll](/docs/mql/data/selectorAll) `<string> | <string[]>` — scopes the conversion to every matching element.
+- [type](/docs/mql/data/type) `<string>` — overrides how the extracted value is normalized, per the [MQL rules grammar](/docs/mql/rules/basic).
+
 ## html
 
-Fully rendered HTML, captured after JavaScript runs:
+Fully rendered HTML, captured after JavaScript runs. It takes the same scoping options as [markdown](#markdown):
 
 ```js
-const html = await microlink.html('https://example.com')
+const html = await microlink.html('https://example.com', {
+  selector: 'main'
+})
 ```
 
 ## text
 
-Readable plain text with the markup stripped out:
+Readable plain text with the markup stripped out, with the same scoping options as [markdown](#markdown):
 
 ```js
 const text = await microlink.text('https://example.com')
@@ -51,32 +69,119 @@ const { url } = await microlink.screenshot('https://example.com', {
 })
 ```
 
-Pass `animated: true` to capture the page as an animation, or any other [screenshot parameter](/docs/api/parameters/screenshot) such as `device` emulation or custom styles.
+Options:
+
+- [fullPage](/docs/api/parameters/screenshot/fullPage) `<boolean>` — captures the entire scrollable page instead of the visible viewport (default: `false`).
+- [type](/docs/api/parameters/screenshot/type) `<string>` — the image format, `'png'` or `'jpeg'` (default: `'png'`).
+- [quality](/docs/api/parameters/screenshot/quality) `<number>` — the JPEG compression quality, from `0` to `100`; only applied when type is `'jpeg'` (default: `80`).
+- [element](/docs/api/parameters/screenshot/element) `<string>` — captures only the DOM element matching the CSS selector, waiting for it to be visible.
+- [omitBackground](/docs/api/parameters/screenshot/omitBackground) `<boolean>` — omits the default white background, producing transparent captures (default: `false`).
+- [overlay](/docs/api/parameters/screenshot/overlay) `<object>` — composes the capture over a `browser` frame (`'light'` or `'dark'`) and a `background` color, gradient, or image URL.
+- [codeScheme](/docs/api/parameters/screenshot/codeScheme) `<string>` — syntax-highlights JSON and text responses using a Prism theme or a remote CSS URL (default: `'atom-dark'`).
+- [animated](/docs/api/parameters/screenshot/animated) `<boolean>` — records a short MP4 of the page instead of a static image (default: `false`).
+- `optimizeForSpeed` `<boolean>` — prioritizes capture speed over image size and fidelity (default: `false`).
+
+Capture a single element with a transparent background:
+
+```js
+const { url } = await microlink.screenshot('https://codepen.io/fossheim/full/oNjxrZa', {
+  element: '#result-iframe-wrap',
+  omitBackground: true
+})
+```
+
+Compose a compressed JPEG over a browser frame and a gradient:
+
+```js
+const { url } = await microlink.screenshot('https://www.apple.com/music', {
+  type: 'jpeg',
+  quality: 60,
+  overlay: {
+    browser: 'dark',
+    background: 'linear-gradient(225deg, #FF057C 0%, #8D0B93 50%, #321575 100%)'
+  }
+})
+```
+
+Record the page as a short MP4 — the asset gains an `animated` object pointing to the video:
+
+```js
+const { animated } = await microlink.screenshot(
+  'https://threejs.org/examples/webgl_animation_skinning_blending',
+  { animated: true }
+)
+
+console.log(animated.url)
+```
+
+Shared options compose naturally here: [device](/docs/api/parameters/device) emulation, custom [styles](/docs/api/parameters/styles), or [waitForSelector](/docs/api/parameters/waitForSelector) timing all apply before the capture happens.
 
 ## pdf
 
-Print any URL to PDF with format, margin, and scale control:
+Print any URL to PDF. The result is an asset object pointing to the hosted document:
 
 ```js
 const { url } = await microlink.pdf('https://example.com', { format: 'A4' })
 ```
 
-See the [pdf parameters](/docs/api/parameters/pdf) for every knob.
+Options:
+
+- [format](/docs/api/parameters/pdf/format) `<string>` — the paper format: `'Letter'`, `'Legal'`, `'Tabloid'`, `'Ledger'`, or `'A0'` to `'A6'` (default: `'A4'`).
+- [landscape](/docs/api/parameters/pdf/landscape) `<boolean>` — prints in landscape orientation.
+- [margin](/docs/api/parameters/pdf/margin) `<string> | <object>` — the paper margins, as a unit-labeled value (`'4mm'`) or an object with `top`/`right`/`bottom`/`left` sides (default: `'0.35cm'`).
+- [scale](/docs/api/parameters/pdf/scale) `<number>` — the rendering zoom, between `0.1` and `2` (default: `0.6`).
+- [pageRanges](/docs/api/parameters/pdf/pageRanges) `<string>` — the pages to print, e.g. `'1-5, 8, 11-13'`.
+- [width](/docs/api/parameters/pdf/width) `<string> | <number>` — a custom paper width, accepting unit-labeled values (`'640px'`).
+- [height](/docs/api/parameters/pdf/height) `<string> | <number>` — a custom paper height, accepting unit-labeled values (`'480px'`).
+- `printBackground` `<boolean>` — includes background graphics in the printed output.
+
+Print the first three pages on landscape Letter paper with asymmetric margins:
+
+```js
+const { url } = await microlink.pdf('https://basecamp.com/shapeup/0.3-chapter-01', {
+  format: 'Letter',
+  landscape: true,
+  margin: { top: '1cm', right: '4mm', bottom: '1cm', left: '4mm' },
+  pageRanges: '1-3'
+})
+```
+
+Or drop the standard formats entirely and print onto custom paper:
+
+```js
+const { url } = await microlink.pdf('https://www.raycast.com', {
+  width: '640px',
+  height: '480px',
+  scale: 0.8,
+  printBackground: true
+})
+```
 
 ## logo
 
-The brand logo behind any URL. Use `square: true` to prefer a square variant:
+The brand logo behind any URL:
 
 ```js
 const { url } = await microlink.logo('https://github.com', { square: true })
 ```
 
+Options:
+
+- `square` `<boolean>` — prefers a square variant of the logo when available.
+
 ## embed
 
-oEmbed-style iframe HTML for rich cards, with `maxWidth`/`maxHeight` support:
+oEmbed-style iframe HTML for rich cards:
 
 ```js
-const { html } = await microlink.embed('https://www.youtube.com/watch?v=9P6rdqiybaw')
+const { html } = await microlink.embed('https://www.youtube.com/watch?v=9P6rdqiybaw', {
+  maxWidth: 350
+})
 ```
 
-See the [iframe parameter](/docs/api/parameters/iframe) for the list of supported providers.
+Options:
+
+- `maxWidth` `<number>` — the maximum width of the embedded resource, in pixels.
+- `maxHeight` `<number>` — the maximum height of the embedded resource, in pixels.
+
+Both are forwarded per the [oEmbed spec](https://oembed.com/), so support depends on each provider. See the [iframe parameter](/docs/api/parameters/iframe) for the list of supported providers.

--- a/src/content/docs/sdk/methods/content.md
+++ b/src/content/docs/sdk/methods/content.md
@@ -78,7 +78,7 @@ Options:
 - [omitBackground](/docs/api/parameters/screenshot/omitBackground) `<boolean>` — omits the default white background, producing transparent captures (default: `false`).
 - [overlay](/docs/api/parameters/screenshot/overlay) `<object>` — composes the capture over a `browser` frame (`'light'` or `'dark'`) and a `background` color, gradient, or image URL.
 - [codeScheme](/docs/api/parameters/screenshot/codeScheme) `<string>` — syntax-highlights JSON and text responses using a Prism theme or a remote CSS URL (default: `'atom-dark'`).
-- [animated](/docs/api/parameters/screenshot/animated) `<boolean>` — records a short MP4 of the page instead of a static image (default: `false`).
+- [animated](/docs/api/parameters/screenshot/animated) `<boolean> | <object>` — records a short video of the page instead of a static image (default: `false`). As an object it takes `duration`, the recording length in milliseconds and also accepting `'5s'` form (default: `5000`, max `10000`), `fps` (default: `30`, max `60`), and `type`, the video container — `'mp4'` or `'webm'` (default: `'mp4'`).
 - `optimizeForSpeed` `<boolean>` — prioritizes capture speed over image size and fidelity (default: `false`).
 
 Capture a single element with a transparent background:
@@ -103,16 +103,18 @@ const { url } = await microlink.screenshot('https://www.apple.com/music', {
 })
 ```
 
-Record the page as a short MP4 — the asset gains an `animated` object pointing to the video:
+Record the page as a short video instead of a static image. Passing `animated: true` records with the defaults; passing an object tunes the result:
 
 ```js
 const { animated } = await microlink.screenshot(
   'https://threejs.org/examples/webgl_animation_skinning_blending',
-  { animated: true }
+  { animated: { duration: '8s', fps: 60, type: 'webm' } }
 )
 
-console.log(animated.url)
+console.log(animated.url, animated.type)
 ```
+
+The asset gains an `animated` object carrying the recording — its `url`, `duration`, `fps`, `type`, and `size`.
 
 Shared options compose naturally here: [device](/docs/api/parameters/device) emulation, custom [styles](/docs/api/parameters/styles), or [waitForSelector](/docs/api/parameters/waitForSelector) timing all apply before the capture happens.
 

--- a/src/content/docs/sdk/methods/specialized.md
+++ b/src/content/docs/sdk/methods/specialized.md
@@ -3,7 +3,7 @@ title: 'Specialized'
 description: 'The deeper Microlink SDK capabilities: remote code execution, structured Google search, media extraction, custom data rules, technology detection, and Lighthouse reports.'
 ---
 
-The specialized methods cover the deeper capabilities — remote code execution, search, media extraction, custom extraction rules, and tech detection.
+The specialized methods cover the deeper capabilities — remote code execution, search, media extraction, custom extraction rules, and tech detection. All of them accept the [shared options](/docs/sdk/getting-started/options); the ones with method-specific keys list them below.
 
 ## run
 
@@ -44,12 +44,19 @@ const page = await microlink.search('Lotus Elise S2')
 console.log(page.results)
 ```
 
-Switch verticals with `type` — `news`, `images`, `videos`, `places`, `maps`, `shopping`, `scholar`, `patents`, or `autocomplete` — and refine with `location`, `period`, and `limit`:
+Options:
+
+- `type` `<string>` — the search vertical: `'search'` (default), `'news'`, `'images'`, `'videos'`, `'places'`, `'maps'`, `'shopping'`, `'scholar'`, `'patents'`, or `'autocomplete'`.
+- `limit` `<number>` — the maximum number of results per page.
+- `location` `<string>` — a two-letter country code geo-targeting the results, e.g. `'us'` or `'es'`.
+- `period` `<string>` — restricts results by recency: `'hour'`, `'day'`, `'week'`, `'month'`, or `'year'`.
 
 ```js
 const { results } = await microlink.search('open source llm', {
   type: 'news',
-  period: 'week'
+  period: 'week',
+  location: 'us',
+  limit: 10
 })
 ```
 
@@ -94,6 +101,16 @@ const { image } = await microlink.extract('https://microlink.io', {
 })
 ```
 
+A third argument takes the [shared options](/docs/sdk/getting-started/options), useful for pairing rules with `prerender` or `waitForSelector`:
+
+```js
+const { price } = await microlink.extract(
+  'https://example.com/product',
+  { price: { selector: '.price', type: 'number' } },
+  { waitForSelector: '.price' }
+)
+```
+
 ## technologies
 
 The tech stack powering any site:
@@ -108,4 +125,20 @@ A full [Lighthouse report](/docs/api/parameters/insights/lighthouse) for any URL
 
 ```js
 const report = await microlink.lighthouse('https://example.com')
+```
+
+Options:
+
+- `onlyCategories` `<string[]>` — runs only the given categories, e.g. `['performance', 'accessibility']`.
+- `onlyAudits` `<string[]>` — runs only the given audits.
+- `skipAudits` `<string[]>` — skips the given audits.
+- `output` `<string> | <string[]>` — the report format: `'json'`, `'html'`, or `'csv'` (default: `'json'`).
+
+Audit just two categories and get the report as a self-contained HTML page:
+
+```js
+const report = await microlink.lighthouse('https://example.com', {
+  onlyCategories: ['performance', 'accessibility'],
+  output: 'html'
+})
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded SDK getting-started guidance with shared browser, page, cache, and request options, including defaults, types, links, and examples.
  * Clarified collection methods, scanned elements, extracted attributes, normalization, and lazy-loaded images.
  * Added detailed content-method guidance for selectors, metadata, screenshots, PDFs, logos, and embeds.
  * Documented search filters, extraction waiting options, and Lighthouse filtering and report formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->