### PR TITLE
feat: publish OpenAPI and agent 404s

### DIFF
--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -270,7 +270,7 @@
   "src/content/styleguide.md": "2026-01-10T00:00:00.000Z",
   "src/content/subprocessors.md": "2026-08-27T00:00:00.000Z",
   "src/content/tos.md": "2026-01-10T00:00:00.000Z",
-  "src/pages/404.js": "2026-07-12T00:00:00.000Z",
+  "src/pages/404.js": "2026-09-06T00:00:00.000Z",
   "src/pages/about.md": "2025-10-30T00:00:00.000Z",
   "src/pages/alternative/apiflash.js": "2026-08-20T00:00:00.000Z",
   "src/pages/alternative/browserbase.js": "2026-08-31T00:00:00.000Z",

--- a/scripts/build-llms-txt.js
+++ b/scripts/build-llms-txt.js
@@ -75,6 +75,10 @@ const llmsTxt = [
   '',
   '> Turn any website into data. APIs for link previews, screenshots, PDF generation, and web scraping.',
   '',
+  '## Machine-readable',
+  '',
+  '- [OpenAPI](https://microlink.io/openapi.json): Microlink API specification',
+  '',
   SECTIONS.map(toSection).join('\n\n'),
   ''
 ].join('\n')

--- a/scripts/build-openapi.js
+++ b/scripts/build-openapi.js
@@ -1,0 +1,59 @@
+'use strict'
+
+/**
+ * Generates static/openapi.json from the API parameter docs and error codes.
+ *
+ * Usage:
+ *   node scripts/build-openapi.js
+ */
+
+const { readdirSync, readFileSync, writeFileSync } = require('fs')
+const path = require('path')
+
+const ROOT_DIR = path.join(__dirname, '..')
+const PARAMETERS_DIR = path.join(
+  ROOT_DIR,
+  'src',
+  'content',
+  'docs',
+  'api',
+  'parameters'
+)
+const ERROR_CODES_PATH = path.join(
+  ROOT_DIR,
+  'src',
+  'content',
+  'docs',
+  'api',
+  'basics',
+  'error-codes.md'
+)
+const OUTPUT_PATH = path.join(ROOT_DIR, 'static', 'openapi.json')
+
+const load = async () => {
+  const { buildOpenApi, errorCodesFrom, parameterFromDoc } = await import(
+    '../src/helpers/openapi.js'
+  )
+
+  const files = readdirSync(PARAMETERS_DIR, { recursive: true })
+    .filter(entry => entry.endsWith('.md'))
+    .map(entry => entry.split(path.sep).join('/'))
+    .sort()
+
+  const parameters = files.map(file =>
+    parameterFromDoc(
+      file,
+      readFileSync(path.join(PARAMETERS_DIR, file), 'utf8')
+    )
+  )
+
+  const spec = buildOpenApi({
+    parameters,
+    errorCodes: errorCodesFrom(readFileSync(ERROR_CODES_PATH, 'utf8'))
+  })
+
+  writeFileSync(OUTPUT_PATH, `${JSON.stringify(spec, null, 2)}\n`)
+  console.log(`Generated ${path.relative(ROOT_DIR, OUTPUT_PATH)}`)
+}
+
+load()

--- a/src/helpers/llms-txt.js
+++ b/src/helpers/llms-txt.js
@@ -7,6 +7,10 @@ const HEADING = '# Microlink'
 const SUMMARY =
   '> Turn any website into data. APIs for link previews, screenshots, PDF generation, and web scraping.'
 
+const MACHINE_READABLE = `## Machine-readable
+
+- [OpenAPI](https://microlink.io/openapi.json): Microlink API specification`
+
 const TITLE_SUFFIX = /\s+—\s+Microlink(\s+\w+)?$/
 
 const SECTIONS = [
@@ -68,5 +72,5 @@ export const buildLlmsTxt = pages => {
     )
     .join('\n\n')
 
-  return `${HEADING}\n\n${SUMMARY}\n\n${body}\n`
+  return `${HEADING}\n\n${SUMMARY}\n\n${MACHINE_READABLE}\n\n${body}\n`
 }

