### PR TITLE
fix(build): retry markdown fetch with force on 404

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,6 +20,7 @@ const {
   extractMarkdown,
   isNotDeployedYet,
   isMarkdownPage,
+  retryStaleNotFound,
   toMarkdownPath,
   prependTitle,
   notFoundMarkdown
@@ -60,25 +61,22 @@ const githubUrl = (() => {
   }
 })()
 
-const markdownFetcher = url => async selector => {
-  const {
-    data: { markdown },
-    statusCode,
-    response
-  } = await mql(url, {
+const requestMarkdown = (url, selector, force) =>
+  mql(url, {
     apiKey: process.env.MICROLINK_API_KEY,
     data: {
       markdown: selector ? { selector, attr: 'markdown' } : { attr: 'markdown' }
     },
-    meta: false
-  })
-
-  return {
+    meta: false,
+    force
+  }).then(({ data: { markdown }, statusCode, response }) => ({
     markdown,
     statusCode,
     duration: response.headers.get('x-response-time')
-  }
-}
+  }))
+
+const markdownFetcher = url => async selector =>
+  retryStaleNotFound(force => requestMarkdown(url, selector, force))
 
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions

--- a/src/helpers/page-markdown.js
+++ b/src/helpers/page-markdown.js
@@ -63,6 +63,12 @@ const NOT_FOUND_STATUS_CODE = 404
 export const isNotDeployedYet = statusCode =>
   statusCode === NOT_FOUND_STATUS_CODE
 
+export const retryStaleNotFound = async fetchOnce => {
+  const first = await fetchOnce(false)
+  if (!isNotDeployedYet(first.statusCode)) return first
+  return fetchOnce(true)
+}
+
 export const extractMarkdown = async (fetchMarkdown, pathname) => {
   for (const selector of selectorsFor(pathname)) {
     const result = await fetchMarkdown(selector)

--- a/test/helpers/page-markdown.js
+++ b/test/helpers/page-markdown.js
@@ -6,6 +6,7 @@ import {
   extractMarkdown,
   isNotDeployedYet,
   isMarkdownPage,
+  retryStaleNotFound,
   toMarkdownPath,
   prependTitle,
   notFoundLinks,
@@ -102,6 +103,47 @@ describe('isNotDeployedYet', () => {
     expect(isNotDeployedYet(404)).toBe(true)
     expect(isNotDeployedYet(200)).toBe(false)
     expect(isNotDeployedYet(undefined)).toBe(false)
+  })
+})
+
+describe('retryStaleNotFound', () => {
+  test('keeps a live response', async () => {
+    const calls = []
+    const fetchOnce = force => {
+      calls.push(force)
+      return { markdown: 'article', statusCode: 200 }
+    }
+
+    expect(await retryStaleNotFound(fetchOnce)).toEqual({
+      markdown: 'article',
+      statusCode: 200
+    })
+    expect(calls).toEqual([false])
+  })
+
+  test('busts a cached 404 and returns the fresh page', async () => {
+    const calls = []
+    const fetchOnce = force => {
+      calls.push(force)
+      return force
+        ? { markdown: 'article', statusCode: 200 }
+        : { markdown: null, statusCode: 404 }
+    }
+
+    expect(await retryStaleNotFound(fetchOnce)).toEqual({
+      markdown: 'article',
+      statusCode: 200
+    })
+    expect(calls).toEqual([false, true])
+  })
+
+  test('keeps a real 404 after force', async () => {
+    const fetchOnce = () => ({ markdown: null, statusCode: 404 })
+
+    expect(await retryStaleNotFound(fetchOnce)).toEqual({
+      markdown: null,
+      statusCode: 404
+    })
   })
 })
 

--- a/test/llms-txt.js
+++ b/test/llms-txt.js
@@ -162,7 +162,9 @@ describe('the build', () => {
   })
 
   test('busts a cached 404 when converting a page', () => {
-    expect(gatsbyNode).toContain('retryStaleNotFound')
+    expect(bodyOf('markdownFetcher')).toContain(
+      'retryStaleNotFound(force => requestMarkdown'
+    )
     expect(bodyOf('requestMarkdown')).toContain('force')
   })
 })

--- a/test/llms-txt.js
+++ b/test/llms-txt.js
@@ -160,4 +160,9 @@ describe('the build', () => {
   test('writes both only on a production build', () => {
     expect(bodyOf('createPageMarkdownFiles')).toContain('isProductionBuild()')
   })
+
+  test('busts a cached 404 when converting a page', () => {
+    expect(gatsbyNode).toContain('retryStaleNotFound')
+    expect(bodyOf('requestMarkdown')).toContain('force')
+  })
 })


### PR DESCRIPTION
## Summary
- Page `.md` twins are built by asking the Microlink API to convert the already-deployed HTML. A page added in the same deploy 404s; that 404 is cached, so later deploys keep skipping it (`metadata.md` and the other new SDK method docs).
- Retry the conversion once with `force: true` when the first call is a 404. A live page becomes a 200 and the file is written; a real miss still skips.
- After the forced fetch succeeds, the API caches a 200, so later builds stay one cheap cache hit.

## Test plan
- [x] `npx vitest run test/helpers/page-markdown.js test/llms-txt.js`
- [ ] Production build writes `/docs/sdk/methods/metadata.md` (and the other skipped SDK method pages) instead of "not deployed yet"
- [ ] Existing `.md` pages (e.g. `/docs/sdk/getting-started/overview.md`) still generate from a cache hit


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page fetching during builds by retrying responses that indicate a page has not been deployed yet.
  * Prevents cached not-found responses from incorrectly blocking newly available pages.
  * Preserves genuine not-found results after a forced retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->