### PR TITLE
feat(pdf): add /pdf/go landing page

### DIFF
--- a/src/components/pages/pdf/cta.js
+++ b/src/components/pages/pdf/cta.js
@@ -1,11 +1,14 @@
 import React from 'react'
 import styled, { keyframes } from 'styled-components'
 import { SECTION_VERTICAL_SPACING, layout, colors, theme } from 'theme'
+import Box from 'components/elements/Box'
 import Container from 'components/elements/Container'
 import Flex from 'components/elements/Flex'
 import Text from 'components/elements/Text'
 import { Check as CheckIcon } from 'react-feather'
 import ArrowLink from 'components/patterns/ArrowLink'
+import { LangLandingsNav } from 'components/patterns/LangLandings'
+import { LANG_LANDINGS } from './lang/registry'
 import { ACCENT, Subhead, Caption } from './shared'
 
 const CTA_DURATION = 6.2
@@ -127,6 +130,13 @@ export const CallToAction = () => (
           )
         )}
       </Flex>
+      <Box css={theme({ pt: [4, 4, 5, 5] })}>
+        <LangLandingsNav
+          langs={LANG_LANDINGS}
+          label='Language guides'
+          accent={ACCENT}
+        />
+      </Box>
     </Flex>
   </Container>
 )

--- a/src/components/pages/pdf/lang/config/go.js
+++ b/src/components/pages/pdf/lang/config/go.js
@@ -1,0 +1,657 @@
+import React from 'react'
+import { CDN_EDGES } from 'helpers/cdn-edges'
+import { Link } from 'components/elements/Link'
+import { ACCENT } from 'components/pages/pdf/shared'
+
+const Accent = ({ children }) => (
+  <span style={{ color: ACCENT }}>{children}</span>
+)
+
+const PAGE_URL = 'https://microlink.io/pdf/go'
+const OG_IMAGE = 'https://cdn.microlink.io/banner/pdf.jpeg'
+
+const HELPER_SOURCE = `package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "net/http"
+    "net/url"
+)
+
+func pdfURL(target string) (string, error) {
+    endpoint, err := url.Parse("https://api.microlink.io")
+    if err != nil {
+        return "", err
+    }
+
+    query := endpoint.Query()
+    query.Set("url", target)
+    query.Set("pdf", "true")
+    query.Set("meta", "false")
+    endpoint.RawQuery = query.Encode()
+
+    res, err := http.Get(endpoint.String())
+    if err != nil {
+        return "", err
+    }
+    defer res.Body.Close()
+
+    var payload struct {
+        Data struct {
+            PDF struct {
+                URL string \`json:"url"\`
+            } \`json:"pdf"\`
+        } \`json:"data"\`
+    }
+
+    if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+        return "", err
+    }
+
+    return payload.Data.PDF.URL, nil
+}
+
+func main() {
+    link, err := pdfURL("https://example.com")
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Println(link)
+}`
+
+const go = {
+  lang: 'go',
+  label: 'Go',
+
+  meta: {
+    title: 'Golang HTML to PDF API without chromedp',
+    description:
+      'Convert any URL to a pixel-perfect PDF in Go with one HTTP request — no chromedp, no Chrome binary to install. Works with net/http, Gin, Echo and Chi.',
+    image: OG_IMAGE,
+    structured: [
+      {
+        '@context': 'https://schema.org',
+        '@type': 'TechArticle',
+        '@id': `${PAGE_URL}#article`,
+        headline: 'HTML to PDF API for Go',
+        name: 'HTML to PDF API for Go',
+        description:
+          'A developer guide to converting web pages to PDF programmatically in Go over the Microlink REST API — request, convert, framework integration, and serverless deployment without shipping a Chrome binary.',
+        url: PAGE_URL,
+        image: OG_IMAGE,
+        inLanguage: 'en',
+        proficiencyLevel: 'Beginner',
+        dependencies: 'Go 1.21+, standard library only',
+        keywords:
+          'golang html to pdf api, url to pdf go, convert webpage to pdf golang, chromedp alternative, generate pdf from html go, net/http pdf',
+        author: {
+          '@type': 'Organization',
+          name: 'Microlink',
+          url: 'https://microlink.io'
+        },
+        publisher: {
+          '@type': 'Organization',
+          name: 'Microlink',
+          url: 'https://microlink.io',
+          logo: {
+            '@type': 'ImageObject',
+            url: 'https://cdn.microlink.io/logo/logo.png'
+          }
+        },
+        isPartOf: {
+          '@type': 'WebSite',
+          '@id': 'https://microlink.io',
+          url: 'https://microlink.io',
+          name: 'Microlink'
+        },
+        about: {
+          '@type': 'SoftwareApplication',
+          name: 'Microlink PDF API',
+          url: 'https://microlink.io/pdf',
+          applicationCategory: ['DeveloperApplication', 'WebAPI']
+        },
+        mainEntityOfPage: PAGE_URL
+      },
+      {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        '@id': `${PAGE_URL}#breadcrumb`,
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'Microlink',
+            item: 'https://microlink.io'
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'PDF API',
+            item: 'https://microlink.io/pdf'
+          },
+          {
+            '@type': 'ListItem',
+            position: 3,
+            name: 'Go',
+            item: PAGE_URL
+          }
+        ]
+      },
+      {
+        '@context': 'https://schema.org',
+        '@type': 'HowTo',
+        '@id': `${PAGE_URL}#howto`,
+        name: 'How to convert a URL to PDF in Go',
+        description:
+          'Convert any URL into a PDF document in Go with one HTTP request to the Microlink API in three steps.',
+        tool: [
+          { '@type': 'HowToTool', name: 'Go' },
+          { '@type': 'HowToTool', name: 'net/http' }
+        ],
+        step: [
+          {
+            '@type': 'HowToStep',
+            position: 1,
+            name: 'Send the request',
+            text: 'Make an HTTP GET to api.microlink.io with the url and pdf parameters.',
+            url: `${PAGE_URL}#quickstart`
+          },
+          {
+            '@type': 'HowToStep',
+            position: 2,
+            name: 'Read the PDF URL',
+            text: 'Decode the JSON response and read the hosted document from data.pdf.url.'
+          },
+          {
+            '@type': 'HowToStep',
+            position: 3,
+            name: 'Use the PDF URL',
+            text: 'Serve the hosted document to your users or stream it to disk.'
+          }
+        ]
+      }
+    ]
+  },
+
+  breadcrumb: [{ label: 'PDF API', href: '/pdf' }, { label: 'Go' }],
+
+  hero: {
+    title: (
+      <>
+        <Accent>Go</Accent> HTML to PDF API
+      </>
+    ),
+    subtitle:
+      'Convert any URL into a pixel-perfect PDF with one HTTP request in Go — no chromedp, no Chrome binary in your image, no servers to maintain.',
+    primaryCta: { label: 'Get started free', href: '#quickstart' },
+    secondaryCta: {
+      label: 'Read the docs',
+      href: '/docs/guides/pdf'
+    }
+  },
+
+  quickstart: {
+    title: (
+      <>
+        Convert a URL to <Accent>PDF</Accent> in Go
+      </>
+    ),
+    caption:
+      'No SDK and no browser binaries — the Microlink REST API turns any URL into a hosted PDF with a single HTTP GET. Everything below is standard library: net/http, net/url and encoding/json.',
+    steps: [
+      {
+        title: 'Start a module',
+        description:
+          'Nothing to go get. The API is plain HTTP, so the standard library is the only dependency.',
+        code: { language: 'bash', source: 'go mod init example.com/pdf' }
+      },
+      {
+        title: 'Convert any URL',
+        description:
+          'Point it at a page, ask for a PDF, and decode the hosted document URL from the JSON response. This helper is reused everywhere below.',
+        code: {
+          language: 'go',
+          title: 'main.go',
+          source: HELPER_SOURCE
+        }
+      },
+      {
+        title: 'Customize the document',
+        description:
+          'Paper format, margins, orientation, and print CSS are all query params. Nested options use dot notation, so pdf.format maps to the format field.',
+        code: {
+          language: 'go',
+          title: 'options.go',
+          source: `func withOptions(endpoint *url.URL, target string) {
+    query := endpoint.Query()
+    query.Set("url", target)
+    query.Set("pdf.format", "A4")        // A0-A6 | Letter | Legal | Tabloid
+    query.Set("pdf.margin", "0.35cm")    // cm, mm, in or px
+    query.Set("pdf.landscape", "false")  // portrait (default) | landscape
+    query.Set("mediaType", "print")      // print CSS stylesheets | screen (default)
+    query.Set("meta", "false")
+    endpoint.RawQuery = query.Encode()
+}`
+        }
+      },
+      {
+        title: 'Stream it to disk',
+        description:
+          'The response is a hosted PDF URL on a global CDN. Copy it into a file with a second request, or hand the URL straight to your template.',
+        code: {
+          language: 'go',
+          title: 'save.go',
+          source: `func savePDF(target string) error {
+    link, err := pdfURL(target)
+    if err != nil {
+        return err
+    }
+
+    res, err := http.Get(link)
+    if err != nil {
+        return err
+    }
+    defer res.Body.Close()
+
+    file, err := os.Create("document.pdf")
+    if err != nil {
+        return err
+    }
+    defer file.Close()
+
+    _, err = io.Copy(file, res.Body)
+    return err
+}`
+        }
+      }
+    ]
+  },
+
+  framework: {
+    title: (
+      <>
+        Drop it into your <Accent>router</Accent>
+      </>
+    ),
+    caption:
+      'A handler, a route, or a standalone binary — the same request becomes ' +
+      'your own PDF endpoint, perfect for invoice downloads, nightly reports, ' +
+      'and export views in net/http, Gin, Echo or Chi.',
+    examples: [
+      {
+        id: 'nethttp',
+        label: 'net/http',
+        code: {
+          language: 'go',
+          title: 'main.go',
+          source: `package main
+
+import (
+    "log"
+    "net/http"
+)
+
+// GET /pdf?url=https://example.com
+func main() {
+    http.HandleFunc("/pdf", func(w http.ResponseWriter, r *http.Request) {
+        link, err := pdfURL(r.URL.Query().Get("url"))
+        if err != nil {
+            http.Error(w, err.Error(), http.StatusBadGateway)
+            return
+        }
+
+        http.Redirect(w, r, link, http.StatusFound)
+    })
+
+    log.Fatal(http.ListenAndServe(":3000", nil))
+}`
+        }
+      },
+      {
+        id: 'gin',
+        label: 'Gin',
+        code: {
+          language: 'go',
+          title: 'main.go',
+          source: `package main
+
+import (
+    "net/http"
+
+    "github.com/gin-gonic/gin"
+)
+
+// GET /pdf?url=https://example.com
+func main() {
+    router := gin.Default()
+
+    router.GET("/pdf", func(c *gin.Context) {
+        link, err := pdfURL(c.Query("url"))
+        if err != nil {
+            c.String(http.StatusBadGateway, err.Error())
+            return
+        }
+
+        c.Redirect(http.StatusFound, link)
+    })
+
+    router.Run(":3000")
+}`
+        }
+      },
+      {
+        id: 'echo',
+        label: 'Echo',
+        code: {
+          language: 'go',
+          title: 'main.go',
+          source: `package main
+
+import (
+    "net/http"
+
+    "github.com/labstack/echo/v4"
+)
+
+// GET /pdf?url=https://example.com
+func main() {
+    e := echo.New()
+
+    e.GET("/pdf", func(c echo.Context) error {
+        link, err := pdfURL(c.QueryParam("url"))
+        if err != nil {
+            return err
+        }
+
+        return c.Redirect(http.StatusFound, link)
+    })
+
+    e.Logger.Fatal(e.Start(":3000"))
+}`
+        }
+      },
+      {
+        id: 'chi',
+        label: 'Chi',
+        code: {
+          language: 'go',
+          title: 'main.go',
+          source: `package main
+
+import (
+    "log"
+    "net/http"
+
+    "github.com/go-chi/chi/v5"
+)
+
+// GET /pdf?url=https://example.com
+func main() {
+    router := chi.NewRouter()
+
+    router.Get("/pdf", func(w http.ResponseWriter, r *http.Request) {
+        link, err := pdfURL(r.URL.Query().Get("url"))
+        if err != nil {
+            http.Error(w, err.Error(), http.StatusBadGateway)
+            return
+        }
+
+        http.Redirect(w, r, link, http.StatusFound)
+    })
+
+    log.Fatal(http.ListenAndServe(":3000", router))
+}`
+        }
+      }
+    ],
+    footnote: {
+      text: 'Every tab reuses the helper from the quickstart:',
+      code: 'func pdfURL(target string) (string, error)'
+    }
+  },
+
+  comparison: {
+    title: (
+      <>
+        Ship a binary, not a <Accent>browser</Accent>
+      </>
+    ),
+    caption:
+      'Rendering a web page to PDF from Go means driving headless Chrome yourself, shelling out to a binary, or drawing the document by hand. The API gives you a real browser rendering engine without any of the infrastructure.',
+    columns: [
+      {
+        tone: 'negative',
+        heading: 'Self-hosted PDF tooling',
+        points: [
+          'chromedp and rod need a Chrome install on every host that runs them',
+          'wkhtmltopdf wrappers shell out to a binary archived upstream',
+          'gofpdf and maroto draw documents from primitives, never from a URL',
+          'Each browser eats hundreds of MB of RAM; workers crash under load',
+          'You build the pooling, queueing, retries and autoscaling',
+          'Fonts, emoji, and modern CSS break differently on every host'
+        ]
+      },
+      {
+        tone: 'positive',
+        heading: 'Microlink for Go',
+        points: [
+          'One HTTP request — net/http and encoding/json, nothing to go get',
+          'Runs anywhere: serverless, containers, a cron job, your laptop',
+          'Autoscaled managed browser fleet with a 99.9% uptime SLA',
+          `Sub-second cached responses from ${CDN_EDGES} edge locations`,
+          'A0-A6, Letter, Legal & Tabloid — set as plain query params',
+          'Print stylesheets, custom CSS & DOM interaction, no extra deps'
+        ]
+      }
+    ]
+  },
+
+  features: {
+    title: (
+      <>
+        Built for the way you write <Accent>Go</Accent>.
+      </>
+    ),
+    caption: (
+      <>
+        A REST API that feels native in Go — one HTTP call, JSON back, and at
+        home in any runtime from a Chi service to an AWS Lambda. Read the{' '}
+        <Link href='/docs/guides/pdf'>PDF guide</Link> to go deeper.
+      </>
+    ),
+    items: [
+      {
+        title: 'No Binaries to Install',
+        description:
+          'Skip chromedp and the Chrome install it expects. There is no rendering engine to download, patch, or keep in sync across hosts.'
+      },
+      {
+        title: 'Standard Library Only',
+        description:
+          'net/http builds the request, net/url builds the query, encoding/json reads the response. No module to add to go.mod.'
+      },
+      {
+        title: 'Router Friendly',
+        description:
+          'Drop it into net/http, Gin, Echo, or Chi as a handler in a few lines. The same request works in every router.'
+      },
+      {
+        title: 'Small Container Images',
+        description:
+          'No browser layer to bundle. A scratch or distroless image stays a static binary, which keeps cold starts on Lambda and Cloud Run short.'
+      },
+      {
+        title: 'Real Browser Rendering',
+        description:
+          'Pages render in Headless Chrome, so JavaScript-driven dashboards and charts come out right — the blind spot of PDF builders that never run scripts.'
+      },
+      {
+        title: 'Zero Infrastructure',
+        description:
+          'No Chrome to pin to a driver version and no browser pool inside your service. Your binary stays a plain HTTP client.'
+      },
+      {
+        title: 'Custom Paper & Layout',
+        description:
+          'Every layout option is a query param: pdf.format, pdf.margin, pdf.landscape, pdf.scale, and pdf.pageRanges.'
+      },
+      {
+        title: 'Screen & Print Media',
+        description:
+          'Set mediaType to print in the same query to apply print stylesheets, or keep the default screen layout.'
+      },
+      {
+        title: 'Generous Free Tier',
+        description:
+          'Start with 25 requests per day — no account, no credit card. Point at pro.microlink.io with an x-api-key header when you scale.'
+      }
+    ]
+  },
+
+  tool: {
+    title: (
+      <>
+        Try it live in the <Accent>playground</Accent>
+      </>
+    ),
+    caption:
+      'Paste a URL and see the exact API request before you write a line of Go.',
+    cta: {
+      label: 'Open the PDF tool',
+      href: '/tools/website-to-pdf'
+    }
+  },
+
+  faq: {
+    title: 'Go PDF FAQ',
+    caption: (
+      <>
+        What Go developers ask before integrating. For formats, limits, and SLA,
+        see the <Link href='/pdf'>PDF API overview</Link>.
+      </>
+    ),
+    questions: [
+      {
+        question: 'Do I need chromedp or a Chrome binary?',
+        answer: (
+          <>
+            <div>
+              No. It is a plain HTTP request to the Microlink API — there is no
+              Chrome to install next to your binary and no driver to pin. The
+              Headless Chrome fleet runs on Microlink&apos;s side.
+            </div>
+            <div>
+              That keeps your container image a static binary, so a scratch or
+              distroless base still works.
+            </div>
+          </>
+        )
+      },
+      {
+        question: 'Do I need a third-party HTTP client?',
+        answer: (
+          <>
+            <div>
+              No. <code>net/http</code> sends the request, <code>net/url</code>{' '}
+              builds the query string, and <code>encoding/json</code> decodes
+              the response — all standard library.
+            </div>
+            <div>
+              Clients like <code>resty</code> work the same way if you already
+              use one; the request is an ordinary <code>GET</code> either way.
+            </div>
+          </>
+        )
+      },
+      {
+        question: 'Is it safe to call from many goroutines?',
+        answer: (
+          <>
+            <div>
+              Yes. Each conversion is an independent stateless request, and an{' '}
+              <code>http.Client</code> is safe for concurrent use by multiple
+              goroutines, so one shared client serves your whole worker pool.
+            </div>
+            <div>
+              Concurrency is bounded by your plan rather than your hardware —
+              check the{' '}
+              <Link href='/docs/api/basics/rate-limit'>rate limit</Link> docs
+              before fanning out widely.
+            </div>
+          </>
+        )
+      },
+      {
+        question: 'Does it work with Gin, Echo, and Chi?',
+        answer: (
+          <>
+            <div>
+              Yes. Because it is just an HTTP call, it drops into any handler in
+              a few lines — see the tabs above for net/http, Gin, Echo, and Chi,
+              or the <Link href='/docs/guides/pdf'>PDF guide</Link>.
+            </div>
+          </>
+        )
+      },
+      {
+        question: 'How do I authenticate from Go?',
+        answer: (
+          <>
+            <div>
+              Two things change together: send your key as the{' '}
+              <code>x-api-key</code> header, and point the request at{' '}
+              <code>pro.microlink.io</code> instead of{' '}
+              <code>api.microlink.io</code>. Sending the header to the free
+              endpoint returns an <code>EPRO</code> error.
+            </div>
+            <div>
+              Build the request with <code>http.NewRequest</code>, call{' '}
+              <code>req.Header.Set(&quot;x-api-key&quot;, key)</code>, and send
+              it with <code>client.Do(req)</code>. See the{' '}
+              <Link href='/docs/api/basics/authentication'>
+                authentication docs
+              </Link>{' '}
+              and <Link href='/pricing'>pricing</Link>.
+            </div>
+          </>
+        )
+      },
+      {
+        question: 'How do I set a timeout?',
+        answer: (
+          <>
+            <div>
+              Give the shared <code>http.Client</code> a <code>Timeout</code>,
+              or build the request with <code>http.NewRequestWithContext</code>{' '}
+              so an inbound request cancelling propagates to the conversion.
+            </div>
+            <div>
+              Rendering happens on Microlink&apos;s side, so your service only
+              ever waits on the network.
+            </div>
+          </>
+        )
+      }
+    ]
+  },
+
+  cta: {
+    title: (
+      <>
+        Start <Accent>converting</Accent> in Go
+      </>
+    ),
+    caption:
+      'Get 25 requests/day with zero commitment — no account, no credit card. Paste the helper into a handler and ship a PDF today.',
+    primary: {
+      label: 'Read the API docs',
+      href: '/docs/api/getting-started/overview'
+    },
+    secondary: { label: 'See pricing', href: '/pricing' },
+    badges: ['No login needed', '25 reqs/day free', 'No credit card']
+  }
+}
+
+export default go