--- a/src/helpers/openapi.js
+++ b/src/helpers/openapi.js
@@ -1,0 +1,284 @@
+export const SITE_URL = 'https://microlink.io'
+
+export const OPENAPI_PATH = '/openapi.json'
+
+const TYPE_MAP = {
+  string: { type: 'string' },
+  boolean: { type: 'boolean' },
+  number: { type: 'number' },
+  object: { type: 'object', additionalProperties: true }
+}
+
+const unwrapType = value => value.replace(/^<|>$/g, '')
+
+export const errorCodesFrom = markdown =>
+  markdown
+    .split('\n')
+    .filter(line => line.startsWith('## '))
+    .map(line => line.slice(3).trim())
+
+export const parameterNameFrom = file =>
+  file
+    .replace(/\.md$/, '')
+    .replace(/\/index$/, '')
+    .replace(/\//g, '.')
+
+export const schemaFromTypes = types => {
+  const schemas = types
+    .map(unwrapType)
+    .map(type => TYPE_MAP[type])
+    .filter(Boolean)
+
+  if (schemas.length === 0) return { type: 'string' }
+  if (schemas.length === 1) return schemas[0]
+  return { oneOf: schemas }
+}
+
+export const typesFromParameterDoc = content => {
+  const body = content.split(/^---$/m).slice(2).join('---')
+  const typeLine = body.split('\n').find(line => line.startsWith('Type:'))
+  if (!typeLine) return ['string']
+  const matches = [...typeLine.matchAll(/Type children=['"]([^'"]+)['"]/g)]
+  return matches.length > 0 ? matches.map(match => match[1]) : ['string']
+}
+
+const unquote = value =>
+  value
+    .trim()
+    .replace(/^['"]/, '')
+    .replace(/['"]$/, '')
+    .replace(/''/g, "'")
+    .trim()
+
+export const frontmatterField = (content, field) => {
+  const frontmatter = content.split(/^---$/m)[1] || ''
+  const line = frontmatter
+    .split('\n')
+    .find(entry => entry.startsWith(`${field}:`))
+  return line ? unquote(line.slice(field.length + 1)) : ''
+}
+
+export const parameterFromDoc = (file, content) => {
+  const name = parameterNameFrom(file)
+  const description = frontmatterField(content, 'description')
+  const isPro = /isPro:\s*true/.test(content.split(/^---$/m)[1] || '')
+  const schema = schemaFromTypes(typesFromParameterDoc(content))
+
+  return {
+    name,
+    in: 'query',
+    required: name === 'url',
+    description: isPro ? `${description} Requires a Pro plan.` : description,
+    schema,
+    externalDocs: {
+      url: `${SITE_URL}/docs/api/parameters/${file
+        .replace(/\.md$/, '')
+        .replace(/\/index$/, '')}`
+    }
+  }
+}
+
+const errorResponse = description => ({
+  description,
+  content: {
+    'application/json': {
+      schema: { $ref: '#/components/schemas/Error' }
+    }
+  }
+})
+
+export const buildOpenApi = ({ parameters, errorCodes }) => ({
+  openapi: '3.1.0',
+  info: {
+    title: 'Microlink API',
+    summary: 'Turn any website into data.',
+    description:
+      'A single HTTP GET turns a URL into metadata, screenshots, PDFs, media, and structured extraction. Query parameters accept camelCase or snake_case. Authenticated requests use the Pro endpoint with an `x-api-key` header.',
+    version: '1.0.0',
+    contact: {
+      name: 'Microlink HQ',
+      email: 'hello@microlink.io',
+      url: SITE_URL
+    },
+    license: {
+      name: 'MIT',
+      url: 'https://github.com/microlinkhq/www/blob/master/LICENSE'
+    }
+  },
+  externalDocs: {
+    description: 'API documentation',
+    url: `${SITE_URL}/docs/api/getting-started/overview`
+  },
+  servers: [
+    {
+      url: 'https://api.microlink.io',
+      description: 'Free endpoint. Daily rate limit. No API key.'
+    },
+    {
+      url: 'https://pro.microlink.io',
+      description:
+        'Pro endpoint. Send `x-api-key`. Higher limits and Pro parameters.'
+    }
+  ],
+  security: [{}, { apiKey: [] }],
+  tags: [
+    {
+      name: 'URL',
+      description: 'Normalize any public URL into structured data.'
+    }
+  ],
+  paths: {
+    '/': {
+      get: {
+        tags: ['URL'],
+        operationId: 'retrieveUrl',
+        summary: 'Retrieve data from a URL',
+        description:
+          'Give a `url` and get structured metadata back. Add query parameters to take a screenshot, render a PDF, extract fields, or embed a single asset. Failures use a typed error object with `code` and `message`.',
+        parameters,
+        responses: {
+          200: {
+            description: 'The URL was resolved successfully.',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Success' }
+              }
+            }
+          },
+          400: errorResponse(
+            'The request failed. A parameter is missing, invalid, or not allowed on the current plan.'
+          ),
+          401: errorResponse(
+            'Authentication failed. Send a valid `x-api-key` or use the free endpoint without one.'
+          ),
+          403: errorResponse(
+            'The request is not allowed. Typical codes: EFORBIDDENURL, EPRO, EINTEGRATION.'
+          ),
+          408: errorResponse(
+            'The request reached its timeout. Typical codes: ETIMEOUT, EBRWSRTIMEOUT.'
+          ),
+          429: errorResponse(
+            'The daily or monthly rate limit has been reached. Code: ERATE.'
+          ),
+          500: errorResponse(
+            'An unexpected error occurred. Typical codes: EFATAL, EFATALCLIENT.'
+          )
+        }
+      }
+    }
+  },
+  components: {
+    securitySchemes: {
+      apiKey: {
+        type: 'apiKey',
+        in: 'header',
+        name: 'x-api-key',
+        description:
+          'Pro API key. Use the `https://pro.microlink.io` server. Do not send this header to the free endpoint (that returns EPRO).'
+      }
+    },
+    schemas: {
+      Media: {
+        type: 'object',
+        properties: {
+          url: { type: 'string', format: 'uri' },
+          type: { type: 'string' },
+          size: { type: 'integer' },
+          size_pretty: { type: 'string' },
+          width: { type: 'integer' },
+          height: { type: 'integer' },
+          duration: { type: 'number' },
+          duration_pretty: { type: 'string' }
+        }
+      },
+      Data: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          author: { type: ['string', 'null'] },
+          date: { type: ['string', 'null'], format: 'date-time' },
+          description: { type: ['string', 'null'] },
+          image: {
+            oneOf: [{ $ref: '#/components/schemas/Media' }, { type: 'null' }]
+          },
+          video: {
+            oneOf: [{ $ref: '#/components/schemas/Media' }, { type: 'null' }]
+          },
+          audio: {
+            oneOf: [{ $ref: '#/components/schemas/Media' }, { type: 'null' }]
+          },
+          lang: { type: ['string', 'null'] },
+          logo: {
+            oneOf: [{ $ref: '#/components/schemas/Media' }, { type: 'null' }]
+          },
+          publisher: { type: ['string', 'null'] },
+          title: { type: ['string', 'null'] },
+          url: { type: 'string', format: 'uri' },
+          screenshot: { $ref: '#/components/schemas/Media' },
+          pdf: { $ref: '#/components/schemas/Media' },
+          statusCode: { type: 'integer' },
+          headers: {
+            type: 'object',
+            additionalProperties: { type: 'string' }
+          },
+          redirects: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                statusCode: { type: 'integer' },
+                url: { type: 'string', format: 'uri' }
+              }
+            }
+          }
+        }
+      },
+      Success: {
+        type: 'object',
+        required: ['status', 'data'],
+        properties: {
+          status: { type: 'string', const: 'success' },
+          data: { $ref: '#/components/schemas/Data' }
+        }
+      },
+      Error: {
+        type: 'object',
+        required: ['status', 'code', 'message'],
+        description:
+          'JSend fail/error payload. `code` is machine-readable; `message` is human-readable.',
+        properties: {
+          status: { type: 'string', enum: ['fail', 'error'] },
+          code: {
+            type: 'string',
+            enum: errorCodes,
+            description:
+              'Stable error code. See https://microlink.io/docs/api/basics/error-codes'
+          },
+          message: {
+            type: 'string',
+            description: 'Human-readable explanation of why the request failed.'
+          },
+          more: {
+            type: 'string',
+            format: 'uri',
+            description: 'Documentation URL for this error code.'
+          },
+          report: {
+            type: 'string',
+            format: 'uri',
+            description: 'URL for reporting the request to Microlink.'
+          },
+          id: {
+            type: 'string',
+            description:
+              'Request identifier. Include it when contacting support.'
+          },
+          data: {
+            type: 'object',
+            additionalProperties: true
+          }
+        }
+      }
+    }
+  }
+})

--- a/src/helpers/openapi.js
+++ b/src/helpers/openapi.js
@@ -6,7 +6,8 @@ const TYPE_MAP = {
   string: { type: 'string' },
   boolean: { type: 'boolean' },
   number: { type: 'number' },
-  object: { type: 'object', additionalProperties: true }
+  object: { type: 'object', additionalProperties: true },
+  'string[]': { type: 'array', items: { type: 'string' } }
 }
 
 const unwrapType = value => value.replace(/^<|>$/g, '')

--- a/src/helpers/page-markdown.js
+++ b/src/helpers/page-markdown.js
@@ -23,16 +23,39 @@ export const toMarkdownPath = pathname =>
 export const prependTitle = (title, markdown) =>
   title ? `# ${title}\n\n${markdown}` : markdown
 
+export const SITE_URL = 'https://microlink.io'
+
+export const notFoundLinks = [
+  { href: '/', label: 'Home' },
+  { href: '/docs', label: 'Documentation' },
+  {
+    href: '/llms.txt',
+    label: 'llms.txt',
+    detail: 'index of every page as markdown'
+  },
+  {
+    href: '/openapi.json',
+    label: 'OpenAPI',
+    detail: 'machine-readable API specification'
+  },
+  { href: '/sitemap.xml', label: 'Sitemap' }
+]
+
+const toAbsolute = href =>
+  href === '/' ? `${SITE_URL}/` : `${SITE_URL}${href}`
+
 export const notFoundMarkdown = `# Page not found
 
 The page you’re looking for doesn’t exist or has been moved.
 
 ## Where to look next
 
-- [Home](https://microlink.io/)
-- [Documentation](https://microlink.io/docs)
-- [llms.txt](https://microlink.io/llms.txt) — index of every page as markdown
-- [Sitemap](https://microlink.io/sitemap.xml)
+${notFoundLinks
+  .map(({ href, label, detail }) => {
+    const note = detail ? ` — ${detail}` : ''
+    return `- [${label}](${toAbsolute(href)})${note}`
+  })
+  .join('\n')}
 `
 
 export const extractMarkdown = async (fetchMarkdown, pathname) => {

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,12 +1,15 @@
 import { withTitle } from 'helpers/hoc/with-title'
 import Caption from 'components/patterns/Caption/Caption'
 import Layout from 'components/patterns/Layout'
+import { notFoundLinks } from 'helpers/page-markdown'
 import { layout, theme } from 'theme'
 import React from 'react'
 
 import Flex from 'components/elements/Flex'
 import HeadingBase from 'components/elements/Heading'
+import { Link } from 'components/elements/Link'
 import Meta from 'components/elements/Meta/Meta'
+import Text from 'components/elements/Text'
 
 const Heading = withTitle(HeadingBase)
 
@@ -36,6 +39,33 @@ const NotFoundPage = () => (
       >
         The page you’re looking for doesn’t exist or has been moved.
       </Caption>
+
+      <Flex
+        as='ul'
+        css={theme({
+          flexDirection: 'column',
+          alignItems: 'center',
+          pt: [3, null, 4],
+          px: 4,
+          pl: 0,
+          m: 0,
+          maxWidth: layout.small
+        })}
+        style={{ listStyle: 'none' }}
+      >
+        {notFoundLinks.map(({ href, label }) => (
+          <Text
+            as='li'
+            key={href}
+            css={theme({
+              py: [3, 3, 2, 2],
+              textAlign: 'center'
+            })}
+          >
+            <Link href={href}>{label}</Link>
+          </Text>
+        ))}
+      </Flex>
     </Flex>
   </Layout>
 )

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -62,7 +62,9 @@ const NotFoundPage = () => (
               textAlign: 'center'
             })}
           >
