### PR TITLE
docs(function): match free concurrency to 1 in-flight per IP

### DIFF
--- a/src/content/docs/api/parameters/function.md
+++ b/src/content/docs/api/parameters/function.md
@@ -136,13 +136,13 @@ The profiling phases are:
 
 The function parameter is available on both free and pro plans with different resource limits:
 
-|                      | Free       | Pro              |
-| -------------------- | ---------- | ---------------- |
-| Timeout              | 5 seconds  | Up to 60 seconds |
-| Memory               | 16 MB      | 32 MB            |
-| Code size            | 1024 bytes | Unlimited        |
-| Concurrency          | 1 per IP   | Unlimited        |
-| Outgoing requests    | Same-origin only | Unrestricted |
+|                      | Free             | Pro              |
+| -------------------- | ---------------- | ---------------- |
+| Timeout              | 5 seconds        | Up to 60 seconds |
+| Memory               | 16 MB            | 32 MB            |
+| Code size            | 1024 bytes       | Unlimited        |
+| Concurrency          | 1 in-flight per IP | Unlimited      |
+| Outgoing requests    | Same-origin only | Unrestricted     |
 
 When a limit is exceeded, the function returns `isFulfilled: false` with a descriptive error instead of failing the entire request:
 
@@ -170,7 +170,7 @@ The resource error types are:
 | `CpuTimeError`         | Function CPU time exceeded the plan limit                            |
 | `MemoryError`          | Function memory usage exceeded the plan limit                        |
 | `CodeSizeError`        | Function code exceeds the 1024 bytes free plan limit                 |
-| `ConcurrencyError`     | Too many concurrent function executions for the free plan (1 per IP) |
+| `ConcurrencyError`     | Too many concurrent function executions for the free plan            |
 | `OutgoingRequestError` | Function made a cross-origin network request on the free plan        |
 
 Each error message is plan-aware and tells you the exact limit that was hit.

--- a/src/content/docs/guides/function/profiling-and-performance.md
+++ b/src/content/docs/guides/function/profiling-and-performance.md
@@ -46,12 +46,13 @@ Use profiling to understand where time is spent. If install is high, your depend
 
 The function parameter is available on both free and pro plans:
 
-|             | Free       | Pro              |
-| ----------- | ---------- | ---------------- |
-| Timeout     | 5 seconds  | Up to 60 seconds |
-| Memory      | 16 MB      | 32 MB            |
-| Code size   | 1024 bytes | Unlimited        |
-| Concurrency | 1 per IP   | Unlimited        |
+|                   | Free             | Pro              |
+| ----------------- | ---------------- | ---------------- |
+| Timeout           | 5 seconds        | Up to 60 seconds |
+| Memory            | 16 MB            | 32 MB            |
+| Code size         | 1024 bytes       | Unlimited        |
+| Concurrency       | 1 in-flight per IP | Unlimited      |
+| Outgoing requests | Same-origin only | Unrestricted     |
 
 The free plan is enough to prototype workflows and run the examples in this guide. For production workloads that need more time or memory, or parameters such as `headers`, `proxy`, `ttl`, or `staleTtl`, use a pro plan.
 

--- a/src/content/docs/guides/function/troubleshooting.md
+++ b/src/content/docs/guides/function/troubleshooting.md
@@ -28,13 +28,13 @@ Non-Error throws (like `throw 'oh no'`) are normalized into a `NonError` with th
 
 When a function exceeds its plan limits, the API returns a descriptive error instead of failing the entire request:
 
-| Error              | Trigger                                                         |
-| ------------------ | --------------------------------------------------------------- |
-| `TimeoutError`     | Function wall-clock time exceeded the plan limit                |
-| `CpuTimeError`     | Function CPU time exceeded the plan limit                       |
-| `MemoryError`      | Function memory usage exceeded the plan limit                   |
-| `CodeSizeError`    | Function code exceeds the 1024 bytes free plan limit            |
-| `ConcurrencyError` | Too many concurrent function executions for the free plan (1 per IP) |
+| Error                  | Trigger                                                              |
+| ---------------------- | -------------------------------------------------------------------- |
+| `TimeoutError`         | Function wall-clock time exceeded the plan limit                     |
+| `CpuTimeError`         | Function CPU time exceeded the plan limit                            |
+| `MemoryError`          | Function memory usage exceeded the plan limit                        |
+| `CodeSizeError`        | Function code exceeds the 1024 bytes free plan limit                 |
+| `ConcurrencyError`     | Too many concurrent function executions for the free plan            |
 | `OutgoingRequestError` | Function made a cross-origin network request on the free plan        |
 
 Each error message is plan-aware:
@@ -83,7 +83,7 @@ Binary data such as `Buffer` and typed arrays is allocated off the heap and is r
 2. Compress the function body manually with `lz#`, `br#`, or `gz#` prefixes.
 3. Upgrade to pro for unlimited code size.
 
-**ConcurrencyError** — too many concurrent function executions (1 per IP on the free plan):
+**ConcurrencyError** — too many concurrent function executions (1 in-flight per IP on the free plan):
 
 1. Wait for the current function execution to finish before sending another request.
 2. Upgrade to pro for unlimited concurrency.


### PR DESCRIPTION
## Summary
- Align function plan-limit docs with the API: free concurrency is 1 in-flight request per IP, not a vague “1 per IP”.
- Document same-origin vs unrestricted outgoing requests on the profiling page.

## Test plan
- [ ] Docs render on the function parameter and guide pages


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified free-plan concurrency limits as one in-flight request per IP.
  - Updated concurrency error guidance to reflect the revised limit description.
  - Documented outgoing-request restrictions: same-origin requests for free plans and unrestricted requests for pro plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->