### PR TITLE
fix(search): stop claiming Google Search API

### DIFF
--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -616,7 +616,7 @@
   "src/pages/screenshot/php.js": "2026-06-29T00:00:00.000Z",
   "src/pages/screenshot/python.js": "2026-06-29T00:00:00.000Z",
   "src/pages/sdk.js": "2026-05-17T00:00:00.000Z",
-  "src/pages/search.js": "2026-07-22T00:00:00.000Z",
+  "src/pages/search.js": "2026-09-06T00:00:00.000Z",
   "src/pages/security.md": "2025-07-01T00:00:00.000Z",
   "src/pages/sharing-debugger.js": "2026-01-14T00:00:00.000Z",
   "src/pages/skills.js": "2026-07-17T00:00:00.000Z",

--- a/src/components/pages/search/Hero.js
+++ b/src/components/pages/search/Hero.js
@@ -76,7 +76,7 @@ const HeroSection = () => (
               lineHeight: 'inherit'
             })}
           >
-            for public Google results
+            for AI Agents
           </Text>
         </Text>
         <Text
@@ -92,8 +92,8 @@ const HeroSection = () => (
             textAlign: 'center'
           })}
         >
-          Query public Google search surfaces and get structured JSON in ~1s.
-          One Microlink client for tools, prompts, and RAG pipelines.
+          Search results in ~1s via a unified API. One client, normalized JSON
+          for tools, prompts, and RAG pipelines.
         </Text>
       </Box>
 

--- a/src/components/pages/search/Hero.js
+++ b/src/components/pages/search/Hero.js
@@ -65,7 +65,7 @@ const HeroSection = () => (
             textAlign: 'center'
           })}
         >
-          The Google Search API <br />
+          Microlink Search <br />
           <Text
             as='span'
             variant='gradient'
@@ -76,7 +76,7 @@ const HeroSection = () => (
               lineHeight: 'inherit'
             })}
           >
-            for AI Agents
+            for public Google results
           </Text>
         </Text>
         <Text
@@ -92,8 +92,8 @@ const HeroSection = () => (
             textAlign: 'center'
           })}
         >
-          Scrape Google search results in ~1s via a unified API. One client,
-          normalized JSON for tools, prompts, and RAG pipelines.
+          Query public Google search surfaces and get structured JSON in ~1s.
+          One Microlink client for tools, prompts, and RAG pipelines.
         </Text>
       </Box>
 

--- a/src/components/pages/search/IntegrationSection.js
+++ b/src/components/pages/search/IntegrationSection.js
@@ -67,11 +67,7 @@ console.log(page.results)`)
 ]
 
 const IntegrationSection = () => (
-  <Box
-    as='section'
-    id='google-api-integration'
-    css={theme({ py: [5, 5, 6, 6] })}
-  >
+  <Box as='section' id='search-integration' css={theme({ py: [5, 5, 6, 6] })}>
     <Container
       css={theme({
         p: 0,

--- a/src/components/pages/search/Playground.js
+++ b/src/components/pages/search/Playground.js
@@ -502,7 +502,7 @@ const Playground = () => {
     <Box
       id='playground'
       as='section'
-      aria-label='Google SERP API playground'
+      aria-label='Microlink Search playground'
       css={theme({ mt: 4 })}
     >
       <Text aria-live='polite' aria-atomic='true' css={visuallyHiddenCss}>

--- a/src/components/pages/search/RetrievalSection.js
+++ b/src/components/pages/search/RetrievalSection.js
@@ -55,7 +55,7 @@ const RetrievalSection = () => (
               textAlign: 'left'
             })}
           >
-            Scrape Google first, <br />
+            Search first, <br />
             <span css={theme({ color: 'red7' })}>fetch later</span>
           </Text>
           <Text

--- a/src/components/patterns/Footer/Footer.js
+++ b/src/components/patterns/Footer/Footer.js
@@ -34,6 +34,7 @@ const FOOTER_COLUMNS = [
       { label: 'Markdown', href: '/markdown' },
       { label: 'Metadata', href: '/metadata' },
       { label: 'Embed', href: '/embed' },
+      { label: 'Search', href: '/search' },
       { label: 'PDF', href: '/pdf' },
       { label: 'Logo', href: '/logo' },
       { label: 'HTML', href: '/html' },

--- a/src/components/patterns/Toolbar/ToolbarLinks.js
+++ b/src/components/patterns/Toolbar/ToolbarLinks.js
@@ -231,7 +231,7 @@ export const NAVIGATION_SECTIONS = [
         icon: Code
       }),
       createNavigationItem({
-        label: 'Search API',
+        label: 'Search',
         href: '/search',
         description: 'Turn Google results into structured data',
         icon: SearchIcon

--- a/src/helpers/search-landing.js
+++ b/src/helpers/search-landing.js
@@ -283,7 +283,7 @@ const FAQ_ENTRIES = [
   {
     question: 'What is Microlink Search?',
     answers: [
-      'Microlink Search is a paid Microlink product for querying and normalizing public results from multiple Google surfaces through one client.',
+      'Microlink Search is a paid search intelligence API for querying and normalizing public results from multiple Google surfaces through one product.',
       'The microlink.io SDK is the JavaScript client for integrating Search into your own SEO tooling, monitoring jobs, and AI workflows.'
     ]
   },
@@ -349,12 +349,18 @@ const buildSchemas = () => {
     url: PAGE_URL,
     image: HERO_IMAGE,
     description:
-      'Microlink Search queries public Google search surfaces and returns normalized JSON. Independent Microlink product, not affiliated with Google.',
+      'Microlink Search is a paid search intelligence API for querying and normalizing public results from Google Search, News, Maps, Shopping, Scholar, and more.',
     keywords: [
-      'Microlink Search',
-      'structured search results',
-      'public Google search results',
-      'search intelligence'
+      'search api',
+      'serp api',
+      'search intelligence api',
+      'search api for ai agents',
+      'search api for seo',
+      'local search api',
+      'shopping data api',
+      'ai seo data api',
+      'rank tracking api',
+      'news monitoring api'
     ],
     offers: {
       '@type': 'AggregateOffer',

--- a/src/helpers/search-landing.js
+++ b/src/helpers/search-landing.js
@@ -131,7 +131,8 @@ const GOOGLE_VERTICALS = [
   }
 ]
 
-const INSTALL_SNIPPET = sdkExample(`const page = await microlink.search('ai agents')
+const INSTALL_SNIPPET =
+  sdkExample(`const page = await microlink.search('ai agents')
 
 console.log(page.results)`)
 
