### PR TITLE
fix(cli): pin the command while it runs

### DIFF
--- a/data/git-timestamps-created.json
+++ b/data/git-timestamps-created.json
@@ -671,6 +671,7 @@
   "src/pages/payment/success.js": "2019-08-28T00:00:00.000Z",
   "src/pages/payment/update.js": "2019-08-28T00:00:00.000Z",
   "src/pages/pdf.js": "2020-01-05T00:00:00.000Z",
+  "src/pages/pdf/go.js": "2026-09-05T00:00:00.000Z",
   "src/pages/pdf/nodejs.js": "2026-08-08T00:00:00.000Z",
   "src/pages/pdf/php.js": "2026-08-08T00:00:00.000Z",
   "src/pages/pdf/python.js": "2026-08-08T00:00:00.000Z",

--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -671,6 +671,7 @@
   "src/pages/payment/success.js": "2019-08-29T00:00:00.000Z",
   "src/pages/payment/update.js": "2026-07-11T00:00:00.000Z",
   "src/pages/pdf.js": "2026-08-08T00:00:00.000Z",
+  "src/pages/pdf/go.js": "2026-09-05T00:00:00.000Z",
   "src/pages/pdf/nodejs.js": "2026-08-08T00:00:00.000Z",
   "src/pages/pdf/php.js": "2026-08-08T00:00:00.000Z",
   "src/pages/pdf/python.js": "2026-08-08T00:00:00.000Z",

--- a/src/components/pages/cli/fullscreen.js
+++ b/src/components/pages/cli/fullscreen.js
@@ -5,7 +5,7 @@ import Flex from 'components/elements/Flex'
 import LineBreak from 'components/elements/LineBreak'
 import Text from 'components/elements/Text'
 
-import { theme } from 'theme'
+import { space, theme } from 'theme'
 
 import {
   CLI_VERSION,
@@ -123,6 +123,7 @@ const Fullscreen = () => {
             width: '100%',
             bg: 'black',
             p: [3, 3, 4, 4],
+            '--cli-bleed': [space[3], space[3], space[4], space[4]],
             ...XTERM_SURFACE_CSS
           }),
           XTERM_PROMPT_CARET_CSS

