### PR TITLE
docs: finish August changelog

### DIFF
--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -260,7 +260,7 @@
   "src/content/docs/sdk/parameters/size.md": "2026-01-10T00:00:00.000Z",
   "src/content/docs/sdk/parameters/url.md": "2026-01-10T00:00:00.000Z",
   "src/content/dpa.md": "2026-01-21T00:00:00.000Z",
-  "src/content/fragments/changelog.md": "2026-08-23T00:00:00.000Z",
+  "src/content/fragments/changelog.md": "2026-08-27T00:00:00.000Z",
   "src/content/fragments/enterprise.md": "2026-07-28T00:00:00.000Z",
   "src/content/privacy.md": "2026-08-20T00:00:00.000Z",
   "src/content/security.md": "2026-07-28T00:00:00.000Z",

--- a/src/components/patterns/Toolbar/ToolbarDesktopProductsPanel.js
+++ b/src/components/patterns/Toolbar/ToolbarDesktopProductsPanel.js
@@ -5,6 +5,7 @@ import FeatherIcon from 'components/icons/Feather'
 import { ChevronRight } from 'react-feather'
 import React from 'react'
 
+import { changelogBannerLabel } from 'helpers/parse-latest-changelog-entry'
 import { theme } from 'theme'
 
 import {
@@ -59,10 +60,11 @@ const ToolbarDesktopProductsPanel = ({
               flexShrink: 0,
               fontSize: 0,
               fontWeight: 'bold',
-              color: 'black80'
+              color: 'black80',
+              textTransform: 'none'
             })}
           >
-            New: {latestChangelogEntry.product}
+            {changelogBannerLabel(latestChangelogEntry.product)}
           </Text>
           <Text
             as='span'

--- a/src/components/patterns/Toolbar/ToolbarDesktopStyles.js
+++ b/src/components/patterns/Toolbar/ToolbarDesktopStyles.js
@@ -317,6 +317,14 @@ export const ProductsChangelogEntryLink = styled(ToolbarNavLink)`
     .menu-item-title {
       font-weight: ${fontWeights.bold};
     }
+
+    > span:not(.menu-item-title):not(.menu-item-description) {
+      display: flex;
+      align-items: baseline;
+      gap: 8px;
+      min-width: 0;
+      width: 100%;
+    }
   }
 
   &:hover .menu-item-description,

--- a/src/content/fragments/changelog.md
+++ b/src/content/fragments/changelog.md
@@ -1,12 +1,23 @@
 ### August 2026
 
+- [Microlink](https://dashboard.microlink.io): Auto-upgrades the plan at 90% quota. Opt out on Notifications.
+- [Microlink Blog](/blog): Published [Chrome Built-in AI from Node.js](/blog/chrome-built-in-ai-from-nodejs).
 - [Microlink API](/docs/api/getting-started/overview): [timeout](/docs/api/parameters/timeout) is now 30s on the free plan and 60s on pro.
+- [Browserless v13.9](https://browserless.js.org): Added [@browserless/ai](https://github.com/microlinkhq/browserless/tree/master/packages/ai) for Chrome Built-in AI.
+- [Microlink API](/docs/api/getting-started/overview): Improved metadata extraction from PDFs.
+- [unavatar.io](https://unavatar.io): Improved [Printables](https://unavatar.io/printables) avatar resolution.
 - [Metascraper v5.57](https://metascraper.js.org): Added IMDb integration.
-- [Microlink API](/docs/api/getting-started/overview): Improved metadata extraction for Shadow DOM pages.
-- [Microlink API](/docs/api/getting-started/overview): Fixed 500s from [iframe](/docs/api/parameters/iframe) and [pageRanges](/docs/api/parameters/pdf/pageRanges).
 - [Microlink API](/docs/api/getting-started/overview): Rejects invalid query parameters with [EINVALQUERY](/docs/api/basics/error-codes#einvalquery).
 - [Metascraper v5.56](https://metascraper.js.org): Added citation integration for Highwire Press and Dublin Core tags.
+- [Microlink](/): Every page is available as markdown; [llms.txt](/llms.txt) covers the full site.
+- [Microlink](/): Added [SDK](/integrations/sdk) landing.
+- [Microlink](/): Added [adblock](/features/adblock) feature landing.
+- [Microlink](/): Added [PDF](/pdf/nodejs) landings for Node.js, Python, and PHP.
+- [Microlink](/): Added [Cloudflare](/alternative/cloudflare), [Firecrawl](/alternative/firecrawl), and [Context](/alternative/context-dev) alternatives.
 - [Microlink](/): Added [html](/html), [text](/text), [media](/media) and [file conversion](/file-conversion) product landings.
+- [Microlink Blog](/blog): Published [Brand Logos Are Hiding in DNS](/blog/brand-logos-are-hiding-in-dns).
+- [Microlink](/): Added [Sharing Debugger](/extensions/chrome/sharing-debugger) Chrome extension landing.
+- [Microlink](https://dashboard.microlink.io): Added an API playground.
 
 ### July 2026
 

--- a/src/helpers/parse-latest-changelog-entry.js
+++ b/src/helpers/parse-latest-changelog-entry.js
@@ -7,6 +7,24 @@ const stripMarkdownLinks = text =>
     .replace(/\s+/g, ' ')
     .trim()
 
+export const changelogBannerScope = product => {
+  const name = String(product || '').trim()
+  if (!name || /^microlink$/i.test(name)) return null
+
+  const token = name
+    .replace(/^microlink\s+/i, '')
+    .split(/\s+/)[0]
+    .replace(/\.io$/i, '')
+    .toLowerCase()
+
+  return token || null
+}
+
+export const changelogBannerLabel = product => {
+  const scope = changelogBannerScope(product)
+  return scope ? `New(${scope}):` : 'New:'
+}
+
 export const parseLatestChangelogEntry = markdown => {
   const match = String(markdown || '').match(ENTRY_RE)
   if (!match) return null

--- a/test/helpers/parse-latest-changelog-entry.js
+++ b/test/helpers/parse-latest-changelog-entry.js
@@ -1,5 +1,8 @@
 import { expect, test } from 'vitest'
-import { parseLatestChangelogEntry } from '../../src/helpers/parse-latest-changelog-entry'
+import {
+  changelogBannerLabel,
+  parseLatestChangelogEntry
+} from '../../src/helpers/parse-latest-changelog-entry'
 
 test('returns the first changelog bullet with its entry href', () => {
   const markdown = `### July 2026
