### PR TITLE
chore: add a "book a call" CTA to the header and pricing page

### DIFF
--- a/src/components/pages/enterprise/ContactButton.js
+++ b/src/components/pages/enterprise/ContactButton.js
@@ -1,5 +1,11 @@
 import { theme } from 'theme'
 import { trackEvent } from 'helpers/gtag'
+import {
+  BOOK_CALL_LABEL,
+  BOOK_CALL_TITLE,
+  bookCallUrl,
+  trackBookCall
+} from 'helpers/book-call'
 import React from 'react'
 
 import { Button } from 'components/elements/Button/Button'
@@ -10,7 +16,16 @@ const ENTERPRISE_MAILTO =
   'mailto:hello@microlink.io?subject=Microlink%20Enterprise&body=Hi%2C%20I%27m%20interested%20in%20Microlink%20Enterprise.%20Could%20you%20share%20more%20details%3F%0D%0A%0D%0AThanks!%0D%0A'
 
 const ContactButton = ({ event = 'enterprise contact', my = [4, null, 5] }) => (
-  <Flex css={theme({ justifyContent: 'center', width: '100%', my })}>
+  <Flex
+    css={theme({
+      justifyContent: 'center',
+      alignItems: 'center',
+      flexDirection: ['column', 'row', 'row', 'row'],
+      gap: [2, 3, 3, 3],
+      width: '100%',
+      my
+    })}
+  >
     <Button
       variant='black'
       onClick={() => {
@@ -19,6 +34,21 @@ const ContactButton = ({ event = 'enterprise contact', my = [4, null, 5] }) => (
       }}
     >
       <Caps css={theme({ fontSize: 0 })}>Contact sales</Caps>
+    </Button>
+    <Button
+      as='a'
+      href={bookCallUrl('enterprise')}
+      variant='white'
+      title={BOOK_CALL_TITLE}
+      rel='noopener noreferrer'
+      target='_blank'
+      data-event-location='enterprise'
+      data-event-name={BOOK_CALL_LABEL}
+      onClick={() => trackBookCall('enterprise')}
+    >
+      <Caps as='span' css={theme({ fontSize: 0 })}>
+        {BOOK_CALL_LABEL}
+      </Caps>
     </Button>
   </Flex>
 )

--- a/src/components/pages/pricing/book-call.js
+++ b/src/components/pages/pricing/book-call.js
@@ -6,7 +6,12 @@ import Caps from 'components/elements/Caps'
 import Container from 'components/elements/Container'
 import Flex from 'components/elements/Flex'
 import Text from 'components/elements/Text'
-import { BOOK_CALL_LABEL, BOOK_CALL_TITLE, bookCallUrl } from 'helpers/book-call'
+import {
+  BOOK_CALL_LABEL,
+  BOOK_CALL_TITLE,
+  bookCallUrl,
+  trackBookCall
+} from 'helpers/book-call'
 import { layout, theme, SECTION_VERTICAL_SPACING } from 'theme'
 
 import {
@@ -112,6 +117,7 @@ const BookCall = () => (
         target='_blank'
         data-event-location='pricing'
         data-event-name={BOOK_CALL_LABEL}
+        onClick={() => trackBookCall('pricing')}
       >
         <Caps as='span' css={theme({ fontSize: 0 })}>
           {BOOK_CALL_LABEL}

--- a/src/components/pages/pricing/book-call.js
+++ b/src/components/pages/pricing/book-call.js
@@ -1,0 +1,120 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { Button } from 'components/elements/Button/Button'
+import Caps from 'components/elements/Caps'
+import Container from 'components/elements/Container'
+import Flex from 'components/elements/Flex'
+import Text from 'components/elements/Text'
+import { BOOK_CALL_LABEL, BOOK_CALL_TITLE, bookCallUrl } from 'helpers/book-call'
+import { layout, theme, SECTION_VERTICAL_SPACING } from 'theme'
+
+import { CapabilityIcon } from './shared'
+
+const CalendarIcon = (
+  <svg
+    width='20'
+    height='20'
+    viewBox='0 0 24 24'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='2'
+    strokeLinecap='round'
+    strokeLinejoin='round'
+    aria-hidden='true'
+  >
+    <rect x='3' y='4' width='18' height='18' rx='2' ry='2' />
+    <line x1='16' y1='2' x2='16' y2='6' />
+    <line x1='8' y1='2' x2='8' y2='6' />
+    <line x1='3' y1='10' x2='21' y2='10' />
+  </svg>
+)
+
+const BookCallCard = styled(Flex)`
+  ${theme({
+    width: '100%',
+    maxWidth: layout.large,
+    flexDirection: ['column', 'column', 'row', 'row'],
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: [3, 3, 4, 4],
+    bg: 'white',
+    border: 1,
+    borderColor: 'black10',
+    borderRadius: 3,
+    boxShadow: 1,
+    px: [3, 3, 4, 4],
+    py: [3, 3, 4, 4],
+    textAlign: ['center', 'center', 'left', 'left']
+  })}
+`
+
+const BookCallButton = styled(Button)`
+  ${theme({ flexShrink: 0, width: ['100%', 'auto', 'auto', 'auto'] })}
+`
+
+const BookCall = () => (
+  <Container
+    as='section'
+    id='book-call'
+    css={theme({
+      alignItems: 'center',
+      maxWidth: '100%',
+      py: SECTION_VERTICAL_SPACING,
+      px: [3, 3, 4, 4]
+    })}
+  >
+    <BookCallCard>
+      <Flex
+        css={theme({
+          gap: 3,
+          flexDirection: ['column', 'column', 'row', 'row'],
+          alignItems: 'center',
+          flex: 1,
+          minWidth: 0
+        })}
+      >
+        <CapabilityIcon>{CalendarIcon}</CapabilityIcon>
+        <Flex css={theme({ flexDirection: 'column', gap: 1, minWidth: 0 })}>
+          <Text
+            css={theme({
+              fontWeight: 'bold',
+              fontSize: [2, 2, '18px', '18px'],
+              color: 'black',
+              lineHeight: 1
+            })}
+          >
+            Bigger volume, custom infra, or just questions?
+          </Text>
+          <Text
+            css={theme({
+              fontSize: [1, 1, '15px', '15px'],
+              color: 'black70',
+              lineHeight: 2
+            })}
+          >
+            Book 15 minutes with the engineers who run the API. We&apos;ll walk
+            through your use case, size your traffic and tell you which plan
+            actually fits — or whether you need one at all.
+          </Text>
+        </Flex>
+      </Flex>
+      <BookCallButton
+        forwardedAs='a'
+        href={bookCallUrl('pricing')}
+        variant='black'
+        title={BOOK_CALL_TITLE}
+        rel='noopener noreferrer'
+        target='_blank'
+        data-event-location='pricing'
+        data-event-name={BOOK_CALL_LABEL}
+      >
+        <Caps as='span' css={theme({ fontSize: 0 })}>
+          {BOOK_CALL_LABEL}
+        </Caps>
+      </BookCallButton>
+    </BookCallCard>
+  </Container>
+)
+
+export default BookCall

--- a/src/components/pages/pricing/book-call.js
+++ b/src/components/pages/pricing/book-call.js
@@ -9,7 +9,11 @@ import Text from 'components/elements/Text'
 import { BOOK_CALL_LABEL, BOOK_CALL_TITLE, bookCallUrl } from 'helpers/book-call'
 import { layout, theme, SECTION_VERTICAL_SPACING } from 'theme'
 
-import { CapabilityIcon } from './shared'
+import {
+  CapabilityIcon,
+  TILE_DESCRIPTION_FONT_SIZE,
+  TILE_TITLE_FONT_SIZE
+} from './shared'
 
 const CalendarIcon = (
   <svg
@@ -79,7 +83,7 @@ const BookCall = () => (
           <Text
             css={theme({
               fontWeight: 'bold',
-              fontSize: [2, 2, '18px', '18px'],
+              fontSize: TILE_TITLE_FONT_SIZE,
               color: 'black',
               lineHeight: 1
             })}
@@ -88,7 +92,7 @@ const BookCall = () => (
           </Text>
           <Text
             css={theme({
-              fontSize: [1, 1, '15px', '15px'],
+              fontSize: TILE_DESCRIPTION_FONT_SIZE,
               color: 'black70',
               lineHeight: 2
             })}

--- a/src/components/pages/pricing/shared.js
+++ b/src/components/pages/pricing/shared.js
@@ -3,6 +3,9 @@ import styled from 'styled-components'
 import Flex from 'components/elements/Flex'
 import { space, theme } from 'theme'
 
+export const TILE_TITLE_FONT_SIZE = [2, 2, '18px', '18px']
+export const TILE_DESCRIPTION_FONT_SIZE = [1, 1, '15px', '15px']
+
 export const CapabilityIcon = styled(Flex)`
   ${theme({
     width: space[4],

--- a/src/components/pages/pricing/shared.js
+++ b/src/components/pages/pricing/shared.js
@@ -1,0 +1,17 @@
+import styled from 'styled-components'
+
+import Flex from 'components/elements/Flex'
+import { space, theme } from 'theme'
+
+export const CapabilityIcon = styled(Flex)`
+  ${theme({
+    width: space[4],
+    height: space[4],
+    borderRadius: 4,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    color: 'secondary',
+    bg: 'pinkest'
+  })}
+`

--- a/src/components/patterns/Toolbar/ToolbarDesktop.js
+++ b/src/components/patterns/Toolbar/ToolbarDesktop.js
@@ -1,13 +1,10 @@
 import Toolbar from 'components/elements/Toolbar'
 import Flex from 'components/elements/Flex'
 import Box from 'components/elements/Box'
-import { Button } from 'components/elements/Button/Button'
-import styled from 'styled-components'
 import { useLocation } from '@gatsbyjs/reach-router'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useBlogIndex } from 'components/hook/use-blog-index'
 import { useChangelogLatest } from 'components/hook/use-changelog-latest'
-import { BOOK_CALL_LABEL, bookCallUrl } from 'helpers/book-call'
 
 import { layout, theme } from 'theme'
 
@@ -30,15 +27,6 @@ import {
 
 import ToolbarDesktopMegaMenu from './ToolbarDesktopMegaMenu'
 import ToolbarDesktopTopLevelNav from './ToolbarDesktopTopLevelNav'
-
-const BookCallButton = styled(Button)`
-  ${theme({
-    fontSize: 0,
-    px: 3,
-    py: '6px',
-    minHeight: '36px'
-  })}
-`
 
 const ToolbarDesktop = () => {
   const location = useLocation()
@@ -187,25 +175,7 @@ const ToolbarDesktop = () => {
             onOpenSectionWithHover={handleOpenSectionWithHover}
             onClosePanel={handleClosePanel}
           />
-          <Flex as='div' css={theme({ alignItems: 'center', gap: 3 })}>
-            <Box
-              onMouseEnter={handleClosePanel}
-              css={theme({
-                display: ['none', 'none', 'block', 'block']
-              })}
-            >
-              <BookCallButton
-                forwardedAs='a'
-                href={bookCallUrl('header')}
-                variant='white'
-                rel='noopener noreferrer'
-                target='_blank'
-                data-event-location='header'
-                data-event-name={BOOK_CALL_LABEL}
-              >
-                {BOOK_CALL_LABEL}
-              </BookCallButton>
-            </Box>
+          <Flex as='div' css={theme({ alignItems: 'center' })}>
             {SOCIAL_NAV_ITEMS.map(
               ({ href, label, title, externalIcon, icon: Icon }) => {
                 return (

--- a/src/components/patterns/Toolbar/ToolbarDesktop.js
+++ b/src/components/patterns/Toolbar/ToolbarDesktop.js
@@ -1,10 +1,13 @@
 import Toolbar from 'components/elements/Toolbar'
 import Flex from 'components/elements/Flex'
 import Box from 'components/elements/Box'
+import { Button } from 'components/elements/Button/Button'
+import styled from 'styled-components'
 import { useLocation } from '@gatsbyjs/reach-router'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useBlogIndex } from 'components/hook/use-blog-index'
 import { useChangelogLatest } from 'components/hook/use-changelog-latest'
+import { BOOK_CALL_LABEL, bookCallUrl } from 'helpers/book-call'
 
 import { layout, theme } from 'theme'
 
@@ -27,6 +30,15 @@ import {
 
 import ToolbarDesktopMegaMenu from './ToolbarDesktopMegaMenu'
 import ToolbarDesktopTopLevelNav from './ToolbarDesktopTopLevelNav'
+
+const BookCallButton = styled(Button)`
+  ${theme({
+    fontSize: 0,
+    px: 3,
+    py: '6px',
+    minHeight: '36px'
+  })}
+`
 
 const ToolbarDesktop = () => {
   const location = useLocation()
@@ -175,7 +187,25 @@ const ToolbarDesktop = () => {
             onOpenSectionWithHover={handleOpenSectionWithHover}
             onClosePanel={handleClosePanel}
           />
-          <Flex as='div' css={theme({ alignItems: 'center' })}>
+          <Flex as='div' css={theme({ alignItems: 'center', gap: 3 })}>
+            <Box
+              onMouseEnter={handleClosePanel}
+              css={theme({
+                display: ['none', 'none', 'block', 'block']
+              })}
+            >
+              <BookCallButton
+                forwardedAs='a'
+                href={bookCallUrl('header')}
+                variant='white'
+                rel='noopener noreferrer'
+                target='_blank'
+                data-event-location='header'
+                data-event-name={BOOK_CALL_LABEL}
+              >
+                {BOOK_CALL_LABEL}
+              </BookCallButton>
+            </Box>
             {SOCIAL_NAV_ITEMS.map(
               ({ href, label, title, externalIcon, icon: Icon }) => {
                 return (

--- a/src/components/patterns/Toolbar/ToolbarDesktopTopLevelNav.js
+++ b/src/components/patterns/Toolbar/ToolbarDesktopTopLevelNav.js
@@ -4,7 +4,12 @@ import Caps from 'components/elements/Caps'
 import FeatherIcon from 'components/icons/Feather'
 import { Calendar, ChevronDown } from 'react-feather'
 import React from 'react'
-import { BOOK_CALL_LABEL, BOOK_CALL_TITLE, bookCallUrl } from 'helpers/book-call'
+import {
+  BOOK_CALL_LABEL,
+  BOOK_CALL_TITLE,
+  bookCallUrl,
+  trackBookCall
+} from 'helpers/book-call'
 
 import { theme } from 'theme'
 
@@ -148,6 +153,7 @@ const ToolbarDesktopTopLevelNav = ({
       externalIcon={false}
       data-event-location='header'
       data-event-name={BOOK_CALL_LABEL}
+      onClick={() => trackBookCall('header')}
       onMouseEnter={onClosePanel}
       css={theme({
         display: ['none', 'none', 'inline-flex', 'inline-flex'],

--- a/src/components/patterns/Toolbar/ToolbarDesktopTopLevelNav.js
+++ b/src/components/patterns/Toolbar/ToolbarDesktopTopLevelNav.js
@@ -1,12 +1,18 @@
 import Flex from 'components/elements/Flex'
 import Box from 'components/elements/Box'
 import Caps from 'components/elements/Caps'
-import { ChevronDown } from 'react-feather'
+import FeatherIcon from 'components/icons/Feather'
+import { Calendar, ChevronDown } from 'react-feather'
 import React from 'react'
+import { BOOK_CALL_LABEL, BOOK_CALL_TITLE, bookCallUrl } from 'helpers/book-call'
 
 import { theme } from 'theme'
 
-import { DIRECT_NAV_ITEMS, NAVIGATION_SECTIONS } from './ToolbarLinks'
+import {
+  DIRECT_NAV_ITEMS,
+  NAVIGATION_SECTIONS,
+  ToolbarActionLink
+} from './ToolbarLinks'
 import {
   TOOLBAR_CHEVRON_ICON_SIZE,
   TOOLBAR_LIST_RESET_STYLES,
@@ -135,6 +141,26 @@ const ToolbarDesktopTopLevelNav = ({
         </Caps>
       </TopLevelDirectLink>
     ))}
+    <ToolbarActionLink
+      forwardedAs='li'
+      href={bookCallUrl('header')}
+      title={BOOK_CALL_TITLE}
+      externalIcon={false}
+      data-event-location='header'
+      data-event-name={BOOK_CALL_LABEL}
+      onMouseEnter={onClosePanel}
+      css={theme({
+        display: ['none', 'none', 'inline-flex', 'inline-flex'],
+        alignSelf: 'center',
+        height: '36px',
+        ml: 2
+      })}
+    >
+      <FeatherIcon icon={Calendar} size='14px' />
+      <Caps as='span' css={theme(TOOLBAR_TOP_LEVEL_CAPS_STYLES)}>
+        {BOOK_CALL_LABEL}
+      </Caps>
+    </ToolbarActionLink>
   </Flex>
 )
 

--- a/src/components/patterns/Toolbar/ToolbarLinks.js
+++ b/src/components/patterns/Toolbar/ToolbarLinks.js
@@ -43,7 +43,7 @@ import { Grid as GridIcon } from 'components/icons/Grid'
 import { GitHub as GitHubBrand } from 'components/icons/GitHub'
 import { Brain as BrainIcon } from 'components/icons/Brain'
 import { useOssTotalStars } from 'components/hook/use-oss-total-stars'
-import { theme } from 'theme'
+import { theme, transition } from 'theme'
 import styled from 'styled-components'
 import NavLink from './NavLink'
 
@@ -64,6 +64,31 @@ export const ToolbarNavLink = styled(NavLink)`
   ${theme({
     pl: 0
   })}
+`
+
+export const ToolbarActionLink = styled(ToolbarNavLink)`
+  ${theme({
+    border: 1,
+    borderColor: 'black10',
+    borderRadius: '999px',
+    color: 'black80'
+  })}
+  transition: color ${transition.medium}, background-color ${transition.medium},
+    border-color ${transition.medium};
+
+  > a {
+    ${theme({ px: 3 })}
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    height: 100%;
+    border-radius: inherit;
+  }
+
+  &:hover,
+  &:focus-within {
+    ${theme({ bg: 'black05', borderColor: 'black20', color: 'black' })}
+  }
 `
 
 const docsMatcher = ({ location }) => location.pathname.startsWith('/docs')

--- a/src/components/patterns/Toolbar/ToolbarMobile.js
+++ b/src/components/patterns/Toolbar/ToolbarMobile.js
@@ -5,19 +5,19 @@ import Toolbar, {
 import Flex from 'components/elements/Flex'
 import Text from 'components/elements/Text'
 import Caps from 'components/elements/Caps'
-import { Button } from 'components/elements/Button/Button'
 import FeatherIcon from 'components/icons/Feather'
 import { useLocation } from '@gatsbyjs/reach-router'
-import { ChevronDown, X } from 'react-feather'
+import { Calendar, ChevronDown, X } from 'react-feather'
 import { backDrop } from 'helpers/style'
 import styled, { css } from 'styled-components'
 import { colors, fontWeights, theme, transition } from 'theme'
-import { BOOK_CALL_LABEL, bookCallUrl } from 'helpers/book-call'
+import { BOOK_CALL_LABEL, BOOK_CALL_TITLE, bookCallUrl } from 'helpers/book-call'
 import React, { useEffect, useState } from 'react'
 
 import {
   DIRECT_NAV_ITEMS,
   NAVIGATION_SECTIONS,
+  ToolbarActionLink,
   ToolbarNavLink,
   getToolbarSectionFromPathname
 } from './ToolbarLinks'
@@ -468,28 +468,27 @@ const ToolbarMobile = () => {
               </Caps>
             </MobileDirectNavLink>
           ))}
-          <Flex
-            as='li'
+          <ToolbarActionLink
+            forwardedAs='li'
+            href={bookCallUrl('header')}
+            title={BOOK_CALL_TITLE}
+            externalIcon={false}
+            data-event-location='header'
+            data-event-name={BOOK_CALL_LABEL}
+            onClick={closeMenu}
             css={theme({
-              flexDirection: 'column',
-              listStyle: 'none',
-              pt: 3,
-              px: 2
+              display: 'flex',
+              width: '100%',
+              height: '44px',
+              mt: 3,
+              listStyle: 'none'
             })}
           >
-            <Button
-              as='a'
-              href={bookCallUrl('header')}
-              variant='white'
-              rel='noopener noreferrer'
-              target='_blank'
-              data-event-location='header'
-              data-event-name={BOOK_CALL_LABEL}
-              onClick={closeMenu}
-            >
+            <FeatherIcon icon={Calendar} size='14px' />
+            <Caps as='span' css={theme(TOOLBAR_TOP_LEVEL_CAPS_STYLES)}>
               {BOOK_CALL_LABEL}
-            </Button>
-          </Flex>
+            </Caps>
+          </ToolbarActionLink>
         </Box>
       </MobileMenuPanel>
     </Header>

--- a/src/components/patterns/Toolbar/ToolbarMobile.js
+++ b/src/components/patterns/Toolbar/ToolbarMobile.js
@@ -5,12 +5,14 @@ import Toolbar, {
 import Flex from 'components/elements/Flex'
 import Text from 'components/elements/Text'
 import Caps from 'components/elements/Caps'
+import { Button } from 'components/elements/Button/Button'
 import FeatherIcon from 'components/icons/Feather'
 import { useLocation } from '@gatsbyjs/reach-router'
 import { ChevronDown, X } from 'react-feather'
 import { backDrop } from 'helpers/style'
 import styled, { css } from 'styled-components'
 import { colors, fontWeights, theme, transition } from 'theme'
+import { BOOK_CALL_LABEL, bookCallUrl } from 'helpers/book-call'
 import React, { useEffect, useState } from 'react'
 
 import {
@@ -466,6 +468,28 @@ const ToolbarMobile = () => {
               </Caps>
             </MobileDirectNavLink>
           ))}
+          <Flex
+            as='li'
+            css={theme({
+              flexDirection: 'column',
+              listStyle: 'none',
+              pt: 3,
+              px: 2
+            })}
+          >
+            <Button
+              as='a'
+              href={bookCallUrl('header')}
+              variant='white'
+              rel='noopener noreferrer'
+              target='_blank'
+              data-event-location='header'
+              data-event-name={BOOK_CALL_LABEL}
+              onClick={closeMenu}
+            >
+              {BOOK_CALL_LABEL}
+            </Button>
+          </Flex>
         </Box>
       </MobileMenuPanel>
     </Header>

--- a/src/components/patterns/Toolbar/ToolbarMobile.js
+++ b/src/components/patterns/Toolbar/ToolbarMobile.js
@@ -11,7 +11,12 @@ import { Calendar, ChevronDown, X } from 'react-feather'
 import { backDrop } from 'helpers/style'
 import styled, { css } from 'styled-components'
 import { colors, fontWeights, theme, transition } from 'theme'
-import { BOOK_CALL_LABEL, BOOK_CALL_TITLE, bookCallUrl } from 'helpers/book-call'
+import {
+  BOOK_CALL_LABEL,
+  BOOK_CALL_TITLE,
+  bookCallUrl,
+  trackBookCall
+} from 'helpers/book-call'
 import React, { useEffect, useState } from 'react'
 
 import {
@@ -470,12 +475,15 @@ const ToolbarMobile = () => {
           ))}
           <ToolbarActionLink
             forwardedAs='li'
-            href={bookCallUrl('header')}
+            href={bookCallUrl('mobile_menu')}
             title={BOOK_CALL_TITLE}
             externalIcon={false}
-            data-event-location='header'
+            data-event-location='mobile_menu'
             data-event-name={BOOK_CALL_LABEL}
-            onClick={closeMenu}
+            onClick={() => {
+              trackBookCall('mobile_menu')
+              closeMenu()
+            }}
             css={theme({
               display: 'flex',
               width: '100%',

--- a/src/helpers/book-call.js
+++ b/src/helpers/book-call.js
@@ -1,3 +1,5 @@
+import { trackEvent } from 'helpers/gtag'
+
 export const BOOK_CALL_LABEL = 'Book a call'
 
 export const BOOK_CALL_TITLE = 'Book a 15-minute call with an engineer'
@@ -6,3 +8,5 @@ const BOOK_CALL_BASE_URL = 'https://cal.com/microlink/15min'
 
 export const bookCallUrl = medium =>
   `${BOOK_CALL_BASE_URL}?utm_source=microlink&utm_medium=${medium}&utm_campaign=book_call`
+
+export const trackBookCall = location => trackEvent('book call', { location })

--- a/src/helpers/book-call.js
+++ b/src/helpers/book-call.js
@@ -1,5 +1,7 @@
 export const BOOK_CALL_LABEL = 'Book a call'
 
+export const BOOK_CALL_TITLE = 'Book a 15-minute call with an engineer'
+
 const BOOK_CALL_BASE_URL = 'https://cal.com/microlink/15min'
 
 export const bookCallUrl = medium =>

--- a/src/helpers/book-call.js
+++ b/src/helpers/book-call.js
@@ -1,0 +1,6 @@
+export const BOOK_CALL_LABEL = 'Book a call'
+
+const BOOK_CALL_BASE_URL = 'https://cal.com/microlink/15min'
+
+export const bookCallUrl = medium =>
+  `${BOOK_CALL_BASE_URL}?utm_source=microlink&utm_medium=${medium}&utm_campaign=book_call`

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -28,7 +28,7 @@ import {
 import Plans from 'components/patterns/Plans/Plans'
 import { CURRENCIES, formatPrice } from 'components/patterns/Plans/shared'
 import { trackEvent } from 'helpers/gtag'
-import { BOOK_CALL_LABEL, bookCallUrl } from 'helpers/book-call'
+import { BOOK_CALL_LABEL, BOOK_CALL_TITLE, bookCallUrl } from 'helpers/book-call'
 import { CDN_EDGES } from 'helpers/cdn-edges'
 import {
   borders,
@@ -253,19 +253,24 @@ const CalendarIcon = (
 const BookCallCard = styled(Flex)`
   ${theme({
     width: '100%',
-    maxWidth: layout.normal,
+    maxWidth: layout.large,
     flexDirection: ['column', 'column', 'row', 'row'],
     alignItems: 'center',
     justifyContent: 'space-between',
     gap: [3, 3, 4, 4],
+    bg: 'white',
+    border: 1,
+    borderColor: 'black10',
     borderRadius: 3,
+    boxShadow: 1,
     px: [3, 3, 4, 4],
     py: [3, 3, 4, 4],
-    bg: 'white',
     textAlign: ['center', 'center', 'left', 'left']
   })}
-  border: ${borders[1]};
-  border-color: ${colors.black10};
+`
+
+const BookCallButton = styled(Button)`
+  ${theme({ flexShrink: 0, width: ['100%', 'auto', 'auto', 'auto'] })}
 `
 
 const BookCall = () => (
@@ -285,6 +290,7 @@ const BookCall = () => (
           gap: 3,
           flexDirection: ['column', 'column', 'row', 'row'],
           alignItems: 'center',
+          flex: 1,
           minWidth: 0
         })}
       >
@@ -293,31 +299,40 @@ const BookCall = () => (
           <Text
             css={theme({
               fontWeight: 'bold',
-              fontSize: [1, 1, 2, 2],
+              fontSize: [2, 2, '18px', '18px'],
               color: 'black',
               lineHeight: 1
             })}
           >
-            Not sure which plan fits?
+            Bigger volume, custom infra, or just questions?
           </Text>
-          <Text css={theme({ fontSize: [0, 0, 1, 1], color: 'black60' })}>
-            Talk to an engineer for 15 minutes — no sales pitch.
+          <Text
+            css={theme({
+              fontSize: [1, 1, '15px', '15px'],
+              color: 'black70',
+              lineHeight: 2
+            })}
+          >
+            Book 15 minutes with the engineers who run the API. We&apos;ll walk
+            through your use case, size your traffic and tell you which plan
+            actually fits — or whether you need one at all.
           </Text>
         </Flex>
       </Flex>
-      <Box css={theme({ flexShrink: 0 })}>
-        <Button
-          as='a'
-          href={bookCallUrl('pricing')}
-          variant='white'
-          rel='noopener noreferrer'
-          target='_blank'
-          data-event-location='pricing'
-          data-event-name={BOOK_CALL_LABEL}
-        >
+      <BookCallButton
+        forwardedAs='a'
+        href={bookCallUrl('pricing')}
+        variant='black'
+        title={BOOK_CALL_TITLE}
+        rel='noopener noreferrer'
+        target='_blank'
+        data-event-location='pricing'
+        data-event-name={BOOK_CALL_LABEL}
+      >
+        <Caps as='span' css={theme({ fontSize: 0 })}>
           {BOOK_CALL_LABEL}
-        </Button>
-      </Box>
+        </Caps>
+      </BookCallButton>
     </BookCallCard>
   </Container>
 )

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -25,10 +25,11 @@ import {
   CurrencyProvider,
   useCurrencyContext
 } from 'components/hook/use-currency'
+import BookCall from 'components/pages/pricing/book-call'
+import { CapabilityIcon } from 'components/pages/pricing/shared'
 import Plans from 'components/patterns/Plans/Plans'
 import { CURRENCIES, formatPrice } from 'components/patterns/Plans/shared'
 import { trackEvent } from 'helpers/gtag'
-import { BOOK_CALL_LABEL, BOOK_CALL_TITLE, bookCallUrl } from 'helpers/book-call'
 import { CDN_EDGES } from 'helpers/cdn-edges'
 import {
   borders,
@@ -36,7 +37,6 @@ import {
   gradient,
   layout,
   radii,
-  space,
   theme,
   transition,
   shadows,
@@ -230,112 +230,6 @@ const Hero = () => {
     </Container>
   )
 }
-
-const CalendarIcon = (
-  <svg
-    width='20'
-    height='20'
-    viewBox='0 0 24 24'
-    fill='none'
-    stroke='currentColor'
-    strokeWidth='2'
-    strokeLinecap='round'
-    strokeLinejoin='round'
-    aria-hidden='true'
-  >
-    <rect x='3' y='4' width='18' height='18' rx='2' ry='2' />
-    <line x1='16' y1='2' x2='16' y2='6' />
-    <line x1='8' y1='2' x2='8' y2='6' />
-    <line x1='3' y1='10' x2='21' y2='10' />
-  </svg>
-)
-
-const BookCallCard = styled(Flex)`
-  ${theme({
-    width: '100%',
-    maxWidth: layout.large,
-    flexDirection: ['column', 'column', 'row', 'row'],
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: [3, 3, 4, 4],
-    bg: 'white',
-    border: 1,
-    borderColor: 'black10',
-    borderRadius: 3,
-    boxShadow: 1,
-    px: [3, 3, 4, 4],
-    py: [3, 3, 4, 4],
-    textAlign: ['center', 'center', 'left', 'left']
-  })}
-`
-
-const BookCallButton = styled(Button)`
-  ${theme({ flexShrink: 0, width: ['100%', 'auto', 'auto', 'auto'] })}
-`
-
-const BookCall = () => (
-  <Container
-    as='section'
-    id='book-call'
-    css={theme({
-      alignItems: 'center',
-      maxWidth: '100%',
-      py: SECTION_VERTICAL_SPACING,
-      px: [3, 3, 4, 4]
-    })}
-  >
-    <BookCallCard>
-      <Flex
-        css={theme({
-          gap: 3,
-          flexDirection: ['column', 'column', 'row', 'row'],
-          alignItems: 'center',
-          flex: 1,
-          minWidth: 0
-        })}
-      >
-        <CapabilityIcon>{CalendarIcon}</CapabilityIcon>
-        <Flex css={theme({ flexDirection: 'column', gap: 1, minWidth: 0 })}>
-          <Text
-            css={theme({
-              fontWeight: 'bold',
-              fontSize: [2, 2, '18px', '18px'],
-              color: 'black',
-              lineHeight: 1
-            })}
-          >
-            Bigger volume, custom infra, or just questions?
-          </Text>
-          <Text
-            css={theme({
-              fontSize: [1, 1, '15px', '15px'],
-              color: 'black70',
-              lineHeight: 2
-            })}
-          >
-            Book 15 minutes with the engineers who run the API. We&apos;ll walk
-            through your use case, size your traffic and tell you which plan
-            actually fits — or whether you need one at all.
-          </Text>
-        </Flex>
-      </Flex>
-      <BookCallButton
-        forwardedAs='a'
-        href={bookCallUrl('pricing')}
-        variant='black'
-        title={BOOK_CALL_TITLE}
-        rel='noopener noreferrer'
-        target='_blank'
-        data-event-location='pricing'
-        data-event-name={BOOK_CALL_LABEL}
-      >
-        <Caps as='span' css={theme({ fontSize: 0 })}>
-          {BOOK_CALL_LABEL}
-        </Caps>
-      </BookCallButton>
-    </BookCallCard>
-  </Container>
-)
 
 const PLAN_NAMES = ['Free', 'Pro', 'Enterprise']
 
@@ -703,19 +597,6 @@ const CAPABILITIES = [
     href: '/features/adblock'
   }
 ]
-
-const CapabilityIcon = styled(Flex)`
-  ${theme({
-    width: space[4],
-    height: space[4],
-    borderRadius: 4,
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexShrink: 0,
-    color: 'secondary',
-    bg: 'pinkest'
-  })}
-`
 
 const CapabilityTile = ({ icon, title, description, href }) => (
   <Flex

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -26,7 +26,11 @@ import {
   useCurrencyContext
 } from 'components/hook/use-currency'
 import BookCall from 'components/pages/pricing/book-call'
-import { CapabilityIcon } from 'components/pages/pricing/shared'
+import {
+  CapabilityIcon,
+  TILE_DESCRIPTION_FONT_SIZE,
+  TILE_TITLE_FONT_SIZE
+} from 'components/pages/pricing/shared'
 import Plans from 'components/patterns/Plans/Plans'
 import { CURRENCIES, formatPrice } from 'components/patterns/Plans/shared'
 import { trackEvent } from 'helpers/gtag'
@@ -619,7 +623,7 @@ const CapabilityTile = ({ icon, title, description, href }) => (
       <Text
         css={theme({
           fontWeight: 'bold',
-          fontSize: [2, 2, '18px', '18px'],
+          fontSize: TILE_TITLE_FONT_SIZE,
           color: 'black',
           lineHeight: 1
         })}
@@ -628,7 +632,7 @@ const CapabilityTile = ({ icon, title, description, href }) => (
       </Text>
       <Text
         css={theme({
-          fontSize: [1, 1, '15px', '15px'],
+          fontSize: TILE_DESCRIPTION_FONT_SIZE,
           color: 'black70',
           lineHeight: 2
         })}

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -28,6 +28,7 @@ import {
 import Plans from 'components/patterns/Plans/Plans'
 import { CURRENCIES, formatPrice } from 'components/patterns/Plans/shared'
 import { trackEvent } from 'helpers/gtag'
+import { BOOK_CALL_LABEL, bookCallUrl } from 'helpers/book-call'
 import { CDN_EDGES } from 'helpers/cdn-edges'
 import {
   borders,
@@ -229,6 +230,97 @@ const Hero = () => {
     </Container>
   )
 }
+
+const CalendarIcon = (
+  <svg
+    width='20'
+    height='20'
+    viewBox='0 0 24 24'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='2'
+    strokeLinecap='round'
+    strokeLinejoin='round'
+    aria-hidden='true'
+  >
+    <rect x='3' y='4' width='18' height='18' rx='2' ry='2' />
+    <line x1='16' y1='2' x2='16' y2='6' />
+    <line x1='8' y1='2' x2='8' y2='6' />
+    <line x1='3' y1='10' x2='21' y2='10' />
+  </svg>
+)
+
+const BookCallCard = styled(Flex)`
+  ${theme({
+    width: '100%',
+    maxWidth: layout.normal,
+    flexDirection: ['column', 'column', 'row', 'row'],
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: [3, 3, 4, 4],
+    borderRadius: 3,
+    px: [3, 3, 4, 4],
+    py: [3, 3, 4, 4],
+    bg: 'white',
+    textAlign: ['center', 'center', 'left', 'left']
+  })}
+  border: ${borders[1]};
+  border-color: ${colors.black10};
+`
+
+const BookCall = () => (
+  <Container
+    as='section'
+    id='book-call'
+    css={theme({
+      alignItems: 'center',
+      maxWidth: '100%',
+      py: SECTION_VERTICAL_SPACING,
+      px: [3, 3, 4, 4]
+    })}
+  >
+    <BookCallCard>
+      <Flex
+        css={theme({
+          gap: 3,
+          flexDirection: ['column', 'column', 'row', 'row'],
+          alignItems: 'center',
+          minWidth: 0
+        })}
+      >
+        <CapabilityIcon>{CalendarIcon}</CapabilityIcon>
+        <Flex css={theme({ flexDirection: 'column', gap: 1, minWidth: 0 })}>
+          <Text
+            css={theme({
+              fontWeight: 'bold',
+              fontSize: [1, 1, 2, 2],
+              color: 'black',
+              lineHeight: 1
+            })}
+          >
+            Not sure which plan fits?
+          </Text>
+          <Text css={theme({ fontSize: [0, 0, 1, 1], color: 'black60' })}>
+            Talk to an engineer for 15 minutes — no sales pitch.
+          </Text>
+        </Flex>
+      </Flex>
+      <Box css={theme({ flexShrink: 0 })}>
+        <Button
+          as='a'
+          href={bookCallUrl('pricing')}
+          variant='white'
+          rel='noopener noreferrer'
+          target='_blank'
+          data-event-location='pricing'
+          data-event-name={BOOK_CALL_LABEL}
+        >
+          {BOOK_CALL_LABEL}
+        </Button>
+      </Box>
+    </BookCallCard>
+  </Container>
+)
 
 const PLAN_NAMES = ['Free', 'Pro', 'Enterprise']
 
@@ -1524,6 +1616,7 @@ const PricingPage = () => {
             stripeKey={stripeKey}
             footer='stats'
           />
+          <BookCall />
           <Comparison />
           <Testimonials />
           <Clients />


### PR DESCRIPTION
Links to cal.com/microlink/15min from three placements, with the base URL and label shared from helpers/book-call so they stay in sync.

- header: compact secondary button left of the GitHub link, desktop >=768px
- mobile menu: full-width button at the bottom of the collapsed menu
- pricing: contained band under the plan tiers, reusing the page's card border and capability icon tile

Per-placement utm_medium (header/pricing) and a click event via the withAnalytics data-event-* attributes.

The buttons use styled(Button) + forwardedAs rather than a css prop: a css prop compiles to styled(Button), which consumes `as` itself and renders a bare anchor with no button styling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Book a call” links to desktop and mobile navigation.
  * Added a responsive booking section to the pricing page with calendar iconography, consultation messaging, and a booking button.
  * Booking links include tracking parameters and open the external scheduling experience.
  * Added consistent styling and hover/focus states for the new navigation action.
* **Style**
  * Standardized responsive typography across pricing-page capability and booking content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->