--- a/src/components/pages/cli/session.js
+++ b/src/components/pages/cli/session.js
@@ -48,6 +48,7 @@ export const createCliSession = ({
   }
 
   let pinOverlay = false
+  let liveCommand = null
   const marks = []
 
   const commandAt = y => {
@@ -62,9 +63,9 @@ export const createCliSession = ({
     const y = viewLine ?? term.buffer.active.viewportY
     const mark = commandAt(y)
     onPin?.({
-      command: mark ? mark.text : '',
+      command: liveCommand || (mark ? mark.text : ''),
       output: mark ? mark.output || '' : '',
-      prompt: pinOverlay ? `${PROMPT}${buffer}` : '',
+      prompt: pinOverlay && !running ? `${PROMPT}${buffer}` : '',
       viewLine
     })
   }
@@ -147,10 +148,29 @@ export const createCliSession = ({
       return
     }
     running = true
+    const commandText = `${PROMPT}${history.at(-1) || ''}`
     const typedInTerm = !pinOverlay && !attracting
     try {
+      if (!attracting) {
+        liveCommand = commandText
+        pinOverlay = true
+        term.write('\x1b[?25l')
+        paintPins()
+      }
       await write(typedInTerm ? '\r\x1b[2K' : '\r\n')
+      if (!attracting) term.write('\x1b[?25l')
       const commandLine = term.buffer.active.baseY + term.buffer.active.cursorY
+      if (!attracting) {
+        if (!typedInTerm) {
+          const fill = Math.max(0, term.rows - 1)
+          if (fill) {
+            await write('\r\n'.repeat(fill))
+            await write(`\x1b[${fill}A`)
+          }
+        }
+        holdView = commandLine
+        term.scrollToLine(commandLine)
+      }
       const chunks = []
       try {
         await run(argv, createBrowserHost(term, chunks))
@@ -174,37 +194,36 @@ export const createCliSession = ({
           pager = null
         } else {
           await write(text.replace(/\n/g, '\r\n'))
+          term.write('\x1b[?25l')
         }
       }
       if (!disposed && !attracting) {
+        liveCommand = null
         if (usedPager) prompt()
         else {
           resetInput()
-          pinOverlay = true
+          running = false
           marks.push({
             line: commandLine,
-            text: `${PROMPT}${history.at(-1) || ''}`,
+            text: commandText,
             output: toPlain(text)
           })
-          term.write('\x1b[?25l')
-          const viewLine = commandLine
-          holdView = viewLine
-          paintPins(viewLine)
-          const stick = () => term.scrollToLine(viewLine)
+          holdView = commandLine
+          paintPins(commandLine)
+          const stick = () => term.scrollToLine(commandLine)
           stick()
           window.requestAnimationFrame(stick)
           timeouts.push(setTimeout(stick, 50))
           timeouts.push(
             setTimeout(() => {
-              stick()
               holdView = null
-              paintPins()
             }, 200)
           )
         }
       }
     } finally {
       running = false
+      liveCommand = null
     }
   }
 

--- a/src/components/pages/cli/session.js
+++ b/src/components/pages/cli/session.js
@@ -192,9 +192,11 @@ export const createCliSession = ({
         }
       }
       if (!disposed && !attracting) {
+        term.write('\x1b[?25l')
         liveCommand = null
         if (usedPager) prompt()
         else {
+          pinOverlay = true
           resetInput()
           running = false
           marks.push({

--- a/src/components/pages/cli/session.js
+++ b/src/components/pages/cli/session.js
@@ -160,14 +160,8 @@ export const createCliSession = ({
       await write(typedInTerm ? '\r\x1b[2K' : '\r\n')
       if (!attracting) term.write('\x1b[?25l')
       const commandLine = term.buffer.active.baseY + term.buffer.active.cursorY
+      if (!typedInTerm && !attracting) await write(`${commandText}\r\n`)
       if (!attracting) {
-        if (!typedInTerm) {
-          const fill = Math.max(0, term.rows - 1)
-          if (fill) {
-            await write('\r\n'.repeat(fill))
-            await write(`\x1b[${fill}A`)
-          }
-        }
         holdView = commandLine
         term.scrollToLine(commandLine)
       }

--- a/src/components/pages/cli/shared.js
+++ b/src/components/pages/cli/shared.js
@@ -1,11 +1,9 @@
 import React from 'react'
-import { css } from 'styled-components'
+import { css, keyframes } from 'styled-components'
 import { Code, LogIn, Monitor } from 'react-feather'
 
 import { Terminal as TerminalPromptIcon } from 'components/icons/Terminal'
 import { SEARCH_LAYOUT_WIDE_MAX_WIDTH } from 'components/pages/search'
-import { blink } from 'components/keyframes'
-
 import pkg from '../../../../node_modules/microlink.io/package.json'
 import { colors, speed, transition } from 'theme'
 
@@ -170,6 +168,12 @@ export const XTERM_SURFACE_CSS = {
   }
 }
 
+const promptCaretBlink = keyframes`
+  50% {
+    opacity: 0;
+  }
+`
+
 export const XTERM_PROMPT_CARET_CSS = css`
   [data-cli-action] {
     --icon-swap-start-scale: 0.95;
@@ -183,10 +187,7 @@ export const XTERM_PROMPT_CARET_CSS = css`
 
   @media (prefers-reduced-motion: no-preference) {
     [data-cli-pin='prompt']::after {
-      animation-name: ${blink};
-      animation-duration: 1s;
-      animation-timing-function: steps(1);
-      animation-iteration-count: infinite;
+      animation: ${promptCaretBlink} 1s step-end infinite;
     }
   }
 `

--- a/src/components/pages/cli/shared.js
+++ b/src/components/pages/cli/shared.js
@@ -55,22 +55,33 @@ export const XTERM_SURFACE_CSS = {
     display: 'flex',
     alignItems: 'center',
     gap: 2,
+    width: '100%',
     overflow: 'hidden',
     maxHeight: '3em',
     opacity: 1,
-    pb: 2,
-    mb: 2,
-    borderBottom: 1,
-    borderBottomColor: 'white10',
     '@media (prefers-reduced-motion: no-preference)': {
       transition: `opacity ${transition.short}`
+    },
+    '&[data-stuck="true"]': {
+      overflow: 'visible',
+      pb: 2,
+      mb: 2,
+      position: 'relative',
+      '&::after': {
+        content: '""',
+        position: 'absolute',
+        left: 'calc(-1 * var(--cli-bleed, 0px))',
+        right: 'calc(-1 * var(--cli-bleed, 0px))',
+        bottom: 0,
+        borderBottom: 1,
+        borderBottomColor: 'white10'
+      }
     },
     '&[data-collapsed="true"]': {
       maxHeight: 0,
       opacity: 0,
       pb: 0,
       mb: 0,
-      borderBottom: 0,
       pointerEvents: 'none'
     },
     '& [data-cli-cmd]': {
@@ -127,8 +138,10 @@ export const XTERM_SURFACE_CSS = {
       }
     }
   },
+  '& [data-cli-pin="command"][data-stuck="true"] ~ [data-cli-pin="prompt"]': {
+    pt: 2
+  },
   '& [data-cli-pin="prompt"]': {
-    pt: 3,
     pb: 'max(8px, env(safe-area-inset-bottom))',
     '&::after': {
       content: '""',
@@ -144,7 +157,8 @@ export const XTERM_SURFACE_CSS = {
     minHeight: 0,
     width: 'max-content',
     minWidth: '100%',
-    position: 'relative'
+    position: 'relative',
+    overflow: 'hidden'
   },
   '& .xterm': {
     height: '100%',

--- a/src/components/pages/cli/use-cli-terminal.js
+++ b/src/components/pages/cli/use-cli-terminal.js
@@ -296,16 +296,12 @@ export const useCliTerminal = (
           commandPin.inert = !open
           promptPin.textContent = promptText
           promptPin.hidden = !promptText
-          if (viewLine != null) {
-            term.scrollToLine(viewLine)
-            window.requestAnimationFrame(() => {
-              fit()
-              term.scrollToLine(viewLine)
-            })
-          } else if (wasOpen !== open) {
-            const keep = term.buffer.active.viewportY
+          if (wasOpen !== open) {
+            const keep = viewLine ?? term.buffer.active.viewportY
             fit()
             term.scrollToLine(keep)
+          } else if (viewLine != null) {
+            term.scrollToLine(viewLine)
           }
         }
       })

--- a/src/components/pages/cli/use-cli-terminal.js
+++ b/src/components/pages/cli/use-cli-terminal.js
@@ -301,6 +301,7 @@ export const useCliTerminal = (
         promptPin.style.marginTop = stuck ? '' : `${rowHeight}px`
         host.style.flex = '0 0 auto'
         host.style.height = `${Math.min(used, max)}px`
+        const needed = Math.max(1, Math.round(used / rowHeight))
         if (used > max) {
           const rows = Math.max(1, Math.round(max / rowHeight))
           if (Math.abs(term.rows - rows) > 1) {
@@ -308,6 +309,10 @@ export const useCliTerminal = (
             fitTerm()
             term.scrollToLine(keep)
           } else fitCols()
+        } else if (term.rows < needed) {
+          const keep = term.buffer.active.viewportY
+          fitTerm()
+          term.scrollToLine(keep)
         } else fitCols()
       }
       surface.append(commandPin, host, promptPin)

--- a/src/components/pages/cli/use-cli-terminal.js
+++ b/src/components/pages/cli/use-cli-terminal.js
@@ -203,6 +203,7 @@ export const useCliTerminal = (
     let session
     let detachTouch
     let detachActions
+    let unbindStuck
     ;(async () => {
       const [{ Terminal }, { FitAddon }, cli] = await Promise.all([
         import('@xterm/xterm'),
@@ -249,6 +250,13 @@ export const useCliTerminal = (
           getTraceOutput: () => copyTrace()
         })
       }
+      const contentRows = () => {
+        const buf = term.buffer.active
+        for (let i = buf.length - 1; i >= 0; i--) {
+          if (buf.getLine(i)?.translateToString(true).trim()) return i + 1
+        }
+        return 1
+      }
       const syncPinMetrics = () => {
         const size = `${term.options.fontSize}px`
         commandPin.style.fontSize = size
@@ -260,6 +268,27 @@ export const useCliTerminal = (
           commandPin.style.lineHeight = line
           promptPin.style.lineHeight = line
         }
+        if (promptPin.hidden) {
+          host.style.flex = ''
+          host.style.height = ''
+          commandPin.dataset.stuck = 'false'
+          promptPin.style.marginTop = ''
+          return
+        }
+        if (!rowHeight) return
+        const reserved =
+          (commandPin.dataset.collapsed === 'true'
+            ? 0
+            : commandPin.offsetHeight) + promptPin.offsetHeight
+        const max = Math.max(rowHeight, surface.clientHeight - reserved)
+        const used = contentRows() * rowHeight
+        const stuck =
+          commandPin.dataset.collapsed !== 'true' &&
+          (term.buffer.active.viewportY > 0 || used > max)
+        commandPin.dataset.stuck = stuck ? 'true' : 'false'
+        promptPin.style.marginTop = stuck ? '' : `${rowHeight}px`
+        host.style.flex = '0 0 auto'
+        host.style.height = `${Math.min(used, max)}px`
       }
       surface.append(commandPin, host, promptPin)
       const focusTerm = e => {
@@ -270,11 +299,18 @@ export const useCliTerminal = (
       commandPin.addEventListener('pointerdown', focusTerm)
       promptPin.addEventListener('pointerdown', focusTerm)
       term.open(host)
+      unbindStuck = term.onScroll(() => {
+        if (!promptPin.hidden) syncPinMetrics()
+      })
       const fit = () => {
         const y = term.buffer.active.viewportY
-        fitAddon.fit()
-        if (isCompactCli() && term.cols < MIN_TERMINAL_COLS) {
-          term.resize(MIN_TERMINAL_COLS, term.rows)
+        if (promptPin.hidden) {
+          host.style.flex = ''
+          host.style.height = ''
+          fitAddon.fit()
+          if (isCompactCli() && term.cols < MIN_TERMINAL_COLS) {
+            term.resize(MIN_TERMINAL_COLS, term.rows)
+          }
         }
         term.scrollToLine(y)
         syncPinMetrics()
@@ -292,11 +328,12 @@ export const useCliTerminal = (
             commandText.textContent = command
           }
           const wasOpen = commandPin.dataset.collapsed !== 'true'
+          const promptWasHidden = promptPin.hidden
           commandPin.dataset.collapsed = open ? 'false' : 'true'
           commandPin.inert = !open
           promptPin.textContent = promptText
           promptPin.hidden = !promptText
-          if (wasOpen !== open) {
+          if (wasOpen !== open || promptWasHidden !== promptPin.hidden) {
             const keep = viewLine ?? term.buffer.active.viewportY
             fit()
             term.scrollToLine(keep)
@@ -327,6 +364,7 @@ export const useCliTerminal = (
       disposed = true
       detachActions?.()
       detachTouch?.()
+      unbindStuck?.dispose()
       session?.dispose()
       resizeObserver?.disconnect()
       term?.dispose()

--- a/src/components/pages/cli/use-cli-terminal.js
+++ b/src/components/pages/cli/use-cli-terminal.js
@@ -257,6 +257,18 @@ export const useCliTerminal = (
         }
         return 1
       }
+      const fitTerm = () => {
+        fitAddon.fit()
+        if (isCompactCli() && term.cols < MIN_TERMINAL_COLS) {
+          term.resize(MIN_TERMINAL_COLS, term.rows)
+        }
+      }
+      const fitCols = () => {
+        const cols = fitAddon.proposeDimensions()?.cols
+        if (!cols) return
+        const next = isCompactCli() ? Math.max(cols, MIN_TERMINAL_COLS) : cols
+        if (next !== term.cols) term.resize(next, term.rows)
+      }
       const syncPinMetrics = () => {
         const size = `${term.options.fontSize}px`
         commandPin.style.fontSize = size
@@ -289,6 +301,14 @@ export const useCliTerminal = (
         promptPin.style.marginTop = stuck ? '' : `${rowHeight}px`
         host.style.flex = '0 0 auto'
         host.style.height = `${Math.min(used, max)}px`
+        if (used > max) {
+          const rows = Math.max(1, Math.round(max / rowHeight))
+          if (Math.abs(term.rows - rows) > 1) {
+            const keep = term.buffer.active.viewportY
+            fitTerm()
+            term.scrollToLine(keep)
+          } else fitCols()
+        } else fitCols()
       }
       surface.append(commandPin, host, promptPin)
       const focusTerm = e => {
@@ -307,10 +327,7 @@ export const useCliTerminal = (
         if (promptPin.hidden) {
           host.style.flex = ''
           host.style.height = ''
-          fitAddon.fit()
-          if (isCompactCli() && term.cols < MIN_TERMINAL_COLS) {
-            term.resize(MIN_TERMINAL_COLS, term.rows)
-          }
+          fitTerm()
         }
         term.scrollToLine(y)
         syncPinMetrics()


### PR DESCRIPTION
## Summary
- Pin the running command immediately so the spinner sits under it instead of replacing the line.
- Write later commands into the transcript so each run keeps `microlink …` above its output.
- Sit the next prompt after the last output line, and only draw the pin rule when the command has scrolled away (full-bleed, no left gap).
- Blink the overlay caret with a 50/50 `step-end` animation.

## Test plan
- Open `/terminal`, run `metadata example.com`, confirm the command stays on the pin while the spinner runs.
- Run the same command again: the second FAIL (or output) must have the command above it, not another bare FAIL block.
- Short output: no divider under the pin; one-row gap before the next prompt.
- Long/scrolled output: full-width divider under the pinned command, flush to both edges.
- After `/terminal?q=metadata+elenatorro.com`, confirm the overlay caret blinks on the next prompt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to marketing-site CLI terminal UI, styling, and page metadata—no API, auth, or data-path impact.
> 
> **Overview**
> Fixes fullscreen/interactive CLI behavior so the **pinned command bar** stays visible for the whole run (including spinners) and each execution leaves a proper transcript line above its output.
> 
> **Session execution** now sets a `liveCommand` and overlay pin as soon as a command starts, hides the overlay prompt while `running`, and for non-typed runs writes `microlink …` into the scrollback before output. After completion it records marks and adjusts scroll/hold timing so repeat runs don’t stack bare output blocks.
> 
> **Layout & styling**: `syncPinMetrics` sizes the xterm host from content rows, toggles `data-stuck` when the user has scrolled or output overflows, and only then shows a **full-bleed** divider under the pin (via `--cli-bleed` on the fullscreen surface). Prompt spacing and a local 50/50 `step-end` caret blink replace the previous always-on pin border and shared blink animation.
> 
> Also registers git timestamp metadata for `src/pages/pdf/go.js` (and related entries in the diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 085f4a613982fb98cccfd45f1beaec7c550fedb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI command execution so running commands remain clearly visible while output is produced.
  - Prevented pin prompts and cursors from appearing at inappropriate times during command execution.
  - Improved terminal scrolling, resizing, and layout behavior for long or overflowing sessions.
  - Preserved command-line positioning more reliably after commands complete.

- **Style**
  - Refined terminal spacing, borders, prompt padding, and caret animation for a more consistent fullscreen CLI experience.
  - Improved responsive spacing around the fullscreen terminal surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->