### PR TITLE
fix(cli): wrap the terminal intro on phones

### DIFF
--- a/src/components/pages/cli/fullscreen.js
+++ b/src/components/pages/cli/fullscreen.js
@@ -1,6 +1,5 @@
 import React, { useRef } from 'react'
 
-import { Link } from 'components/elements/Link'
 import Box from 'components/elements/Box'
 import Flex from 'components/elements/Flex'
 import LineBreak from 'components/elements/LineBreak'
@@ -12,8 +11,6 @@ import { CLI_VERSION, XTERM_SURFACE_CSS } from './shared'
 import { useCliTerminal } from './use-cli-terminal'
 
 import '@xterm/xterm/css/xterm.css'
-
-const DOCS_HREF = '/docs/sdk/getting-started/cli'
 
 const visuallyHiddenCss = theme({
   position: 'absolute',
@@ -105,11 +102,9 @@ const Fullscreen = () => {
         <Text as='span' css={theme({ fontSize: 'inherit', color: 'white' })}>
           Microlink CLI v{CLI_VERSION}
         </Text>{' '}
-        in your browser. Type <span css={theme({ color: 'white' })}>help</span>{' '}
-        for commands.
-        <LineBreak />
-        Commands hit the live API. See products and flags in the{' '}
-        <Link href={DOCS_HREF}>docs</Link>.
+        in your browser.
+        <LineBreak breakpoints={[0, 1]} /> Type{' '}
+        <span css={theme({ color: 'white' })}>help</span> for commands.
       </Text>
       <Box
         id='cli-terminal'


### PR DESCRIPTION
## Summary
- Break the `/terminal` header after “in your browser.” on mobile so “Type help for commands.” starts on its own line
- Drop the extra docs sentence so the header stays two short lines

## Test plan
- [ ] Open `/terminal` at a phone width (~480px) and confirm the intro wraps after “in your browser.”
- [ ] Open `/terminal` at desktop width and confirm both sentences stay on one line
- [ ] Confirm the docs line is gone


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI fullscreen help text layout for improved responsiveness.
  * Reworded and restructured the command guidance shown to users.
  * Removed the live API and documentation link reference from the help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->