-            <Link href={href}>{label}</Link>
+            <Link href={href} prefetch={false}>
+              {label}
+            </Link>
           </Text>
         ))}
       </Flex>

--- a/static/404.md
+++ b/static/404.md
@@ -1,0 +1,11 @@
+# Page not found
+
+The page you’re looking for doesn’t exist or has been moved.
+
+## Where to look next
+
+- [Home](https://microlink.io/)
+- [Documentation](https://microlink.io/docs)
+- [llms.txt](https://microlink.io/llms.txt) — index of every page as markdown
+- [OpenAPI](https://microlink.io/openapi.json) — machine-readable API specification
+- [Sitemap](https://microlink.io/sitemap.xml)

--- a/static/apis.json
+++ b/static/apis.json
@@ -38,6 +38,10 @@
 	        {
 	          "type": "X-docs",
 	          "url": "https://microlink.io/docs"
+	        },
+	        {
+	          "type": "OpenAPI",
+	          "url": "https://microlink.io/openapi.json"
 	        }
 	      ],
 	      "contact": [

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -2,6 +2,10 @@
 
 > Turn any website into data. APIs for link previews, screenshots, PDF generation, and web scraping.
 
+## Machine-readable
+
+- [OpenAPI](https://microlink.io/openapi.json): Microlink API specification
+
 ## API
 
 - [Authentication](https://microlink.io/docs/api/basics/authentication.md): Securely authenticate your Microlink API requests using x-api-key headers. Includes best practices for Pro plan integration and protecting tokens via proxy for frontend usage.
@@ -11,7 +15,7 @@
 - [Error codes](https://microlink.io/docs/api/basics/error-codes.md): Troubleshoot Microlink API error codes including EAUTH, ERATE, and EBRWSRTIMEOUT. Find solutions for authentication issues, rate limits, timeouts, and specific Pro plan parameter requirements.
 - [Format](https://microlink.io/docs/api/basics/format.md): Understand the Microlink API response format based on the JSend specification. Learn about status codes, JSON data payloads, and how to handle error messages.
 - [Rate limit](https://microlink.io/docs/api/basics/rate-limit.md): Understand Microlink API rate limits for free and pro endpoints. Monitor usage via x-rate-limit headers, handle HTTP 429, and scale your quota for high-concurrency.
-- [CLI](https://microlink.io/docs/api/getting-started/cli.md): Install and use the CLI to interact with the API from your terminal. Perform requests, authenticate via API keys, and format JSON output.
+- [CLI](https://microlink.io/docs/api/getting-started/cli.md): Install and use the CLI to interact with the API from your terminal. Every product is a subcommand; flags map to API options.
 - [Data fields](https://microlink.io/docs/api/getting-started/data-fields.md): Explore the default data fields extracted by Microlink API, including metadata, media properties, and HTTP status details like headers and redirects.
 - [MCP](https://microlink.io/docs/api/getting-started/mcp.md): Connect Microlink MCP to your AI client to extract metadata, screenshots, PDFs, insights, media, markdown, and text from any URL.
 - [Overview](https://microlink.io/docs/api/getting-started/overview.md): Get started with Microlink API. Learn how to automate browser actions, extract metadata, take screenshots, generate PDFs with a simple HTTP GET request.
@@ -49,6 +53,8 @@
 - [ping](https://microlink.io/docs/api/parameters/ping.md): Validate the accessibility of all URLs extracted in the response payload. The ping parameter verifies that links to images, videos, or audio are publicly reachable.
 - [prerender](https://microlink.io/docs/api/parameters/prerender.md): Optimize how content is fetched from the target URL by choosing between a headless browser or a simple HTTP request.
 - [proxy](https://microlink.io/docs/api/parameters/proxy.md): Bypass IP rate limits, CAPTCHAs, and regional restrictions using high-quality proxy rotation.
+- [proxy › location](https://microlink.io/docs/api/parameters/proxy/location.md): Route the request through a proxy IP in a specific country to fetch region-specific content.
+- [proxy › url](https://microlink.io/docs/api/parameters/proxy/url.md): Route every sub-request through your own HTTP proxy server.
 - [retry](https://microlink.io/docs/api/parameters/retry.md): Configure the number of exponential backoff retries to attempt if the underlying browser encounters an unexpected internal error.
 - [screenshot › animated](https://microlink.io/docs/api/parameters/screenshot/animated.md): Record a website as a short video instead of a static image. Capture animations, transitions and live content as an H.264 MP4 with a single API call.
 - [screenshot › codeScheme](https://microlink.io/docs/api/parameters/screenshot/codeScheme.md): Beautify HTML and JSON content with professional code syntax highlighting using the codeScheme parameter. Choose from popular Prism themes like Darcula or provide a custom CSS URL.
@@ -178,7 +184,7 @@
 
 - [CLI](https://microlink.io/docs/sdk/getting-started/cli.md): Use the microlink binary bundled with the Microlink SDK. Every product is a subcommand, with flags mapping one-to-one to the SDK options.
 - [Errors](https://microlink.io/docs/sdk/getting-started/errors.md): Handle Microlink SDK failures with MicrolinkError. Every method throws a typed error carrying code, statusCode, and a human-readable description.
-- [Options](https://microlink.io/docs/sdk/getting-started/options.md): Learn how the Microlink SDK routes options. Product-specific keys nest automatically, headers travel as HTTP headers, and everything else maps to API query parameters.
+- [Options](https://microlink.io/docs/sdk/getting-started/options.md): How the Microlink SDK routes options, plus the shared options every method accepts: browser emulation, page lifecycle, cache, and request controls.
 - [Overview](https://microlink.io/docs/sdk/getting-started/overview.md): Get started with the Microlink SDK. The microlink.io package exposes every Microlink product as a semantic method for Node.js, browsers, and Deno.
 - [Collections](https://microlink.io/docs/sdk/methods/collections.md): Sweep any page with the Microlink SDK and get every matching resource back as an array: links, images, videos, audios, and email addresses.
 - [Content](https://microlink.io/docs/sdk/methods/content.md): Turn any URL into rendered output with the Microlink SDK: unified metadata, Markdown, HTML, plain text, screenshots, PDFs, logos, and embeds.

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -105,7 +105,17 @@
             "required": false,
             "description": "Automate browser interactions by clicking specific DOM elements via CSS selectors. Use this parameter to trigger navigation, toggle UI components, or change page state.",
             "schema": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
             },
             "externalDocs": {
               "url": "https://microlink.io/docs/api/parameters/click"
@@ -343,7 +353,17 @@
             "required": false,
             "description": "Inject JavaScript modules into a webpage during the rendering process.",
             "schema": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
             },
             "externalDocs": {
               "url": "https://microlink.io/docs/api/parameters/modules"
@@ -699,7 +719,17 @@
             "required": false,
             "description": "Inject custom JavaScript into a webpage before it is rendered or captured.",
             "schema": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
             },
             "externalDocs": {
               "url": "https://microlink.io/docs/api/parameters/scripts"
@@ -745,7 +775,17 @@
             "required": false,
             "description": "Inject custom CSS into a webpage before it is rendered or captured. The styles parameter supports both inline CSS rules and absolute URLs to external stylesheets.",
             "schema": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
             },
             "externalDocs": {
               "url": "https://microlink.io/docs/api/parameters/styles"
@@ -863,7 +903,17 @@
             "required": false,
             "description": "Fine-tune when Microlink considers a page fully \"loaded\" by waiting for specific lifecycle events.",
             "schema": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
             },
             "externalDocs": {
               "url": "https://microlink.io/docs/api/parameters/waitUntil"

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -1,0 +1,1198 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Microlink API",
+    "summary": "Turn any website into data.",
+    "description": "A single HTTP GET turns a URL into metadata, screenshots, PDFs, media, and structured extraction. Query parameters accept camelCase or snake_case. Authenticated requests use the Pro endpoint with an `x-api-key` header.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Microlink HQ",
+      "email": "hello@microlink.io",
+      "url": "https://microlink.io"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/microlinkhq/www/blob/master/LICENSE"
+    }
+  },
+  "externalDocs": {
+    "description": "API documentation",
+    "url": "https://microlink.io/docs/api/getting-started/overview"
+  },
+  "servers": [
+    {
+      "url": "https://api.microlink.io",
+      "description": "Free endpoint. Daily rate limit. No API key."
+    },
+    {
+      "url": "https://pro.microlink.io",
+      "description": "Pro endpoint. Send `x-api-key`. Higher limits and Pro parameters."
+    }
+  ],
+  "security": [
+    {},
+    {
+      "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "URL",
+      "description": "Normalize any public URL into structured data."
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "tags": [
+          "URL"
+        ],
+        "operationId": "retrieveUrl",
+        "summary": "Retrieve data from a URL",
+        "description": "Give a `url` and get structured metadata back. Add query parameters to take a screenshot, render a PDF, extract fields, or embed a single asset. Failures use a typed error object with `code` and `message`.",
+        "parameters": [
+          {
+            "name": "adblock",
+            "in": "query",
+            "required": false,
+            "description": "Improve performance and reduce response times by blocking non-essential advertisements, trackers, and cookie banners.",
+            "schema": {
+              "type": "boolean"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/adblock"
+            }
+          },
+          {
+            "name": "animations",
+            "in": "query",
+            "required": false,
+            "description": "Control CSS animations and transitions during website rendering. Ensures consistent snapshots by handling motion effects in the headless browser.",
+            "schema": {
+              "type": "boolean"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/animations"
+            }
+          },
+          {
+            "name": "audio",
+            "in": "query",
+            "required": false,
+            "description": "Detect and extract audio sources from any URL. It returns browser-friendly audio URLs along with metadata enabling integration of media content from platforms.",
+            "schema": {
+              "type": "boolean"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/audio"
+            }
+          },
+          {
+            "name": "cacheKey",
+            "in": "query",
+            "required": false,
+            "description": "Take full control of cache identity to maximize hit rates and avoid redundant processing. Requires a Pro plan.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/cacheKey"
+            }
+          },
+          {
+            "name": "click",
+            "in": "query",
+            "required": false,
+            "description": "Automate browser interactions by clicking specific DOM elements via CSS selectors. Use this parameter to trigger navigation, toggle UI components, or change page state.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/click"
+            }
+          },
+          {
+            "name": "colorScheme",
+            "in": "query",
+            "required": false,
+            "description": "Force the browser to render websites in light or dark mode using the prefers-color-scheme CSS media feature.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/colorScheme"
+            }
+          },
+          {
+            "name": "data",
+            "in": "query",
+            "required": false,
+            "description": "Define custom data extraction rules using CSS selectors with the Microlink Query Language (MQL). Extract specific content like prices, reviews, or any structured data from any URL.",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/data"
+            }
+          },
+          {
+            "name": "device",
+            "in": "query",
+            "required": false,
+            "description": "Emulate a wide range of mobile, tablet, and desktop devices by automatically setting the correct viewport, user agent, and screen resolution.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/device"
+            }
+          },
+          {
+            "name": "embed",
+            "in": "query",
+            "required": false,
+            "description": "Return a specific data field directly as the response body with appropriate content-type headers. Embed screenshots, PDFs, or extracted data directly in HTML, CSS, or Markdown.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/embed"
+            }
+          },
+          {
+            "name": "filename",
+            "in": "query",
+            "required": false,
+            "description": "Define a custom name for generated assets like screenshots or PDFs using the filename parameter. Requires a Pro plan.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/filename"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Reduce response bandwidth and optimize payload size by selecting specific data fields.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/filter"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "description": "Bypass the Microlink CDN cache to fetch a fresh version of the target URL. Use the force parameter to invalidate existing cached copies and ensure the most up-to-date metadata.",
+            "schema": {
+              "type": "boolean"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/force"
+            }
+          },
+          {
+            "name": "function",
+            "in": "query",
+            "required": false,
+            "description": "Execute custom JavaScript code inside a headless browser to perform advanced scraping or automation tasks. Gain full control over the page lifecycle with Puppeteer access.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/function"
+            }
+          },
+          {
+            "name": "headers",
+            "in": "query",
+            "required": false,
+            "description": "Configure custom HTTP headers to be sent with your requests to the target URL. This Pro feature allows for emulating specific browsers. Requires a Pro plan.",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/headers"
+            }
+          },
+          {
+            "name": "iframe",
+            "in": "query",
+            "required": false,
+            "description": "The iframe parameter returns ready-to-use HTML and script tags for hundreds of providers.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/iframe"
+            }
+          },
+          {
+            "name": "insights",
+            "in": "query",
+            "required": false,
+            "description": "Analyze web performance and stack data with Microlink Insights. Extract identified technologies via Wappalyzer and detailed Lighthouse audit reports directly from any target URL.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/insights"
+            }
+          },
+          {
+            "name": "insights.lighthouse",
+            "in": "query",
+            "required": false,
+            "description": "Generate comprehensive Google Lighthouse reports for any URL. Export web performance audits in JSON, HTML, or CSV formats using custom configurations via Microlink API.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/insights/lighthouse"
+            }
+          },
+          {
+            "name": "insights.technologies",
+            "in": "query",
+            "required": false,
+            "description": "Identify the software stack behind any URL using Microlink technology detection. It returns a detailed list of frameworks, CDNs, and analytics tools with confidence scores.",
+            "schema": {
+              "type": "boolean"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/insights/technologies"
+            }
+          },
+          {
+            "name": "javascript",
+            "in": "query",
+            "required": false,
+            "description": "Control whether JavaScript is executed within the headless browser for a target URL.",
+            "schema": {
+              "type": "boolean"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/javascript"
+            }
+          },
+          {
+            "name": "mediaType",
+            "in": "query",
+            "required": false,
+            "description": "Switch between \"screen\" and \"print\" CSS media queries to control how a website renders for capture.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/mediaType"
+            }
+          },
+          {
+            "name": "meta",
+            "in": "query",
+            "required": false,
+            "description": "Extract normalized metadata from any URL, including titles, descriptions, images, and logos.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/meta"
+            }
+          },
+          {
+            "name": "modules",
+            "in": "query",
+            "required": false,
+            "description": "Inject JavaScript modules into a webpage during the rendering process.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/modules"
+            }
+          },
+          {
+            "name": "palette",
+            "in": "query",
+            "required": false,
+            "description": "Extract dominant color palettes and accessibility-compliant color schemes from detected images.",
+            "schema": {
+              "type": "boolean"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/palette"
+            }
+          },
+          {
+            "name": "pdf.format",
+            "in": "query",
+            "required": false,
+            "description": "Customize the paper format for PDF generation from any URL. Supports standard sizes including A4, Letter, Legal, and Tabloid for high-quality.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/pdf/format"
+            }
+          },
+          {
+            "name": "pdf.height",
+            "in": "query",
+            "required": false,
+            "description": "Set a custom paper height for your PDF generation using pixels, inches, or other CSS units. Fine-tune the dimensions of your website-to-PDF conversions.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/pdf/height"
+            }
+          },
+          {
+            "name": "pdf",
+            "in": "query",
+            "required": false,
+            "description": "Generate high-quality PDFs from any website using Microlink headless browser infrastructure.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/pdf"
+            }
+          },
+          {
+            "name": "pdf.landscape",
+            "in": "query",
+            "required": false,
+            "description": "Set the paper orientation to landscape for your website-to-PDF conversions. Toggle between portrait and landscape modes to optimize the layout of generated PDF documents.",
+            "schema": {
+              "type": "boolean"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/pdf/landscape"
+            }
+          },
+          {
+            "name": "pdf.margin",
+            "in": "query",
+            "required": false,
+            "description": "Configure custom paper margins for your website-to-PDF conversions. Specify unified margins or individual top, bottom, left, and right values.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/pdf/margin"
+            }
+          },
+          {
+            "name": "pdf.pageRanges",
+            "in": "query",
+            "required": false,
+            "description": "Define specific page ranges for your website-to-PDF conversion. Extract single pages or custom intervals like \"1-5, 8, 11-13\" from any URL using the Microlink API pageRanges parameter.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/pdf/pageRanges"
+            }
+          },
+          {
+            "name": "pdf.scale",
+            "in": "query",
+            "required": false,
+            "description": "Adjust the zoom level of your website-to-PDF conversions using the scale parameter with Microlink API automated browser.",
+            "schema": {
+              "type": "number"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/pdf/scale"
+            }
+          },
+          {
+            "name": "pdf.width",
+            "in": "query",
+            "required": false,
+            "description": "Set a custom paper width for your PDF generation using pixels, inches, or other CSS units. Fine-tune the horizontal dimensions of your website-to-PDF conversions.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/pdf/width"
+            }
+          },
+          {
+            "name": "ping",
+            "in": "query",
+            "required": false,
+            "description": "Validate the accessibility of all URLs extracted in the response payload. The ping parameter verifies that links to images, videos, or audio are publicly reachable.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/ping"
+            }
+          },
+          {
+            "name": "prerender",
+            "in": "query",
+            "required": false,
+            "description": "Optimize how content is fetched from the target URL by choosing between a headless browser or a simple HTTP request.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/prerender"
+            }
+          },
+          {
+            "name": "proxy",
+            "in": "query",
+            "required": false,
+            "description": "Bypass IP rate limits, CAPTCHAs, and regional restrictions using high-quality proxy rotation. Requires a Pro plan.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/proxy"
+            }
+          },
+          {
+            "name": "proxy.location",
+            "in": "query",
+            "required": false,
+            "description": "Route the request through a proxy IP in a specific country to fetch region-specific content. Requires a Pro plan.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/proxy/location"
+            }
+          },
+          {
+            "name": "proxy.url",
+            "in": "query",
+            "required": false,
+            "description": "Route every sub-request through your own HTTP proxy server. Requires a Pro plan.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/proxy/url"
+            }
+          },
+          {
+            "name": "retry",
+            "in": "query",
+            "required": false,
+            "description": "Configure the number of exponential backoff retries to attempt if the underlying browser encounters an unexpected internal error.",
+            "schema": {
+              "type": "number"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/retry"
+            }
+          },
+          {
+            "name": "screenshot.animated",
+            "in": "query",
+            "required": false,
+            "description": "Record a website as a short video instead of a static image. Capture animations, transitions and live content as an H.264 MP4 with a single API call.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/screenshot/animated"
+            }
+          },
+          {
+            "name": "screenshot.codeScheme",
+            "in": "query",
+            "required": false,
+            "description": "Beautify HTML and JSON content with professional code syntax highlighting using the codeScheme parameter. Choose from popular Prism themes like Darcula or provide a custom CSS URL.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/screenshot/codeScheme"
+            }
+          },
+          {
+            "name": "screenshot.element",
+            "in": "query",
+            "required": false,
+            "description": "Capture a specific DOM element as a screenshot by providing a CSS selector. The Microlink API automatically waits for the element to be visible before rendering the image.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/screenshot/element"
+            }
+          },
+          {
+            "name": "screenshot.fullPage",
+            "in": "query",
+            "required": false,
+            "description": "Capture a high-resolution screenshot of the entire scrollable content of a website. Use the fullPage parameter to render the complete layout of a URL.",
+            "schema": {
+              "type": "boolean"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/screenshot/fullPage"
+            }
+          },
+          {
+            "name": "screenshot",
+            "in": "query",
+            "required": false,
+            "description": "Generate high-fidelity screenshots of any website with a single API call. Automatically handle headless browser infrastructure to extract visual data.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/screenshot"
+            }
+          },
+          {
+            "name": "screenshot.omitBackground",
+            "in": "query",
+            "required": false,
+            "description": "Generate transparent screenshots by omitting the default white background of the webpage.",
+            "schema": {
+              "type": "boolean"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/screenshot/omitBackground"
+            }
+          },
+          {
+            "name": "screenshot.overlay",
+            "in": "query",
+            "required": false,
+            "description": "Create professional screenshot compositions with customizable browser overlays and backgrounds.",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/screenshot/overlay"
+            }
+          },
+          {
+            "name": "screenshot.quality",
+            "in": "query",
+            "required": false,
+            "description": "Control JPEG compression for website screenshots. Set quality between 0 and 100 to balance file size and visual fidelity.",
+            "schema": {
+              "type": "number"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/screenshot/quality"
+            }
+          },
+          {
+            "name": "screenshot.type",
+            "in": "query",
+            "required": false,
+            "description": "Choose between JPEG or PNG file formats for your website screenshots. Assets are automatically optimized and served in modern formats based on client device capabilities.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/screenshot/type"
+            }
+          },
+          {
+            "name": "scripts",
+            "in": "query",
+            "required": false,
+            "description": "Inject custom JavaScript into a webpage before it is rendered or captured.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/scripts"
+            }
+          },
+          {
+            "name": "scroll",
+            "in": "query",
+            "required": false,
+            "description": "Navigate to specific sections of a webpage by scrolling to a DOM element matching a CSS selector.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/scroll"
+            }
+          },
+          {
+            "name": "staleTtl",
+            "in": "query",
+            "required": false,
+            "description": "Optimize API performance by serving cached content while simultaneously refreshing it in the background. Requires a Pro plan.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/staleTtl"
+            }
+          },
+          {
+            "name": "styles",
+            "in": "query",
+            "required": false,
+            "description": "Inject custom CSS into a webpage before it is rendered or captured. The styles parameter supports both inline CSS rules and absolute URLs to external stylesheets.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/styles"
+            }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "required": false,
+            "description": "Define the maximum duration allowed for the API to process a request before timing out. The timeout parameter accepts values in milliseconds or human-readable formats.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/timeout"
+            }
+          },
+          {
+            "name": "ttl",
+            "in": "query",
+            "required": false,
+            "description": "Define the cache expiration time for your requests to balance data freshness and response speed. The ttl parameter supports human-readable formats. Requires a Pro plan.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/ttl"
+            }
+          },
+          {
+            "name": "url",
+            "in": "query",
+            "required": true,
+            "description": "The primary address of the website you want to process. The url parameter is the core requirement for any Microlink API request, serving as the base for metadata extraction.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/url"
+            }
+          },
+          {
+            "name": "video",
+            "in": "query",
+            "required": false,
+            "description": "Detect and extract direct video source URLs from any website in a browser-friendly format.",
+            "schema": {
+              "type": "boolean"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/video"
+            }
+          },
+          {
+            "name": "viewport",
+            "in": "query",
+            "required": false,
+            "description": "Customize the browser visible area and device capabilities to control how a website is rendered.",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/viewport"
+            }
+          },
+          {
+            "name": "waitForSelector",
+            "in": "query",
+            "required": false,
+            "description": "Pause browser execution until a specific element is present in the DOM. The waitForSelector parameter ensures that dynamic content is fully rendered before extracting data.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/waitForSelector"
+            }
+          },
+          {
+            "name": "waitForTimeout",
+            "in": "query",
+            "required": false,
+            "description": "Force the headless browser to wait for a specific duration before capturing or extracting data from the target URL.",
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/waitForTimeout"
+            }
+          },
+          {
+            "name": "waitUntil",
+            "in": "query",
+            "required": false,
+            "description": "Fine-tune when Microlink considers a page fully \"loaded\" by waiting for specific lifecycle events.",
+            "schema": {
+              "type": "string"
+            },
+            "externalDocs": {
+              "url": "https://microlink.io/docs/api/parameters/waitUntil"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The URL was resolved successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Success"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request failed. A parameter is missing, invalid, or not allowed on the current plan.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed. Send a valid `x-api-key` or use the free endpoint without one.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The request is not allowed. Typical codes: EFORBIDDENURL, EPRO, EINTEGRATION.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "408": {
+            "description": "The request reached its timeout. Typical codes: ETIMEOUT, EBRWSRTIMEOUT.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "The daily or monthly rate limit has been reached. Code: ERATE.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected error occurred. Typical codes: EFATAL, EFATALCLIENT.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key",
+        "description": "Pro API key. Use the `https://pro.microlink.io` server. Do not send this header to the free endpoint (that returns EPRO)."
+      }
+    },
+    "schemas": {
+      "Media": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "type": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "size_pretty": {
+            "type": "string"
+          },
+          "width": {
+            "type": "integer"
+          },
+          "height": {
+            "type": "integer"
+          },
+          "duration": {
+            "type": "number"
+          },
+          "duration_pretty": {
+            "type": "string"
+          }
+        }
+      },
+      "Data": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "author": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "date": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "image": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Media"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "video": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Media"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "audio": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Media"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lang": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "logo": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Media"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "publisher": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "screenshot": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "pdf": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "statusCode": {
+            "type": "integer"
+          },
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "redirects": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "statusCode": {
+                  "type": "integer"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Success": {
+        "type": "object",
+        "required": [
+          "status",
+          "data"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "const": "success"
+          },
+          "data": {
+            "$ref": "#/components/schemas/Data"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "status",
+          "code",
+          "message"
+        ],
+        "description": "JSend fail/error payload. `code` is machine-readable; `message` is human-readable.",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "fail",
+              "error"
+            ]
+          },
+          "code": {
+            "type": "string",
+            "enum": [
+              "EAUTH",
+              "ECACHEKEY",
+              "EBRWSRTIMEOUT",
+              "EFATAL",
+              "EFILENAME",
+              "EFATALCLIENT",
+              "EFORBIDDENURL",
+              "EHEADERS",
+              "EINVALURL",
+              "EINVALPROXY",
+              "EINVALURLCLIENT",
+              "EINVALTTL",
+              "EINVALEVAL",
+              "EINVALFUNCTION",
+              "EINVALDATA",
+              "EINVALQUERY",
+              "EINVALSTTL",
+              "EINVALOVERLAYBG",
+              "EINTEGRATION",
+              "EMAXREDIRECTS",
+              "EPAGERANGE",
+              "EPDFTOOLARGE",
+              "EPRO",
+              "EPROXY",
+              "EPROXYNEEDED",
+              "ERATE",
+              "ETIMEOUT",
+              "ETTL",
+              "ESTTL"
+            ],
+            "description": "Stable error code. See https://microlink.io/docs/api/basics/error-codes"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable explanation of why the request failed."
+          },
+          "more": {
+            "type": "string",
+            "format": "uri",
+            "description": "Documentation URL for this error code."
+          },
+          "report": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL for reporting the request to Microlink."
+          },
+          "id": {
+            "type": "string",
+            "description": "Request identifier. Include it when contacting support."
+          },
+          "data": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/helpers/page-markdown.js
+++ b/test/helpers/page-markdown.js
@@ -7,6 +7,7 @@ import {
   isMarkdownPage,
   toMarkdownPath,
   prependTitle,
+  notFoundLinks,
   notFoundMarkdown
 } from '../../src/helpers/page-markdown.js'
 