--- a/src/components/pages/pdf/lang/config/go.js
+++ b/src/components/pages/pdf/lang/config/go.js
@@ -13,13 +13,18 @@ const OG_IMAGE = 'https://cdn.microlink.io/banner/pdf.jpeg'
 const HELPER_SOURCE = `package main
 
 import (
+    "context"
     "encoding/json"
+    "errors"
     "fmt"
     "net/http"
     "net/url"
+    "time"
 )
 
-func pdfURL(target string) (string, error) {
+var client = &http.Client{Timeout: 60 * time.Second}
+
+func pdfURL(ctx context.Context, target string) (string, error) {
     endpoint, err := url.Parse("https://api.microlink.io")
     if err != nil {
         return "", err
@@ -31,14 +36,20 @@ func pdfURL(target string) (string, error) {
     query.Set("meta", "false")
     endpoint.RawQuery = query.Encode()
 
-    res, err := http.Get(endpoint.String())
+    req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+    if err != nil {
+        return "", err
+    }
+
+    res, err := client.Do(req)
     if err != nil {
         return "", err
     }
     defer res.Body.Close()
 
     var payload struct {
-        Data struct {
+        Message string \`json:"message"\`
+        Data    struct {
             PDF struct {
                 URL string \`json:"url"\`
             } \`json:"pdf"\`
@@ -46,14 +57,22 @@ func pdfURL(target string) (string, error) {
     }
 
     if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
-        return "", err
+        return "", fmt.Errorf("microlink: %s: %w", res.Status, err)
+    }
+
+    if res.StatusCode != http.StatusOK {
+        return "", fmt.Errorf("microlink: %s: %s", res.Status, payload.Message)
+    }
+
+    if payload.Data.PDF.URL == "" {
+        return "", errors.New("microlink: no pdf url in response")
     }
 
     return payload.Data.PDF.URL, nil
 }
 
 func main() {
-    link, err := pdfURL("https://example.com")
+    link, err := pdfURL(context.Background(), "https://example.com")
     if err != nil {
         panic(err)
     }
@@ -199,7 +218,7 @@ const go = {
       </>
     ),
     caption:
-      'No SDK and no browser binaries — the Microlink REST API turns any URL into a hosted PDF with a single HTTP GET. Everything below is standard library: net/http, net/url and encoding/json.',
+      'No SDK and no browser binaries — the Microlink REST API turns any URL into a hosted PDF with a single HTTP GET. Everything below is standard library, built on net/http, net/url and encoding/json.',
     steps: [
       {
         title: 'Start a module',
@@ -210,7 +229,7 @@ const go = {
       {
         title: 'Convert any URL',
         description:
-          'Point it at a page, ask for a PDF, and decode the hosted document URL from the JSON response. This helper is reused everywhere below.',
+          'Point it at a page, ask for a PDF, and decode the hosted document URL from the JSON response. A shared http.Client carries the timeout and the context cancels the wait with the caller. This helper is reused everywhere below.',
         code: {
           language: 'go',
           title: 'main.go',
@@ -220,40 +239,48 @@ const go = {
       {
         title: 'Customize the document',
         description:
-          'Paper format, margins, orientation, and print CSS are all query params. Nested options use dot notation, so pdf.format maps to the format field.',
+          'Paper format, margins, orientation, and print CSS are all query params — swap them in for the query block inside pdfURL. Nested options use dot notation, so pdf.format maps to the format field.',
         code: {
           language: 'go',
           title: 'options.go',
-          source: `func withOptions(endpoint *url.URL, target string) {
-    query := endpoint.Query()
+          source: `func setOptions(query url.Values, target string) {
     query.Set("url", target)
     query.Set("pdf.format", "A4")        // A0-A6 | Letter | Legal | Tabloid
     query.Set("pdf.margin", "0.35cm")    // cm, mm, in or px
     query.Set("pdf.landscape", "false")  // portrait (default) | landscape
+    query.Set("pdf.scale", "1")          // zoom the rendering, 0.1 to 2
     query.Set("mediaType", "print")      // print CSS stylesheets | screen (default)
     query.Set("meta", "false")
-    endpoint.RawQuery = query.Encode()
 }`
         }
       },
       {
         title: 'Stream it to disk',
         description:
-          'The response is a hosted PDF URL on a global CDN. Copy it into a file with a second request, or hand the URL straight to your template.',
+          'The response is a hosted PDF URL on a global CDN. Copy it into a file with a second request that reuses the same client and context, or hand the URL straight to your template.',
         code: {
           language: 'go',
           title: 'save.go',
-          source: `func savePDF(target string) error {
-    link, err := pdfURL(target)
+          source: `func savePDF(ctx context.Context, target string) error {
+    link, err := pdfURL(ctx, target)
     if err != nil {
         return err
     }
 
-    res, err := http.Get(link)
+    req, err := http.NewRequestWithContext(ctx, http.MethodGet, link, nil)
+    if err != nil {
+        return err
+    }
+
+    res, err := client.Do(req)
     if err != nil {
         return err
     }
     defer res.Body.Close()
+
+    if res.StatusCode != http.StatusOK {
+        return fmt.Errorf("download %s: %s", link, res.Status)
+    }
 
     file, err := os.Create("document.pdf")
     if err != nil {
@@ -296,7 +323,7 @@ import (
 // GET /pdf?url=https://example.com
 func main() {
     http.HandleFunc("/pdf", func(w http.ResponseWriter, r *http.Request) {
-        link, err := pdfURL(r.URL.Query().Get("url"))
+        link, err := pdfURL(r.Context(), r.URL.Query().Get("url"))
         if err != nil {
             http.Error(w, err.Error(), http.StatusBadGateway)
             return
@@ -328,7 +355,7 @@ func main() {
     router := gin.Default()
 
     router.GET("/pdf", func(c *gin.Context) {
-        link, err := pdfURL(c.Query("url"))
+        link, err := pdfURL(c.Request.Context(), c.Query("url"))
         if err != nil {
             c.String(http.StatusBadGateway, err.Error())
             return
@@ -360,7 +387,7 @@ func main() {
     e := echo.New()
 
     e.GET("/pdf", func(c echo.Context) error {
-        link, err := pdfURL(c.QueryParam("url"))
+        link, err := pdfURL(c.Request().Context(), c.QueryParam("url"))
         if err != nil {
             return err
         }
@@ -392,7 +419,7 @@ func main() {
     router := chi.NewRouter()
 
     router.Get("/pdf", func(w http.ResponseWriter, r *http.Request) {
-        link, err := pdfURL(r.URL.Query().Get("url"))
+        link, err := pdfURL(r.Context(), r.URL.Query().Get("url"))
         if err != nil {
             http.Error(w, err.Error(), http.StatusBadGateway)
             return
@@ -407,8 +434,8 @@ func main() {
       }
     ],
     footnote: {
-      text: 'Every tab reuses the helper from the quickstart:',
-      code: 'func pdfURL(target string) (string, error)'
+      text: 'Every tab reuses the quickstart helper:',
+      code: 'func pdfURL(ctx context.Context, target string) (string, error)'
     }
   },
 
@@ -607,9 +634,9 @@ func main() {
               endpoint returns an <code>EPRO</code> error.
             </div>
             <div>
-              Build the request with <code>http.NewRequest</code>, call{' '}
-              <code>req.Header.Set(&quot;x-api-key&quot;, key)</code>, and send
-              it with <code>client.Do(req)</code>. See the{' '}
+              The helper already builds a request, so add one line before{' '}
+              <code>client.Do(req)</code>:{' '}
+              <code>req.Header.Set(&quot;x-api-key&quot;, key)</code>. See the{' '}
               <Link href='/docs/api/basics/authentication'>
                 authentication docs
               </Link>{' '}
@@ -623,9 +650,10 @@ func main() {
         answer: (
           <>
             <div>
-              Give the shared <code>http.Client</code> a <code>Timeout</code>,
-              or build the request with <code>http.NewRequestWithContext</code>{' '}
-              so an inbound request cancelling propagates to the conversion.
+              Both at once, the way the helper above does it: the shared{' '}
+              <code>http.Client</code> carries a <code>Timeout</code> that caps
+              every call, and <code>http.NewRequestWithContext</code> lets a
+              cancelled inbound request abort the one it started.
             </div>
             <div>
               Rendering happens on Microlink&apos;s side, so your service only

--- a/src/components/pages/pdf/lang/index.js
+++ b/src/components/pages/pdf/lang/index.js
@@ -260,12 +260,17 @@ const Framework = ({ framework }) => {
     return acc
   }, {})
 
+  const aliases = framework.examples.reduce((acc, example) => {
+    acc[example.label] = example.code.language
+    return acc
+  }, {})
+
   return (
     <SectionContainer id='framework'>
       <SectionHead title={framework.title} caption={framework.caption} />
       <Box css={theme({ width: '100%', maxWidth: CONTENT_WIDTH, mx: 'auto' })}>
         <Box css={[theme({ width: '100%' }), CODE_FULL_WIDTH]}>
-          <MultiCodeEditor languages={languages} />
+          <MultiCodeEditor languages={languages} aliases={aliases} />
         </Box>
         {framework.footnote && (
           <Text

--- a/src/components/pages/pdf/lang/registry.js
+++ b/src/components/pages/pdf/lang/registry.js
@@ -1,7 +1,8 @@
 export const LANG_LANDINGS = [
   { lang: 'nodejs', label: 'Node.js', href: '/pdf/nodejs' },
   { lang: 'python', label: 'Python', href: '/pdf/python' },
-  { lang: 'php', label: 'PHP', href: '/pdf/php' }
+  { lang: 'php', label: 'PHP', href: '/pdf/php' },
+  { lang: 'go', label: 'Go', href: '/pdf/go' }
 ]
 
 export default LANG_LANDINGS

--- a/src/pages/pdf/go.js
+++ b/src/pages/pdf/go.js
@@ -1,0 +1,10 @@
+import React from 'react'
+
+import PdfLang, { LangHead } from 'components/pages/pdf/lang'
+import go from 'components/pages/pdf/lang/config/go'
+
+const PdfGo = () => <PdfLang config={go} />
+
+export const Head = () => <LangHead config={go} />
+
+export default PdfGo


### PR DESCRIPTION
## 1. Target intent

`golang html to pdf api` — a Go developer looking to turn a URL into a PDF without installing a browser.

## 2. Pages checked for overlap

| Page checked | Why this one is distinct |
| --- | --- |
| `/pdf` | The vertical hub: product, pricing, benchmark. No language-specific quickstart, no framework integration, no Go code. |
| `/pdf/nodejs`, `/pdf/python`, `/pdf/php` | Same layout, different language. Go is the fourth slug in a matrix that already exists; it was the missing one. |
| `/tools/website-to-pdf` | The interactive tool, not an integration guide. The new page links to it. |
| `/docs/guides/pdf` | Reference docs. This page is a quickstart + framework tabs + a `chromedp`/`wkhtmltopdf`/`gofpdf` comparison the docs do not carry, and it links out to the guide four times. |
| `/integrations/sdk` | The JavaScript client. There is no Go SDK; the page teaches the REST API with `net/http`, which is what the site's own Golang snippets already do. |

Go is on the site's promoted-language allowlist (`LANGUAGE_MAP` in `src/components/patterns/MultiCodeEditor/interactive/language-map.js`) and is already a first-class tab in the `/pdf` code example (`CODE_EXAMPLE_LANGUAGES` in `src/components/pages/pdf/code-example.js`).

Not proposed, and why: `/pdf/ruby` and `/screenshot/ruby` are valid but rank below Go on search intent; every `/alternative/*` candidate was dropped because competitor pricing and limits cannot be verified from this sandbox (its network allowlist only reaches Microlink hosts), and this repo has already had to correct invented competitor claims twice (27a5682, d8479cb); `/pdf/java` is out of scope (Java is not in `LANGUAGE_MAP`) and was closed as #2223.

## 3. Proof the capability ships today

Every claim on the page is taken from code already on `master`, not from anything new:

- Go as a promoted language: `src/components/patterns/MultiCodeEditor/interactive/language-map.js` (`Golang: 'go'`) and `src/helpers/mql-code.js` (`generateGolangCode`, which emits the `net/http` + `net/url` + `x-api-key` idiom this page teaches).
- PDF parameters (`pdf.format`, `pdf.margin`, `pdf.landscape`, `pdf.scale`, `pdf.pageRanges`, `mediaType`): `src/components/pages/pdf/lang/config/python.js` and `src/components/pages/pdf/capabilities.js`.
- `data.pdf.url` response shape: same sibling configs.
- Free tier (25 requests/day), `pro.microlink.io` + `x-api-key`, 99.9% uptime SLA, edge-location count (`CDN_EDGES` from `helpers/cdn-edges`): `src/pages/pdf.js` and the sibling lang configs. No number on this page is new.

Every Go snippet on the page compiles. Verified under go1.24.7 with `gofmt -l` (clean), `go vet ./...` and `go build ./...`, all passing.

## 4. Gate output

```
$ npm run lint
> microlink-www@2.11.22 lint
> standard
(exit 0, no output)
```

```
$ npm test
 Test Files  52 passed (52)
      Tests  394 passed | 2 skipped (396)
```

```
$ npm run build
info Done building in 212.907502749 sec
(exit 0)
```

Two notes on the gates, both environmental and neither caused by this branch:

- `npm run build` needs `STRIPE_KEY`, `PAYMENT_API_KEY` and `PAYMENT_ENDPOINT` (`env.js:27`), which this sandbox does not carry, so the build was run with stub values for those three. Nothing else was changed.
- Run locally with a freshly fetched `data/skills.json`, `test/skills-catalog.js` fails 2 assertions: the upstream skills feed now serves `microlink-google`, which is missing from `SKILL_CATEGORY` in `src/components/pages/skills/taxonomy.js`. **This reproduces on a clean `master` checkout with this branch stashed**, and is invisible in CI because those tests are `test.skipIf(!skills)` and CI has no `data/skills.json`. The 394-passed run above is the CI-equivalent one. Flagging it because it is a real (small) data drift someone may want to fix separately; it is not this PR's to fix.

## 5. Verification of the built page

`npx gatsby serve --port 9000` against the `public/` produced by the build above:

```
/pdf/go                                  200
/pdf                                     200
/pdf/nodejs                              200
/pdf/python                              200
/pdf/php                                 200
/tools/website-to-pdf                    200
/pricing                                 200
/docs/guides/pdf                         200
/docs/api/basics/authentication          200
/docs/api/basics/rate-limit              200
/docs/api/getting-started/overview       200
```

Head of `/pdf/go` (counted, not eyeballed):

```
h1 count: 1
h2 count: 7
h3 count: 10
head title: Golang HTML to PDF API without chromedp — Microlink        (39 chars before the suffix)
meta description: Convert any URL to a pixel-perfect PDF in Go with one HTTP request
  — no chromedp, no Chrome binary to install. Works with net/http, Gin, Echo and Chi.   (150 chars)
canonical: https://microlink.io/pdf/go
h1: <span style="color:rgb(224, 0, 172)">Go</span> HTML to PDF API
```

Sitemap: `public/sitemap-0.xml` contains `https://microlink.io/pdf/go` (reachable from `sitemap-index.xml`).

Interlinking, measured on the served HTML:

```
/pdf         -> /pdf/go links: 2   (new "Language guides" nav in the CTA)
/pdf/nodejs  -> /pdf/go links: 2
/pdf/python  -> /pdf/go links: 2
/pdf/php     -> /pdf/go links: 2
```

Outbound internal links from `/pdf/go` body (excluding the footer): 8 distinct — `/pdf`, `/pdf/nodejs`, `/pdf/python`, `/pdf/php`, `/docs/guides/pdf`, `/docs/api/basics/authentication`, `/docs/api/basics/rate-limit`, `/docs/api/getting-started/overview`, plus `/tools/website-to-pdf` and `/pricing`.

`grep -i error` on the serve log is clean: its only match is Gatsby's mislabeled banner for Node's `punycode` DeprecationWarning, which prints on every run of this repo.

**No visual or interaction review was possible.** This sandbox has no browser and no display, so rendering, mobile layout, dark mode, console errors, keyboard navigation and the framework tab switching were not checked. That review is left to a human.

## 6. Session

https://claude.ai/code/session_01Pauee6xgSxpYqbQing4wQG

---

### Also in this diff

Two small changes outside the new page, both needed for it:

- `src/components/pages/pdf/cta.js`: the four language landings had **no** inbound link from `/pdf` — only from each other. The CTA section now carries a `LangLandingsNav` ("Language guides"), mirroring the one the lang pages already end with.
- `src/components/pages/pdf/lang/index.js`: `MultiCodeEditor` uses the tab label as the highlight language, so tabs named `net/http`, `Gin`, `Echo`, `Chi` render unhighlighted. `Framework` now derives an alias map from each example's own `code.language`. This also fixes the today-unhighlighted `Flask`/`Django`/`FastAPI` tabs on `/pdf/python` and the framework tabs on `/pdf/php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pauee6xgSxpYqbQing4wQG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pauee6xgSxpYqbQing4wQG)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing and documentation pages only; no API, auth, or payment logic changes.
> 
> **Overview**
> Adds a **Go** language landing at `/pdf/go`, following the same pattern as the existing Node.js, Python, and PHP PDF integration pages. The new config covers quickstart (`net/http`), framework handler examples (net/http, Gin, Echo, Chi), chromedp alternatives, FAQ, and SEO/schema metadata.
> 
> **Go** is registered in `LANG_LANDINGS`, and the main `/pdf` CTA now includes a **Language guides** nav (`LangLandingsNav`) so the hub links to all language landings.
> 
> The shared `Framework` section passes an **`aliases`** map into `MultiCodeEditor` so tab titles like `net/http` or `Gin` use the real highlight language (`go`) instead of the label—also improving Python/PHP framework tabs that had the same issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 090e43bdaa14c0aeb48fa8ff3ded31a6fabee5d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Go language guide for the PDF API, including setup instructions, code examples, framework integrations, FAQs, and feature details.
  - Added a dedicated Go PDF API page with search-engine metadata and structured guidance.
  - Added Go to the available PDF language guides.
  - Added a “Language guides” navigation section to PDF calls to action.
  - Improved code examples to support framework-specific language aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->