### PR TITLE
feat(cli): add shareable terminal sessions

### DIFF
--- a/data/git-timestamps-created.json
+++ b/data/git-timestamps-created.json
@@ -679,6 +679,7 @@
   "src/pages/privacy.md": "2019-03-13T00:00:00.000Z",
   "src/pages/recipes.js": "2020-07-13T00:00:00.000Z",
   "src/pages/screenshot.js": "2019-07-15T00:00:00.000Z",
+  "src/pages/screenshot/go.js": "2026-09-05T00:00:00.000Z",
   "src/pages/screenshot/nodejs.js": "2026-06-22T00:00:00.000Z",
   "src/pages/screenshot/php.js": "2026-06-29T00:00:00.000Z",
   "src/pages/screenshot/python.js": "2026-06-29T00:00:00.000Z",

--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -679,6 +679,7 @@
   "src/pages/privacy.md": "2025-07-01T00:00:00.000Z",
   "src/pages/recipes.js": "2026-07-11T00:00:00.000Z",
   "src/pages/screenshot.js": "2026-08-08T00:00:00.000Z",
+  "src/pages/screenshot/go.js": "2026-09-05T00:00:00.000Z",
   "src/pages/screenshot/nodejs.js": "2026-06-29T00:00:00.000Z",
   "src/pages/screenshot/php.js": "2026-06-29T00:00:00.000Z",
   "src/pages/screenshot/python.js": "2026-06-29T00:00:00.000Z",

--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -692,7 +692,7 @@
   "src/pages/status.js": "2026-08-18T00:00:00.000Z",
   "src/pages/styleguide.md": "2024-07-20T00:00:00.000Z",
   "src/pages/subprocessors.md": "2025-07-01T00:00:00.000Z",
-  "src/pages/terminal.js": "2026-09-08T00:00:00.000Z",
+  "src/pages/terminal.js": "2026-09-09T00:00:00.000Z",
   "src/pages/terms.js": "2018-08-20T00:00:00.000Z",
   "src/pages/text.js": "2026-08-07T00:00:00.000Z",
   "src/pages/tools.js": "2026-07-15T00:00:00.000Z",

--- a/src/components/pages/cli/browser-host.js
+++ b/src/components/pages/cli/browser-host.js
@@ -6,6 +6,35 @@ const isSpinnerChunk = chunk => SPINNER.test(String(chunk))
 
 const toCrlf = value => String(value).replace(/\n/g, '\r\n')
 