@@ -79,8 +80,19 @@ describe('notFoundMarkdown', () => {
     expect(notFoundMarkdown.startsWith('# Page not found\n')).toBe(true)
     expect(notFoundMarkdown).not.toContain('<!DOCTYPE')
     expect(notFoundMarkdown).toContain('https://microlink.io/llms.txt')
+    expect(notFoundMarkdown).toContain('https://microlink.io/openapi.json')
     expect(notFoundMarkdown).toContain('https://microlink.io/sitemap.xml')
     expect(notFoundMarkdown).toContain('https://microlink.io/docs')
+  })
+
+  test('lists every recovery link the HTML 404 page uses', () => {
+    expect(notFoundLinks.map(({ href }) => href)).toEqual([
+      '/',
+      '/docs',
+      '/llms.txt',
+      '/openapi.json',
+      '/sitemap.xml'
+    ])
   })
 })
 

--- a/test/llms-txt.js
+++ b/test/llms-txt.js
@@ -89,13 +89,32 @@ describe('buildLlmsTxt', () => {
     expect(content.startsWith('# Microlink\n\n> ')).toBe(true)
   })
 
+  test('points agents at the OpenAPI spec', () => {
+    expect(content).toContain(
+      '- [OpenAPI](https://microlink.io/openapi.json): Microlink API specification'
+    )
+  })
+
   test('writes one link per page', () => {
-    const links = content.split('\n').filter(line => line.startsWith('- ['))
-    expect(links).toHaveLength(PAGES.length)
+    const pageLinks = content
+      .split('## Machine-readable')[1]
+      .split(/^## /m)
+      .slice(1)
+      .join('\n')
+      .split('\n')
+      .filter(line => line.startsWith('- ['))
+    expect(pageLinks).toHaveLength(PAGES.length)
   })
 
   test('links every page to an absolute .md URL', () => {
-    for (const line of content.split('\n').filter(l => l.startsWith('- ['))) {
+    const pageLinks = content
+      .split('## Machine-readable')[1]
+      .split(/^## /m)
+      .slice(1)
+      .join('\n')
+      .split('\n')
+      .filter(line => line.startsWith('- ['))
+    for (const line of pageLinks) {
       expect(line).toMatch(/^- \[[^\]]+\]\(https:\/\/microlink\.io\/.+\.md\)/)
     }
   })
@@ -111,6 +130,7 @@ describe('buildLlmsTxt', () => {
 
   test('groups the links under H2 sections', () => {
     expect(content.match(/^## .+$/gm)).toEqual([
+      '## Machine-readable',
       '## API',
       '## Blog',
       '## Pages'

--- a/test/markdown-routes.js
+++ b/test/markdown-routes.js
@@ -54,9 +54,16 @@ const EXCLUDED_PATHNAMES = [
   '/offline-plugin-app-shell-fallback.md'
 ]
 
+const varyValue = headers =>
+  headers.find(({ key }) => key.toLowerCase() === 'vary')?.value
+
 describe('markdown content-type header', () => {
   test('is declared', () => {
     expect(markdownRule).toBeDefined()
+  })
+
+  test('varies by Accept so caches do not mix HTML and markdown', () => {
+    expect(varyValue(markdownRule.headers)).toBe('Accept, Accept-Encoding')
   })
 
   test('covers every generated markdown file', () => {
@@ -145,10 +152,26 @@ describe('markdown content negotiation', () => {
       )
     }
   })
+
+  test('marks HTML pages as varying by Accept', () => {
+    const htmlVary = headers.find(
+      ({ source, headers: ruleHeaders }) =>
+        source === '/((?!.*\\.[a-zA-Z0-9]+$).*)' && varyValue(ruleHeaders)
+    )
+    expect(htmlVary).toBeDefined()
+    expect(varyValue(htmlVary.headers)).toBe('Accept, Accept-Encoding')
+    expect(new RegExp(`^${htmlVary.source}$`).test('/pricing')).toBe(true)
+    expect(new RegExp(`^${htmlVary.source}$`).test('/pricing.md')).toBe(false)
+  })
 })
 
 const markdownNotFound = (routes || []).find(
-  ({ dest, status }) => dest === '/404.md' && status === 404
+  ({ dest, status, src }) =>
+    dest === '/404.md' && status === 404 && src === '/(.+)\\.md'
+)
+
+const agentNotFound = (routes || []).find(
+  ({ dest, status, missing }) => dest === '/404.md' && status === 404 && missing
 )
 
 const matchesMarkdownNotFound = pathname =>
@@ -160,7 +183,8 @@ describe('missing markdown file', () => {
       ({ handle }) => handle === 'filesystem'
     )
     const notFound = (routes || []).findIndex(
-      ({ dest, status }) => dest === '/404.md' && status === 404
+      ({ dest, status, src }) =>
+        dest === '/404.md' && status === 404 && src === '/(.+)\\.md'
     )
     expect(filesystem).toBeGreaterThanOrEqual(0)
     expect(notFound).toBeGreaterThan(filesystem)
@@ -171,6 +195,7 @@ describe('missing markdown file', () => {
     expect(markdownNotFound.headers['Content-Type']).toBe(
       'text/markdown; charset=utf-8'
     )
+    expect(markdownNotFound.headers.Vary).toBe('Accept, Accept-Encoding')
   })
 
   test('covers a path that has no page', () => {
@@ -181,6 +206,34 @@ describe('missing markdown file', () => {
 
   test('does not steal HTML 404s', () => {
     expect(matchesMarkdownNotFound('/notexist')).toBe(false)
+  })
+})
+
+describe('agent-friendly 404', () => {
+  test('serves 404.md when the client does not ask for HTML', () => {
+    expect(agentNotFound).toBeDefined()
+    expect(agentNotFound.headers['Content-Type']).toBe(
+      'text/markdown; charset=utf-8'
+    )
+    expect(agentNotFound.headers.Vary).toBe('Accept, Accept-Encoding')
+    expect(agentNotFound.missing).toEqual([
+      {
+        type: 'header',
+        key: 'accept',
+        value: '.*text/html.*'
+      }
+    ])
+  })
+
+  test('runs after the filesystem so real pages stay 200', () => {
+    const filesystem = (routes || []).findIndex(
+      ({ handle }) => handle === 'filesystem'
+    )
+    const agent = (routes || []).findIndex(
+      ({ dest, status, missing }) =>
+        dest === '/404.md' && status === 404 && missing
+    )
+    expect(agent).toBeGreaterThan(filesystem)
   })
 })
 

--- a/test/markdown-routes.js
+++ b/test/markdown-routes.js
@@ -163,6 +163,16 @@ describe('markdown content negotiation', () => {
     expect(new RegExp(`^${htmlVary.source}$`).test('/pricing')).toBe(true)
     expect(new RegExp(`^${htmlVary.source}$`).test('/pricing.md')).toBe(false)
   })
+
+  test('also varies extension paths so HTML 404s are not reused for markdown', () => {
+    const catchAll = headers.find(
+      ({ source, headers: ruleHeaders }) =>
+        source === '/(.*)' && varyValue(ruleHeaders)
+    )
+    expect(catchAll).toBeDefined()
+    expect(varyValue(catchAll.headers)).toBe('Accept, Accept-Encoding')
+    expect(new RegExp(`^${catchAll.source}$`).test('/missing.txt')).toBe(true)
+  })
 })
 
 const markdownNotFound = (routes || []).find(

--- a/test/openapi.js
+++ b/test/openapi.js
@@ -1,0 +1,136 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+import {
+  OPENAPI_PATH,
+  buildOpenApi,
+  errorCodesFrom,
+  parameterFromDoc,
+  parameterNameFrom,
+  schemaFromTypes,
+  typesFromParameterDoc
+} from '../src/helpers/openapi.js'
+import { notFoundMarkdown } from '../src/helpers/page-markdown.js'
+
+const ROOT = process.cwd()
+const PARAMETERS_DIR = path.join(ROOT, 'src/content/docs/api/parameters')
+const ERROR_CODES_PATH = path.join(
+  ROOT,
+  'src/content/docs/api/basics/error-codes.md'
+)
+const OPENAPI_FILE = path.join(ROOT, 'static/openapi.json')
+const NOT_FOUND_FILE = path.join(ROOT, 'static/404.md')
+const VERCEL_CONFIG = path.join(ROOT, 'vercel.json')
+const PAGE_404 = path.join(ROOT, 'src/pages/404.js')
+
+const parameterFiles = fs
+  .readdirSync(PARAMETERS_DIR, { recursive: true })
+  .filter(entry => entry.endsWith('.md'))
+  .map(entry => entry.split(path.sep).join('/'))
+  .sort()
+
+const parameters = parameterFiles.map(file =>
+  parameterFromDoc(
+    file,
+    fs.readFileSync(path.join(PARAMETERS_DIR, file), 'utf8')
+  )
+)
+
+const errorCodes = errorCodesFrom(fs.readFileSync(ERROR_CODES_PATH, 'utf8'))
+const spec = buildOpenApi({ parameters, errorCodes })
+const published = JSON.parse(fs.readFileSync(OPENAPI_FILE, 'utf8'))
+const { headers } = JSON.parse(fs.readFileSync(VERCEL_CONFIG, 'utf8'))
+
+describe('parameter parsing', () => {
+  test('names a nested file as a dotted query parameter', () => {
+    expect(parameterNameFrom('screenshot/type.md')).toBe('screenshot.type')
+    expect(parameterNameFrom('screenshot/index.md')).toBe('screenshot')
+  })
+
+  test('reads the Type line, not later examples', () => {
+    expect(
+      typesFromParameterDoc(`---
+title: timeout
+---
+
+Type: <TypeContainer><Type children='<string>'/> | <Type children='<number>'/></TypeContainer>
+
+Later <Type children="'10s'"/>
+`)
+    ).toEqual(['<string>', '<number>'])
+  })
+
+  test('maps union types to oneOf', () => {
+    expect(schemaFromTypes(['<boolean>', '<object>'])).toEqual({
+      oneOf: [
+        { type: 'boolean' },
+        { type: 'object', additionalProperties: true }
+      ]
+    })
+  })
+})
+
+describe('OpenAPI document', () => {
+  test('is OpenAPI 3.1 at the published path', () => {
+    expect(spec.openapi).toBe('3.1.0')
+    expect(OPENAPI_PATH).toBe('/openapi.json')
+    expect(spec.paths['/'].get.operationId).toBe('retrieveUrl')
+  })
+
+  test('documents every API parameter page', () => {
+    const names = spec.paths['/'].get.parameters.map(({ name }) => name)
+    expect(parameterFiles.length).toBeGreaterThan(0)
+    for (const file of parameterFiles) {
+      expect(names).toContain(parameterNameFrom(file))
+    }
+    expect(names).toContain('url')
+    expect(
+      spec.paths['/'].get.parameters.find(({ name }) => name === 'url').required
+    ).toBe(true)
+  })
+
+  test('gives 4xx and 5xx a typed error schema', () => {
+    const responses = spec.paths['/'].get.responses
+    for (const status of ['400', '401', '403', '408', '429', '500']) {
+      expect(responses[status].content['application/json'].schema.$ref).toBe(
+        '#/components/schemas/Error'
+      )
+    }
+
+    const error = spec.components.schemas.Error
+    expect(error.required).toEqual(['status', 'code', 'message'])
+    expect(error.properties.code.enum).toEqual(errorCodes)
+    expect(error.properties.message.type).toBe('string')
+    expect(errorCodes).toContain('EAUTH')
+    expect(errorCodes).toContain('ERATE')
+  })
+
+  test('matches the committed file so deploys stay in sync', () => {
+    expect(published).toEqual(spec)
+  })
+})
+
+describe('published files', () => {
+  test('serves openapi.json with CORS so agents can fetch it', () => {
+    const rule = headers.find(({ source }) => source === '/openapi.json')
+    expect(rule).toBeDefined()
+    expect(rule.headers.find(({ key }) => key === 'content-type').value).toBe(
+      'application/json; charset=utf-8'
+    )
+    expect(
+      rule.headers.find(({ key }) => key === 'access-control-allow-origin')
+        .value
+    ).toBe('*')
+  })
+
+  test('keeps static/404.md identical to the generated recovery page', () => {
+    expect(fs.readFileSync(NOT_FOUND_FILE, 'utf8')).toBe(notFoundMarkdown)
+  })
+
+  test('the HTML 404 page renders the same recovery links', () => {
+    const page = fs.readFileSync(PAGE_404, 'utf8')
+    expect(page).toContain('notFoundLinks')
+    expect(page).toContain("from 'helpers/page-markdown'")
+  })
+})

--- a/test/openapi.js
+++ b/test/openapi.js
@@ -69,6 +69,12 @@ Later <Type children="'10s'"/>
       ]
     })
   })
+
+  test('keeps string-or-array parameter types', () => {
+    expect(schemaFromTypes(['<string>', '<string[]>'])).toEqual({
+      oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }]
+    })
+  })
 })
 
 describe('OpenAPI document', () => {
@@ -88,6 +94,11 @@ describe('OpenAPI document', () => {
     expect(
       spec.paths['/'].get.parameters.find(({ name }) => name === 'url').required
     ).toBe(true)
+    expect(
+      spec.paths['/'].get.parameters.find(({ name }) => name === 'click').schema
+    ).toEqual({
+      oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }]
+    })
   })
 
   test('gives 4xx and 5xx a typed error schema', () => {
@@ -132,5 +143,6 @@ describe('published files', () => {
     const page = fs.readFileSync(PAGE_404, 'utf8')
     expect(page).toContain('notFoundLinks')
     expect(page).toContain("from 'helpers/page-markdown'")
+    expect(page).toContain('prefetch={false}')
   })
 })

--- a/vercel.json
+++ b/vercel.json
@@ -135,6 +135,10 @@
         {
           "key": "x-xss-protection",
           "value": "0"
+        },
+        {
+          "key": "Vary",
+          "value": "Accept, Accept-Encoding"
         }
       ]
     },