@@ -16,13 +19,23 @@ test('returns the first changelog bullet with its entry href', () => {
 })
 
 test('falls back to the product href when the description has no link', () => {
-  const markdown = '- [Browserless v13.6](https://browserless.js.org): Fixed screenshots.'
+  const markdown =
+    '- [Browserless v13.6](https://browserless.js.org): Fixed screenshots.'
 
   expect(parseLatestChangelogEntry(markdown)).toEqual({
     product: 'Browserless v13.6',
     description: 'Fixed screenshots.',
     href: 'https://browserless.js.org'
   })
+})
+
+test('formats the toolbar banner label with a short scope', () => {
+  expect(changelogBannerLabel('Microlink')).toBe('New:')
+  expect(changelogBannerLabel('Microlink Blog')).toBe('New(blog):')
+  expect(changelogBannerLabel('Microlink API')).toBe('New(api):')
+  expect(changelogBannerLabel('Browserless v13.9')).toBe('New(browserless):')
+  expect(changelogBannerLabel('Metascraper v5.57')).toBe('New(metascraper):')
+  expect(changelogBannerLabel('unavatar.io')).toBe('New(unavatar):')
 })
 
 test('returns null when no entry is present', () => {


### PR DESCRIPTION
## Summary
- Close out August with the remaining user-facing ships: dashboard auto-upgrade and playground, Browserless AI, PDF metadata, Printables avatars, site-wide markdown/`llms.txt`, SDK/adblock/PDF/alternative landings, Sharing Debugger, and the two August blog posts.

## Test plan
- [ ] Check `/changelog` renders August newest-first
- [ ] Confirm new links resolve (dashboard, blog slugs, Browserless AI, llms.txt, SDK, adblock, PDF langs, alternatives, Sharing Debugger, Printables)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the August 2026 changelog with new product updates, including plan auto-upgrades, built-in AI content, Browserless improvements, enhanced PDF and avatar handling, and markdown access through `llms.txt`.
  * Added entries for new SDK, adblock, PDF, alternative, and Sharing Debugger landing pages.
  * Removed outdated changelog entries.

* **Improvements**
  * Updated product toolbar banners to display clearer, context-specific changelog labels and improved alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->