+const hostServices = () => ({
+  env: {},
+  readFile () {
+    throw new Error('`--file` is not available in the browser playground')
+  },
+  readApiKey () {
+    const value = globalThis.localStorage?.getItem(STORAGE_KEY)
+    return value || undefined
+  },
+  writeConfig (data) {
+    if (data?.apiKey) {
+      globalThis.localStorage?.setItem(STORAGE_KEY, data.apiKey)
+    }
+  },
+  clearConfig () {
+    const had = Boolean(globalThis.localStorage?.getItem(STORAGE_KEY))
+    globalThis.localStorage?.removeItem(STORAGE_KEY)
+    return had
+  },
+  async login () {
+    throw new Error(
+      'login is not available here. Pass --api-key, or run microlink login in your terminal.'
+    )
+  },
+  exit (code) {
+    return code
+  }
+})
+
 export const createBrowserHost = (term, chunks) => {
   const writeLive = chunk => term.write(toCrlf(chunk))
   const collect = chunk => {
@@ -13,40 +42,28 @@ export const createBrowserHost = (term, chunks) => {
     else writeLive(chunk)
   }
   return {
+    ...hostServices(),
+    isTTY: true,
+    hasColors: true,
     stdout: { write: collect },
     stderr: {
       write (chunk) {
         if (isSpinnerChunk(chunk)) writeLive(chunk)
         else collect(chunk)
       }
-    },
-    env: {},
-    isTTY: true,
-    hasColors: true,
-    readFile () {
-      throw new Error('`--file` is not available in the browser playground')
-    },
-    readApiKey () {
-      const value = globalThis.localStorage?.getItem(STORAGE_KEY)
-      return value || undefined
-    },
-    writeConfig (data) {
-      if (data?.apiKey) {
-        globalThis.localStorage?.setItem(STORAGE_KEY, data.apiKey)
-      }
-    },
-    clearConfig () {
-      const had = Boolean(globalThis.localStorage?.getItem(STORAGE_KEY))
-      globalThis.localStorage?.removeItem(STORAGE_KEY)
-      return had
-    },
-    async login () {
-      throw new Error(
-        'login is not available here. Pass --api-key, or run microlink login in your terminal.'
-      )
-    },
-    exit (code) {
-      return code
     }
+  }
+}
+
+export const createSilentHost = chunks => {
+  const collect = chunk => {
+    if (!isSpinnerChunk(chunk)) chunks.push(String(chunk))
+  }
+  return {
+    ...hostServices(),
+    isTTY: false,
+    hasColors: false,
+    stdout: { write: collect },
+    stderr: { write: collect }
   }
 }

--- a/src/components/pages/cli/fullscreen.js
+++ b/src/components/pages/cli/fullscreen.js
@@ -7,7 +7,11 @@ import Text from 'components/elements/Text'
 
 import { theme } from 'theme'
 
-import { CLI_VERSION, XTERM_SURFACE_CSS } from './shared'
+import {
+  CLI_VERSION,
+  XTERM_PROMPT_CARET_CSS,
+  XTERM_SURFACE_CSS
+} from './shared'
 import { useCliTerminal } from './use-cli-terminal'
 
 import '@xterm/xterm/css/xterm.css'
@@ -112,14 +116,17 @@ const Fullscreen = () => {
         tabIndex={-1}
         role='application'
         aria-label='Interactive Microlink CLI'
-        css={theme({
-          flex: 1,
-          minHeight: 0,
-          width: '100%',
-          bg: 'black',
-          p: [3, 3, 4, 4],
-          ...XTERM_SURFACE_CSS
-        })}
+        css={[
+          theme({
+            flex: 1,
+            minHeight: 0,
+            width: '100%',
+            bg: 'black',
+            p: [3, 3, 4, 4],
+            ...XTERM_SURFACE_CSS
+          }),
+          XTERM_PROMPT_CARET_CSS
+        ]}
       />
     </Flex>
   )

--- a/src/components/pages/cli/fullscreen.js
+++ b/src/components/pages/cli/fullscreen.js
@@ -26,7 +26,7 @@ const visuallyHiddenCss = theme({
 
 const Fullscreen = () => {
   const surfaceRef = useRef(null)
-  useCliTerminal(surfaceRef, { attract: false })
+  useCliTerminal(surfaceRef, { attract: false, share: true })
 
   return (
     <Flex

--- a/src/components/pages/cli/playground.js
+++ b/src/components/pages/cli/playground.js
@@ -4,7 +4,7 @@ import Terminal from 'components/elements/Terminal/Terminal'
 
 import { theme, toPx } from 'theme'
 
-import { XTERM_SURFACE_CSS } from './shared'
+import { XTERM_PROMPT_CARET_CSS, XTERM_SURFACE_CSS } from './shared'
 import { PLAYGROUND_HEIGHT, useCliTerminal } from './use-cli-terminal'
 
 import '@xterm/xterm/css/xterm.css'
@@ -39,13 +39,16 @@ const Playground = () => {
         role='application'
         tabIndex={-1}
         aria-label='Interactive Microlink CLI'
-        css={theme({
-          width: '100%',
-          height: toPx(PLAYGROUND_HEIGHT),
-          minHeight: toPx(PLAYGROUND_HEIGHT),
-          bg: 'black',
-          ...XTERM_SURFACE_CSS
-        })}
+        css={[
+          theme({
+            width: '100%',
+            height: toPx(PLAYGROUND_HEIGHT),
+            minHeight: toPx(PLAYGROUND_HEIGHT),
+            bg: 'black',
+            ...XTERM_SURFACE_CSS
+          }),
+          XTERM_PROMPT_CARET_CSS
+        ]}
       />
     </Terminal>
   )

--- a/src/components/pages/cli/session.js
+++ b/src/components/pages/cli/session.js
@@ -1,8 +1,8 @@
 import { prefersReducedMotion } from 'helpers/reduced-motion'
 
-import { createBrowserHost } from './browser-host'
+import { createBrowserHost, createSilentHost } from './browser-host'
 import { openPager } from './pager'
-import { readSharedLine } from './share'
+import { commandToTraceLine, hasTraceFlag, readSharedLine } from './share'
 import { CLI_COMMAND, isCompactCli } from './shared'
 import { parseCommand } from './tokenize'
 
@@ -304,9 +304,32 @@ export const createCliSession = ({
     }
   }
 
+  const copyTrace = async () => {
+    const mark = commandAt(term.buffer.active.viewportY)
+    if (!mark) return ''
+    if (mark.traceOutput) return mark.traceOutput
+    if (mark.output && hasTraceFlag(mark.text)) {
+      mark.traceOutput = mark.output
+      return mark.output
+    }
+    const line = commandToTraceLine(mark.text)
+    if (!line) return ''
+    const { argv } = parseCommand(line)
+    if (!argv.length) return ''
+    const chunks = []
+    try {
+      await run(argv, createSilentHost(chunks))
+    } catch (error) {
+      if (!disposed) chunks.push(`\n${error.message || error}\n`)
+    }
+    mark.traceOutput = toPlain(chunks.join(''))
+    return mark.traceOutput
+  }
+
   return {
     onData,
     stopAttract,
+    copyTrace,
     async start () {
       const shared = share ? readSharedLine() : ''
       if (shared) {

--- a/src/components/pages/cli/session.js
+++ b/src/components/pages/cli/session.js
@@ -2,17 +2,23 @@ import { prefersReducedMotion } from 'helpers/reduced-motion'
 
 import { createBrowserHost } from './browser-host'
 import { openPager } from './pager'
+import { readSharedLine } from './share'
 import { CLI_COMMAND, isCompactCli } from './shared'
 import { parseCommand } from './tokenize'
 
 const PROMPT = `${CLI_COMMAND} `
+const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;?]*[ -/]*[@-~]`, 'g')
+
+const toPlain = value =>
+  String(value).replace(ANSI, '').replace(/\r/g, '').trim()
 
 export const createCliSession = ({
   term,
   run,
   attractCommands,
   onPin,
-  surface
+  surface,
+  share = false
 }) => {
   let disposed = false
   let running = false
@@ -47,7 +53,7 @@ export const createCliSession = ({
   const commandAt = y => {
     let found = null
     for (const mark of marks) {
-      if (mark.line < y) found = mark
+      if (mark.line <= y) found = mark
     }
     return found
   }
@@ -57,6 +63,7 @@ export const createCliSession = ({
     const mark = commandAt(y)
     onPin?.({
       command: mark ? mark.text : '',
+      output: mark ? mark.output || '' : '',
       prompt: pinOverlay ? `${PROMPT}${buffer}` : '',
       viewLine
     })
@@ -140,9 +147,10 @@ export const createCliSession = ({
       return
     }
     running = true
-    const commandLine = term.buffer.active.baseY + term.buffer.active.cursorY
+    const typedInTerm = !pinOverlay && !attracting
     try {
-      await write('\r\n')
+      await write(typedInTerm ? '\r\x1b[2K' : '\r\n')
+      const commandLine = term.buffer.active.baseY + term.buffer.active.cursorY
       const chunks = []
       try {
         await run(argv, createBrowserHost(term, chunks))
@@ -175,10 +183,11 @@ export const createCliSession = ({
           pinOverlay = true
           marks.push({
             line: commandLine,
-            text: `${PROMPT}${history.at(-1) || ''}`
+            text: `${PROMPT}${history.at(-1) || ''}`,
+            output: toPlain(text)
           })
           term.write('\x1b[?25l')
-          const viewLine = commandLine + 1
+          const viewLine = commandLine
           holdView = viewLine
           paintPins(viewLine)
           const stick = () => term.scrollToLine(viewLine)
@@ -299,6 +308,16 @@ export const createCliSession = ({
     onData,
     stopAttract,
     async start () {
+      const shared = share ? readSharedLine() : ''
+      if (shared) {
+        resetInput()
+        buffer = shared
+        remember(shared)
+        const parsed = parseCommand(shared)
+        await execute(parsed.argv, { page: parsed.page })
+        term.focus()
+        return
+      }
       if (attractCommands?.length && !prefersReducedMotion()) {
         await runAttract()
         return

--- a/src/components/pages/cli/share.js
+++ b/src/components/pages/cli/share.js
@@ -1,0 +1,33 @@
+export const SHARE_QUERY_KEY = 'q'
+
+const SECRET_FLAG = /(?:^|\s)--api-key(?:=|\s+)\S+/gi
+
+export const sanitizeShareLine = line =>
+  String(line || '')
+    .replace(SECRET_FLAG, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+export const parseSharedLine = search =>
+  sanitizeShareLine(new URLSearchParams(search).get(SHARE_QUERY_KEY) || '')
+
+export const sharePath = (line, loc) => {
+  const url = new URL(loc.href)
+  const next = sanitizeShareLine(line)
+  if (next) url.searchParams.set(SHARE_QUERY_KEY, next)
+  else url.searchParams.delete(SHARE_QUERY_KEY)
+  return `${url.pathname}${url.search}${url.hash}`
+}
+
+export const commandToShareLine = command =>
+  sanitizeShareLine(
+    String(command || '').replace(/^(?:microlink(?:\.io)?\s+)/i, '')
+  )
+
+export const shareHref = (command, loc = window.location) =>
+  new URL(sharePath(commandToShareLine(command), loc), loc.href).href
+
+export const readSharedLine = () => {
+  if (typeof window === 'undefined') return ''
+  return parseSharedLine(window.location.search)
+}

--- a/src/components/pages/cli/share.js
+++ b/src/components/pages/cli/share.js
@@ -24,6 +24,16 @@ export const commandToShareLine = command =>
     String(command || '').replace(/^(?:microlink(?:\.io)?\s+)/i, '')
   )
 
+const TRACE_FLAG = /(?:^|\s)--trace(?:-full)?(?:\s|=|$)/i
+
+export const hasTraceFlag = line => TRACE_FLAG.test(String(line || ''))
+
+export const commandToTraceLine = command => {
+  const line = sanitizeShareLine(command)
+  if (!line) return ''
+  return hasTraceFlag(line) ? line : `${line} --trace`
+}
+
 export const shareHref = (command, loc = window.location) =>
   new URL(sharePath(commandToShareLine(command), loc), loc.href).href
 

--- a/src/components/pages/cli/shared.js
+++ b/src/components/pages/cli/shared.js
@@ -5,7 +5,7 @@ import { Terminal as TerminalPromptIcon } from 'components/icons/Terminal'
 import { SEARCH_LAYOUT_WIDE_MAX_WIDTH } from 'components/pages/search'
 
 import pkg from '../../../../node_modules/microlink.io/package.json'
-import { colors } from 'theme'
+import { colors, transition } from 'theme'
 
 export const CLI_VERSION = pkg.version
 export const ACCENT = 'red6'
@@ -52,6 +52,9 @@ export const XTERM_SURFACE_CSS = {
     cursor: 'text'
   },
   '& [data-cli-pin="command"]': {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 2,
     overflow: 'hidden',
     maxHeight: '3em',
     opacity: 1,
@@ -68,7 +71,71 @@ export const XTERM_SURFACE_CSS = {
       opacity: 0,
       pb: 0,
       mb: 0,
-      borderBottom: 0
+      borderBottom: 0,
+      pointerEvents: 'none'
+    },
+    '& [data-cli-cmd]': {
+      minWidth: 0
+    },
+    '& [data-cli-actions]': {
+      display: 'inline-flex',
+      alignItems: 'center',
+      flexShrink: 0,
+      gap: 1
+    },
+    '& [data-cli-action]': {
+      position: 'relative',
+      display: 'inline-grid',
+      alignItems: 'center',
+      justifyItems: 'center',
+      appearance: 'none',
+      background: 'transparent',
+      border: 0,
+      color: 'white40',
+      cursor: 'pointer',
+      p: 0,
+      width: '1.2em',
+      height: '1.2em',
+      _hover: { color: 'white' },
+      '&[data-copied="true"]': { color: 'green5' },
+      '&:focus-visible': {
+        outline: '2px solid',
+        outlineColor: 'link',
+        outlineOffset: '2px'
+      },
+      '&::after': {
+        content: '""',
+        position: 'absolute',
+        inset: ['-12px', '-4px', '-4px', '-4px']
+      },
+      '& [data-cli-icon]': {
+        gridArea: '1 / 1',
+        display: 'flex',
+        '& svg': {
+          display: 'block',
+          width: '1em',
+          height: '1em'
+        }
+      },
+      '& [data-cli-icon="done"]': {
+        opacity: 0,
+        transform: 'scale(0.4)'
+      },
+      '&[data-copied="true"] [data-cli-icon="action"]': {
+        opacity: 0,
+        transform: 'scale(0.4)'
+      },
+      '&[data-copied="true"] [data-cli-icon="done"]': {
+        opacity: 1,
+        transform: 'scale(1)'
+      },
+      '@media (prefers-reduced-motion: no-preference)': {
+        transition: `color ${transition.short}`,
+        '&:active': { transform: 'scale(0.92)' },
+        '& [data-cli-icon]': {
+          transition: `opacity ${transition.short}, transform ${transition.short}`
+        }
+      }
     }
   },
   '& [data-cli-pin="prompt"]': {

--- a/src/components/pages/cli/shared.js
+++ b/src/components/pages/cli/shared.js
@@ -75,7 +75,11 @@ export const XTERM_SURFACE_CSS = {
       pointerEvents: 'none'
     },
     '& [data-cli-cmd]': {
-      minWidth: 0
+      flex: '0 1 auto',
+      minWidth: 0,
+      overflow: 'hidden',
+      whiteSpace: 'pre-wrap',
+      overflowWrap: 'anywhere'
     },
     '& [data-cli-actions]': {
       display: 'inline-flex',

--- a/src/components/pages/cli/shared.js
+++ b/src/components/pages/cli/shared.js
@@ -7,7 +7,7 @@ import { SEARCH_LAYOUT_WIDE_MAX_WIDTH } from 'components/pages/search'
 import { blink } from 'components/keyframes'
 
 import pkg from '../../../../node_modules/microlink.io/package.json'
-import { colors, transition } from 'theme'
+import { colors, speed, transition } from 'theme'
 
 export const CLI_VERSION = pkg.version
 export const ACCENT = 'red6'
@@ -171,6 +171,16 @@ export const XTERM_SURFACE_CSS = {
 }
 
 export const XTERM_PROMPT_CARET_CSS = css`
+  [data-cli-action] {
+    --icon-swap-start-scale: 0.95;
+    --icon-swap-dur: ${speed.quickly}ms;
+    --icon-swap-ease: cubic-bezier(0.77, 0, 0.175, 1);
+  }
+
+  [data-cli-action][data-state='a'] {
+    --icon-swap-dur: 100ms;
+  }
+
   @media (prefers-reduced-motion: no-preference) {
     [data-cli-pin='prompt']::after {
       animation-name: ${blink};

--- a/src/components/pages/cli/shared.js
+++ b/src/components/pages/cli/shared.js
@@ -1,8 +1,10 @@
 import React from 'react'
+import { css } from 'styled-components'
 import { Code, LogIn, Monitor } from 'react-feather'
 
 import { Terminal as TerminalPromptIcon } from 'components/icons/Terminal'
 import { SEARCH_LAYOUT_WIDE_MAX_WIDTH } from 'components/pages/search'
+import { blink } from 'components/keyframes'
 
 import pkg from '../../../../node_modules/microlink.io/package.json'
 import { colors, transition } from 'theme'
@@ -63,8 +65,7 @@ export const XTERM_SURFACE_CSS = {
     borderBottom: 1,
     borderBottomColor: 'white10',
     '@media (prefers-reduced-motion: no-preference)': {
-      transition:
-        'max-height 160ms ease, padding 160ms ease, margin 160ms ease, opacity 160ms ease, border-width 160ms ease'
+      transition: `opacity ${transition.short}`
     },
     '&[data-collapsed="true"]': {
       maxHeight: 0,
@@ -100,7 +101,9 @@ export const XTERM_SURFACE_CSS = {
       p: 0,
       width: '1.2em',
       height: '1.2em',
-      _hover: { color: 'white' },
+      '@media (hover: hover) and (pointer: fine)': {
+        '&:hover': { color: 'white' }
+      },
       '&[data-copied="true"]': { color: 'green5' },
       '&:focus-visible': {
         outline: '2px solid',
@@ -113,7 +116,6 @@ export const XTERM_SURFACE_CSS = {
         inset: ['-12px', '-4px', '-4px', '-4px']
       },
       '& [data-cli-icon]': {
-        gridArea: '1 / 1',
         display: 'flex',
         '& svg': {
           display: 'block',
@@ -121,24 +123,9 @@ export const XTERM_SURFACE_CSS = {
           height: '1em'
         }
       },
-      '& [data-cli-icon="done"]': {
-        opacity: 0,
-        transform: 'scale(0.4)'
-      },
-      '&[data-copied="true"] [data-cli-icon="action"]': {
-        opacity: 0,
-        transform: 'scale(0.4)'
-      },
-      '&[data-copied="true"] [data-cli-icon="done"]': {
-        opacity: 1,
-        transform: 'scale(1)'
-      },
       '@media (prefers-reduced-motion: no-preference)': {
         transition: `color ${transition.short}`,
-        '&:active': { transform: 'scale(0.92)' },
-        '& [data-cli-icon]': {
-          transition: `opacity ${transition.short}, transform ${transition.short}`
-        }
+        '&:active': { transform: 'scale(0.97)' }
       }
     }
   },
@@ -146,8 +133,12 @@ export const XTERM_SURFACE_CSS = {
     pt: 3,
     pb: 'max(8px, env(safe-area-inset-bottom))',
     '&::after': {
-      content: '"▋"',
-      color: 'white'
+      content: '""',
+      display: 'inline-block',
+      width: '1px',
+      height: '1lh',
+      bg: 'secondary',
+      verticalAlign: 'bottom'
     }
   },
   '& [data-cli-host]': {
@@ -178,6 +169,17 @@ export const XTERM_SURFACE_CSS = {
     touchAction: 'manipulation'
   }
 }
+
+export const XTERM_PROMPT_CARET_CSS = css`
+  @media (prefers-reduced-motion: no-preference) {
+    [data-cli-pin='prompt']::after {
+      animation-name: ${blink};
+      animation-duration: 1s;
+      animation-timing-function: steps(1);
+      animation-iteration-count: infinite;
+    }
+  }
+`
 
 const FEATURE_ICON_SIZE = 20
 

--- a/src/components/pages/cli/use-cli-terminal.js
+++ b/src/components/pages/cli/use-cli-terminal.js
@@ -253,6 +253,7 @@ export const useCliTerminal = (
           }
           const wasOpen = commandPin.dataset.collapsed !== 'true'
           commandPin.dataset.collapsed = open ? 'false' : 'true'
+          commandPin.inert = !open
           promptPin.textContent = promptText
           promptPin.hidden = !promptText
           if (viewLine != null) {

--- a/src/components/pages/cli/use-cli-terminal.js
+++ b/src/components/pages/cli/use-cli-terminal.js
@@ -16,6 +16,8 @@ const ICON = {
 
 const iconSlot = (name, svg) => {
   const span = document.createElement('span')
+  span.className = 't-icon'
+  span.dataset.icon = name === 'done' ? 'b' : 'a'
   span.dataset.cliIcon = name
   span.setAttribute('aria-hidden', 'true')
   span.innerHTML = svg
@@ -25,32 +27,60 @@ const iconSlot = (name, svg) => {
 const attachPinButton = (parent, { name, label, icon, getText }) => {
   const button = document.createElement('button')
   button.type = 'button'
+  button.className = 't-icon-swap'
+  button.dataset.state = 'a'
   button.dataset.cliAction = name
   button.setAttribute('aria-label', label)
   button.setAttribute('aria-live', 'polite')
   button.append(iconSlot('action', icon), iconSlot('done', ICON.check))
   let timer
+  const restoreLabel = () => {
+    delete button.dataset.copied
+    button.dataset.state = 'a'
+    button.setAttribute('aria-label', label)
+  }
+  const announce = message => {
+    delete button.dataset.copied
+    button.dataset.state = 'a'
+    button.setAttribute('aria-label', message)
+    clearTimeout(timer)
+    timer = setTimeout(restoreLabel, 1500)
+  }
   const onClick = e => {
     e.preventDefault()
     e.stopPropagation()
-    const text = getText()
-    if (!text || typeof navigator === 'undefined' || !navigator.clipboard) {
+    if (button.disabled) return
+    if (typeof navigator === 'undefined' || !navigator.clipboard) {
+      announce('Couldn’t copy')
       return
     }
-    navigator.clipboard
-      .writeText(text)
-      .then(() => {
-        delete button.dataset.copied
-        button.getBoundingClientRect()
-        button.dataset.copied = 'true'
-        button.setAttribute('aria-label', 'Copied')
-        clearTimeout(timer)
-        timer = setTimeout(() => {
+    button.disabled = true
+    button.setAttribute('aria-busy', 'true')
+    Promise.resolve()
+      .then(getText)
+      .then(text => {
+        if (!text) {
+          announce('Couldn’t copy')
+          return
+        }
+        return navigator.clipboard.writeText(text).then(() => {
           delete button.dataset.copied
-          button.setAttribute('aria-label', label)
-        }, 1500)
+          button.dataset.state = 'a'
+          button.getBoundingClientRect()
+          button.dataset.copied = 'true'
+          button.dataset.state = 'b'
+          button.setAttribute('aria-label', 'Copied')
+          clearTimeout(timer)
+          timer = setTimeout(restoreLabel, 1500)
+        })
       })
-      .catch(() => {})
+      .catch(() => {
+        announce('Couldn’t copy')
+      })
+      .finally(() => {
+        button.disabled = false
+        button.removeAttribute('aria-busy')
+      })
   }
   button.addEventListener('click', onClick)
   parent.append(button)
@@ -60,7 +90,7 @@ const attachPinButton = (parent, { name, label, icon, getText }) => {
   }
 }
 
-const attachPinActions = (pin, { getCommand, getOutput }) => {
+const attachPinActions = (pin, { getCommand, getTraceOutput }) => {
   const actions = document.createElement('span')
   actions.dataset.cliActions = ''
   const unbind = [
@@ -68,7 +98,7 @@ const attachPinActions = (pin, { getCommand, getOutput }) => {
       name: 'copy',
       label: 'Copy output',
       icon: ICON.copy,
-      getText: getOutput
+      getText: getTraceOutput
     }),
     attachPinButton(actions, {
       name: 'permalink',
@@ -88,7 +118,7 @@ const FONT_FAMILY = '"SF Mono", Menlo, Monaco, monospace'
 const THEME = {
   background: colors.black,
   foreground: colors.white,
-  cursor: colors.white,
+  cursor: colors.secondary,
   cursorAccent: colors.black,
   selectionBackground: colors.white20,
   black: colors.black,
@@ -212,16 +242,25 @@ export const useCliTerminal = (
       const commandText = document.createElement('span')
       commandText.dataset.cliCmd = ''
       commandPin.append(commandText)
-      let pinnedOutput = ''
+      let copyTrace = async () => ''
       if (share) {
         detachActions = attachPinActions(commandPin, {
           getCommand: () => commandText.textContent,
-          getOutput: () => pinnedOutput
+          getTraceOutput: () => copyTrace()
         })
       }
-      const pinFont = `${term.options.fontSize}px`
-      commandPin.style.fontSize = pinFont
-      promptPin.style.fontSize = pinFont
+      const syncPinMetrics = () => {
+        const size = `${term.options.fontSize}px`
+        commandPin.style.fontSize = size
+        promptPin.style.fontSize = size
+        const row = term.element?.querySelector('.xterm-rows > div')
+        const rowHeight = row?.getBoundingClientRect().height
+        if (rowHeight) {
+          const line = `${rowHeight}px`
+          commandPin.style.lineHeight = line
+          promptPin.style.lineHeight = line
+        }
+      }
       surface.append(commandPin, host, promptPin)
       const focusTerm = e => {
         if (e.target.closest('[data-cli-actions]')) return
@@ -238,6 +277,7 @@ export const useCliTerminal = (
           term.resize(MIN_TERMINAL_COLS, term.rows)
         }
         term.scrollToLine(y)
+        syncPinMetrics()
       }
       fit()
       session = createCliSession({
@@ -246,11 +286,10 @@ export const useCliTerminal = (
         attractCommands: commands,
         share,
         surface,
-        onPin: ({ command, output, prompt: promptText, viewLine }) => {
+        onPin: ({ command, prompt: promptText, viewLine }) => {
           const open = Boolean(command)
           if (command) {
             commandText.textContent = command
-            pinnedOutput = output || ''
           }
           const wasOpen = commandPin.dataset.collapsed !== 'true'
           commandPin.dataset.collapsed = open ? 'false' : 'true'
@@ -270,6 +309,7 @@ export const useCliTerminal = (
           }
         }
       })
+      copyTrace = () => session.copyTrace()
       term.onData(session.onData)
       const unbindTouch = bindTouchScroll(surface, term)
       const onViewportResize = () => fit()

--- a/src/components/pages/cli/use-cli-terminal.js
+++ b/src/components/pages/cli/use-cli-terminal.js
@@ -4,7 +4,82 @@ import { prefersReducedMotion } from 'helpers/reduced-motion'
 import { colors, fontSizes, toRaw } from 'theme'
 
 import { createCliSession } from './session'
+import { shareHref } from './share'
 import { ATTRACT_COMMANDS, MIN_TERMINAL_COLS, isCompactCli } from './shared'
+
+const ICON = {
+  copy: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>',
+  link: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>',
+  check:
+    '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>'
+}
+
+const iconSlot = (name, svg) => {
+  const span = document.createElement('span')
+  span.dataset.cliIcon = name
+  span.setAttribute('aria-hidden', 'true')
+  span.innerHTML = svg
+  return span
+}
+
+const attachPinButton = (parent, { name, label, icon, getText }) => {
+  const button = document.createElement('button')
+  button.type = 'button'
+  button.dataset.cliAction = name
+  button.setAttribute('aria-label', label)
+  button.setAttribute('aria-live', 'polite')
+  button.append(iconSlot('action', icon), iconSlot('done', ICON.check))
+  let timer
+  const onClick = e => {
+    e.preventDefault()
+    e.stopPropagation()
+    const text = getText()
+    if (!text || typeof navigator === 'undefined' || !navigator.clipboard) {
+      return
+    }
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        delete button.dataset.copied
+        button.getBoundingClientRect()
+        button.dataset.copied = 'true'
+        button.setAttribute('aria-label', 'Copied')
+        clearTimeout(timer)
+        timer = setTimeout(() => {
+          delete button.dataset.copied
+          button.setAttribute('aria-label', label)
+        }, 1500)
+      })
+      .catch(() => {})
+  }
+  button.addEventListener('click', onClick)
+  parent.append(button)
+  return () => {
+    clearTimeout(timer)
+    button.removeEventListener('click', onClick)
+  }
+}
+
+const attachPinActions = (pin, { getCommand, getOutput }) => {
+  const actions = document.createElement('span')
+  actions.dataset.cliActions = ''
+  const unbind = [
+    attachPinButton(actions, {
+      name: 'copy',
+      label: 'Copy output',
+      icon: ICON.copy,
+      getText: getOutput
+    }),
+    attachPinButton(actions, {
+      name: 'permalink',
+      label: 'Copy permalink',
+      icon: ICON.link,
+      getText: () => shareHref(getCommand())
+    })
+  ]
+  pin.append(actions)
+  return () => unbind.forEach(fn => fn())
+}
 
 export const PLAYGROUND_HEIGHT = 360
 
@@ -84,7 +159,7 @@ const bindTouchScroll = (surface, term) => {
 
 export const useCliTerminal = (
   containerRef,
-  { attract = true, attractCommands = ATTRACT_COMMANDS } = {}
+  { attract = true, attractCommands = ATTRACT_COMMANDS, share = false } = {}
 ) => {
   const commands = attract ? attractCommands : null
   useEffect(() => {
@@ -97,6 +172,7 @@ export const useCliTerminal = (
     let resizeObserver
     let session
     let detachTouch
+    let detachActions
     ;(async () => {
       const [{ Terminal }, { FitAddon }, cli] = await Promise.all([
         import('@xterm/xterm'),
@@ -132,11 +208,22 @@ export const useCliTerminal = (
       promptPin.dataset.cliPin = 'prompt'
       commandPin.dataset.collapsed = 'true'
       promptPin.hidden = true
+      const commandText = document.createElement('span')
+      commandText.dataset.cliCmd = ''
+      commandPin.append(commandText)
+      let pinnedOutput = ''
+      if (share) {
+        detachActions = attachPinActions(commandPin, {
+          getCommand: () => commandText.textContent,
+          getOutput: () => pinnedOutput
+        })
+      }
       const pinFont = `${term.options.fontSize}px`
       commandPin.style.fontSize = pinFont
       promptPin.style.fontSize = pinFont
       surface.append(commandPin, host, promptPin)
       const focusTerm = e => {
+        if (e.target.closest('[data-cli-actions]')) return
         e.preventDefault()
         term.focus()
       }
@@ -156,10 +243,14 @@ export const useCliTerminal = (
         term,
         run: cli.run ?? cli.default,
         attractCommands: commands,
+        share,
         surface,
-        onPin: ({ command, prompt: promptText, viewLine }) => {
+        onPin: ({ command, output, prompt: promptText, viewLine }) => {
           const open = Boolean(command)
-          if (command) commandPin.textContent = command
+          if (command) {
+            commandText.textContent = command
+            pinnedOutput = output || ''
+          }
           const wasOpen = commandPin.dataset.collapsed !== 'true'
           commandPin.dataset.collapsed = open ? 'false' : 'true'
           promptPin.textContent = promptText
@@ -196,10 +287,11 @@ export const useCliTerminal = (
 
     return () => {
       disposed = true
+      detachActions?.()
       detachTouch?.()
       session?.dispose()
       resizeObserver?.disconnect()
       term?.dispose()
     }
-  }, [containerRef, commands])
+  }, [containerRef, commands, share])
 }

--- a/src/components/pages/cli/use-cli-terminal.js
+++ b/src/components/pages/cli/use-cli-terminal.js
@@ -207,6 +207,7 @@ export const useCliTerminal = (
       host.dataset.cliHost = ''
       promptPin.dataset.cliPin = 'prompt'
       commandPin.dataset.collapsed = 'true'
+      commandPin.inert = true
       promptPin.hidden = true
       const commandText = document.createElement('span')
       commandText.dataset.cliCmd = ''

--- a/src/pages/terminal.js
+++ b/src/pages/terminal.js
@@ -10,7 +10,7 @@ import 'styles/main.scss'
 export const Head = () => (
   <Meta
     title='Terminal'
-    description='Run the Microlink CLI in your browser. Pass any URL or product subcommand and inspect pretty JSON, cache status, and timing.'
+    description='Run the Microlink CLI in your browser. Pass any URL or product subcommand and inspect pretty JSON, cache status, and timing. Share the URL to replay the command.'
   />
 )
 

--- a/test/components/cli-share.js
+++ b/test/components/cli-share.js
@@ -1,0 +1,60 @@
+import { expect, test } from 'vitest'
+
+import {
+  commandToShareLine,
+  parseSharedLine,
+  sanitizeShareLine,
+  shareHref,
+  sharePath
+} from '../../src/components/pages/cli/share'
+
+const loc = href => ({ href })
+
+test('parses q from the query string', () => {
+  expect(parseSharedLine('?q=screenshot+stripe.com')).toBe(
+    'screenshot stripe.com'
+  )
+  expect(parseSharedLine('')).toBe('')
+  expect(parseSharedLine('?q=')).toBe('')
+})
+
+test('sharePath writes and clears q', () => {
+  expect(
+    sharePath('screenshot stripe.com', loc('https://microlink.io/terminal'))
+  ).toBe('/terminal?q=screenshot+stripe.com')
+  expect(
+    sharePath('', loc('https://microlink.io/terminal?q=screenshot+stripe.com'))
+  ).toBe('/terminal')
+})
+
+test('sharePath keeps other params and the hash', () => {
+  expect(
+    sharePath('help', loc('https://microlink.io/terminal?ref=cli#cli-terminal'))
+  ).toBe('/terminal?ref=cli&q=help#cli-terminal')
+})
+
+test('commandToShareLine strips the prompt prefix', () => {
+  expect(commandToShareLine('microlink kikobeats.com')).toBe('kikobeats.com')
+  expect(commandToShareLine('microlink screenshot stripe.com')).toBe(
+    'screenshot stripe.com'
+  )
+  expect(commandToShareLine('help')).toBe('help')
+})
+
+test('shareHref builds an absolute permalink', () => {
+  expect(
+    shareHref('microlink kikobeats.com', loc('https://microlink.io/terminal'))
+  ).toBe('https://microlink.io/terminal?q=kikobeats.com')
+})
+
+test('strips --api-key from shared lines', () => {
+  expect(sanitizeShareLine('screenshot stripe.com --api-key sk_live_xxx')).toBe(
+    'screenshot stripe.com'
+  )
+  expect(sanitizeShareLine('--api-key=sk_live_xxx screenshot stripe.com')).toBe(
+    'screenshot stripe.com'
+  )
+  expect(
+    parseSharedLine('?q=screenshot+stripe.com+--api-key+sk_live_xxx')
+  ).toBe('screenshot stripe.com')
+})

--- a/test/components/cli-share.js
+++ b/test/components/cli-share.js
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 
 import {
   commandToShareLine,
+  commandToTraceLine,
   parseSharedLine,
   sanitizeShareLine,
   shareHref,
@@ -39,6 +40,22 @@ test('commandToShareLine strips the prompt prefix', () => {
     'screenshot stripe.com'
   )
   expect(commandToShareLine('help')).toBe('help')
+})
+
+test('commandToTraceLine appends --trace once', () => {
+  expect(commandToTraceLine('microlink screenshot stripe.com')).toBe(
+    'microlink screenshot stripe.com --trace'
+  )
+  expect(commandToTraceLine('microlink screenshot stripe.com --trace')).toBe(
+    'microlink screenshot stripe.com --trace'
+  )
+  expect(commandToTraceLine('microlink stripe.com --trace-full')).toBe(
+    'microlink stripe.com --trace-full'
+  )
+  expect(
+    commandToTraceLine('screenshot stripe.com --api-key sk_live_xxx')
+  ).toBe('screenshot stripe.com --trace')
+  expect(commandToTraceLine('')).toBe('')
 })
 
 test('shareHref builds an absolute permalink', () => {


### PR DESCRIPTION
## Summary
- `/terminal?q=` replays a command when the page loads.
- Copy output and permalink sit on the pinned command so a multi-command session can share one run.
- Copy re-runs the command with `--trace` and copies that payload; permalink uses the shared icon-swap check.
- Overlay caret matches the xterm bar (size, step blink, secondary). `--api-key` is stripped from shared URLs.

## Test plan
- [ ] Open `/terminal?q=help` — command pin shows once, output starts at Usage, no duplicate command line
- [ ] Copy output copies the `--trace` payload (or help text for `help`); icon swaps with blur/scale
- [ ] Copy permalink copies `…/terminal?q=help`; icon swaps the same way
- [ ] Run a second command, then copy that command’s permalink — opening it replays only that command
- [ ] `/terminal?q=screenshot+stripe.com` runs the command; caret is a secondary bar matching a fresh `/terminal`
- [ ] A URL that includes `--api-key` does not keep the key in the copied permalink
- [ ] Playground on `/integrations/cli` still attracts and has no pin actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI command sharing through URL permalinks.
  * Shared commands can be replayed automatically when opening a shared link.
  * Added copy actions for commands and command output, including trace details.
  * Shared links preserve other URL parameters and remove API keys from shared commands.
  * Improved command pin interactions with clearer actions, focus states, and reduced-motion support.
  * Added improved terminal prompt-caret styling and responsive pinned-output sizing.

* **Documentation**
  * Updated terminal page metadata to mention command replay through shared URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only terminal UX with explicit `--api-key` stripping on shared URLs; copy-output triggers an extra in-browser CLI run for the pinned command.
> 
> **Overview**
> **Adds shareable, replayable browser CLI sessions on `/terminal`**, driven by a new `q` query parameter. Opening a link like `/terminal?q=screenshot+stripe.com` auto-runs that command on load; shared URLs strip `--api-key` and keep other params/hash.
> 
> The pinned command bar (fullscreen only) gains **Copy output** and **Copy permalink** actions. Permalinks encode the sanitized command in `q`; copy output re-runs the pinned command via a silent host (adding `--trace` when needed) and copies plain text to the clipboard, with icon-swap feedback and accessibility labels.
> 
> Session/pin behavior is tightened so typed commands clear the input line instead of duplicating it, command marks track scroll position and stored output, and the overlay prompt uses a secondary blinking bar caret aligned with xterm styling. The integrations playground keeps attract mode and does not show share actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4314d26e7b37703391692c33c546f820a296a165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->