--- a/vercel.json
+++ b/vercel.json
@@ -63,8 +63,21 @@
           "value": "text/markdown; charset=utf-8"
         },
         {
+          "key": "Vary",
+          "value": "Accept, Accept-Encoding"
+        },
+        {
           "key": "X-Robots-Tag",
           "value": "noindex"
+        }
+      ]
+    },
+    {
+      "source": "/((?!.*\\.[a-zA-Z0-9]+$).*)",
+      "headers": [
+        {
+          "key": "Vary",
+          "value": "Accept, Accept-Encoding"
         }
       ]
     },
@@ -122,6 +135,23 @@
         {
           "key": "x-xss-protection",
           "value": "0"
+        }
+      ]
+    },
+    {
+      "source": "/openapi.json",
+      "headers": [
+        {
+          "key": "content-type",
+          "value": "application/json; charset=utf-8"
+        },
+        {
+          "key": "access-control-allow-origin",
+          "value": "*"
+        },
+        {
+          "key": "cross-origin-resource-policy",
+          "value": "cross-origin"
         }
       ]
     }
@@ -496,6 +526,24 @@
       "status": 404,
       "headers": {
         "Content-Type": "text/markdown; charset=utf-8",
+        "Vary": "Accept, Accept-Encoding",
+        "X-Robots-Tag": "noindex"
+      }
+    },
+    {
+      "src": "/(.*)",
+      "missing": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/html.*"
+        }
+      ],
+      "dest": "/404.md",
+      "status": 404,
+      "headers": {
+        "Content-Type": "text/markdown; charset=utf-8",
+        "Vary": "Accept, Accept-Encoding",
         "X-Robots-Tag": "noindex"
       }
     }