@@ -282,15 +283,15 @@ const FAQ_ENTRIES = [
   {
     question: 'What is Microlink Search?',
     answers: [
-      'Microlink Search is a paid search intelligence API for querying and normalizing public results from multiple Google surfaces through one product.',
+      'Microlink Search is a paid Microlink product for querying and normalizing public results from multiple Google surfaces through one client.',
       'The microlink.io SDK is the JavaScript client for integrating Search into your own SEO tooling, monitoring jobs, and AI workflows.'
     ]
   },
   {
     question: 'Is this an official Google product?',
     answers: [
-      'No. Search is an independent Microlink product that works on top of public Google surfaces.',
-      'It is not affiliated with, endorsed by, or provided by Google.'
+      'No. Search is an independent Microlink product that queries public Google surfaces and returns structured results for your own workflows.',
+      'It is not affiliated with, endorsed by, or provided by Google, and it does not replace Google Search.'
     ]
   },
   {
@@ -348,19 +349,12 @@ const buildSchemas = () => {
     url: PAGE_URL,
     image: HERO_IMAGE,
     description:
-      'Microlink Search is a paid search intelligence API for querying and normalizing public results from Google Search, News, Maps, Shopping, Scholar, and more.',
+      'Microlink Search queries public Google search surfaces and returns normalized JSON. Independent Microlink product, not affiliated with Google.',
     keywords: [
-      'search api',
-      'serp api',
-      'search intelligence api',
-      'serp api alternative',
-      'search api for ai agents',
-      'search api for seo',
-      'local search api',
-      'shopping data api',
-      'ai seo data api',
-      'rank tracking api',
-      'news monitoring api'
+      'Microlink Search',
+      'structured search results',
+      'public Google search results',
+      'search intelligence'
     ],
     offers: {
       '@type': 'AggregateOffer',

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -71,8 +71,8 @@ const GooglePage = () => (
 
 export const Head = () => (
   <Meta
-    title='Google Search API (SERP) for AI Agents | Microlink'
-    description='Scrape Google Search results in ~1s. A reliable Google SERP API delivering normalized JSON for RAG pipelines, LLM tools, and developer workflows.'
+    title='Search — Structured public Google results'
+    description='Query public Google search surfaces with Microlink Search. Normalized JSON for RAG, LLM tools, and developer workflows. Not affiliated with Google.'
     image={HERO_IMAGE}
     structured={STRUCTURED_DATA}
   />

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -71,8 +71,8 @@ const GooglePage = () => (
 
 export const Head = () => (
   <Meta
-    title='Search — Structured public Google results'
-    description='Query public Google search surfaces with Microlink Search. Normalized JSON for RAG, LLM tools, and developer workflows. Not affiliated with Google.'
+    title='Search — Structured results for AI Agents'
+    description='Search results in ~1s. Normalized JSON for RAG pipelines, LLM tools, and developer workflows. Not affiliated with Google.'
     image={HERO_IMAGE}
     structured={STRUCTURED_DATA}
   />


### PR DESCRIPTION
## Summary
- Rename the nav item from Search API to Search, and add Search to the footer product list.
- Reword `/search` so Microlink Search is the product and public Google surfaces are the data source.
- Drop "Google Search API" / SERP API impersonation language from the title, hero, schema, and playground label so crawlers do not read this as a Google product or a Search replacement.

## Test plan
- [ ] Products menu shows Search (not Search API)
- [ ] Footer Products includes Search
- [ ] `/search` title and H1 name Microlink Search and public Google results
- [ ] FAQ "Is this an official Google product?" says not affiliated and does not replace Google Search
- [ ] Meta description includes the not-affiliated line


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Search links to the product navigation and footer.

* **Documentation**
  * Updated search page messaging to emphasize structured results, normalized JSON, AI agents, RAG pipelines, LLM tools, and developer workflows.
  * Clarified that the service is not affiliated with or a replacement for Google Search.
  * Refined headings, accessibility labels, FAQs, and metadata to reflect the updated Search positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->