### PR TITLE
docs: list Datadog and Sentry as subprocessors

### DIFF
--- a/src/content/fragments/changelog.md
+++ b/src/content/fragments/changelog.md
@@ -1,5 +1,6 @@
 ### August 2026
 
+- [Microlink](/subprocessors): Listed [Datadog](https://www.datadoghq.com) and [Sentry](https://sentry.io) as observability subprocessors.
 - [Microlink](https://dashboard.microlink.io): Auto-upgrades the plan at 90% quota. Opt out on Notifications.
 - [Microlink Blog](/blog): Published [Chrome Built-in AI from Node.js](/blog/chrome-built-in-ai-from-nodejs).
 - [Microlink API](/docs/api/getting-started/overview): Added [proxy.location](/docs/api/parameters/proxy/location) to pin the proxy to a country.

--- a/src/content/subprocessors.md
+++ b/src/content/subprocessors.md
@@ -46,6 +46,22 @@ The following companies act as subprocessors and may have access to personal dat
 - **Location**: Global (multiple data centers worldwide)  
 - **Website**: [digitalocean.com](https://digitalocean.com)
 
+### Observability
+
+**Datadog, Inc.**
+
+- **Services**: Application logs, metrics, infrastructure monitoring  
+- **Data Types**: API request logs (URLs, query parameters, IP addresses, API key identifiers, timestamps), server logs, system metrics  
+- **Location**: United States  
+- **Website**: [datadoghq.com](https://www.datadoghq.com)
+
+**Sentry (Functional Software, Inc.)**
+
+- **Services**: Error tracking  
+- **Data Types**: Unexpected error events, request identifiers, query parameters, request headers, IP addresses, API key identifiers  
+- **Location**: United States  
+- **Website**: [sentry.io](https://sentry.io)
+
 ### Payment Processing
 
 **Stripe Inc.**


### PR DESCRIPTION
## Summary
- Add Datadog and Sentry to the public [subprocessors](https://microlink.io/subprocessors) list under Observability.
- They already process API request logs (Datadog) and unexpected error events (Sentry); the page omitted them.
- Record the update in the August changelog.

## Test plan
- [ ] Confirm `/subprocessors` renders the new Observability section.
- [ ] Confirm changelog banner/entry reads correctly.