### PR DESCRIPTION
## Summary
- Publish an OpenAPI 3.1 spec at `/openapi.json` (generated from API parameter docs and error codes) with a typed JSend error model for 4xx/5xx.
- Serve a markdown 404 body (`404.md`) with recovery links when the client does not ask for HTML; keep the visual HTML 404 and add the same links there.
- Add `Vary: Accept, Accept-Encoding` on markdown and HTML page responses so CDNs do not mix representations.

## Test plan
- [ ] `curl -s -o /dev/null -w "%{http_code}" https://<preview>/some-path-that-does-not-exist` prints `404`
- [ ] `curl -s https://<preview>/some-path-that-does-not-exist` returns the markdown recovery page (no `Accept: text/html`)
- [ ] Browser 404 still shows the existing heading/caption plus Home, Documentation, llms.txt, OpenAPI, Sitemap
- [ ] `curl -sI https://<preview>/openapi.json` is `200` + `application/json`; spec has `paths./.get` and `components.schemas.Error`
- [ ] `curl -sI -H "Accept: text/markdown" https://<preview>/pricing.md` includes `Vary: Accept, Accept-Encoding`
- [ ] `npm test` (or at least `test/openapi.js`, `test/markdown-routes.js`, `test/helpers/page-markdown.js`, `test/llms-txt.js`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a published OpenAPI specification describing API parameters, responses, authentication, and schemas.
  - Added machine-readable OpenAPI links to documentation, API listings, and recovery pages.
  - Added an agent-friendly Markdown 404 response for non-browser requests.
  - Added navigation links to the 404 page, including documentation, llms.txt, OpenAPI, and sitemap resources.

- **Documentation**
  - Expanded llms.txt coverage for proxy options, CLI usage, and shared SDK options.

- **Bug Fixes**
  - Improved content negotiation and caching behavior by varying responses based on request headers.
  - Added cross-origin access support for the published OpenAPI specification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->