### PR TITLE
fix(cli): keep prompt and output visible

### DIFF
--- a/src/components/pages/cli/session.js
+++ b/src/components/pages/cli/session.js
@@ -72,9 +72,14 @@ export const createCliSession = ({
 
   let holdView = null
 
+  const applyHold = () => {
+    if (holdView === 'bottom') term.scrollToBottom()
+    else if (holdView != null) term.scrollToLine(holdView)
+  }
+
   const scrollDisp = term.onScroll(() => {
     if (holdView != null) {
-      term.scrollToLine(holdView)
+      applyHold()
       return
     }
     if (pinOverlay) paintPins()
@@ -162,8 +167,8 @@ export const createCliSession = ({
       const commandLine = term.buffer.active.baseY + term.buffer.active.cursorY
       if (!typedInTerm && !attracting) await write(`${commandText}\r\n`)
       if (!attracting) {
-        holdView = commandLine
-        term.scrollToLine(commandLine)
+        holdView = 'bottom'
+        term.scrollToBottom()
       }
       const chunks = []
       try {
@@ -204,12 +209,11 @@ export const createCliSession = ({
             text: commandText,
             output: toPlain(text)
           })
-          holdView = commandLine
-          paintPins(commandLine)
-          const stick = () => term.scrollToLine(commandLine)
-          stick()
-          window.requestAnimationFrame(stick)
-          timeouts.push(setTimeout(stick, 50))
+          holdView = 'bottom'
+          paintPins()
+          applyHold()
+          window.requestAnimationFrame(applyHold)
+          timeouts.push(setTimeout(applyHold, 50))
           timeouts.push(
             setTimeout(() => {
               holdView = null

--- a/src/components/pages/cli/session.js
+++ b/src/components/pages/cli/session.js
@@ -73,6 +73,7 @@ export const createCliSession = ({
   let holdView = null
 
   const applyHold = () => {
+    if (disposed) return
     if (holdView === 'bottom') term.scrollToBottom()
     else if (holdView != null) term.scrollToLine(holdView)
   }

--- a/src/components/pages/cli/use-cli-terminal.js
+++ b/src/components/pages/cli/use-cli-terminal.js
@@ -269,6 +269,15 @@ export const useCliTerminal = (
         const next = isCompactCli() ? Math.max(cols, MIN_TERMINAL_COLS) : cols
         if (next !== term.cols) term.resize(next, term.rows)
       }
+      const pinBlock = el => {
+        if (!el || el.hidden) return 0
+        const cs = window.getComputedStyle(el)
+        return (
+          el.offsetHeight +
+          parseFloat(cs.marginTop) +
+          parseFloat(cs.marginBottom)
+        )
+      }
       const syncPinMetrics = () => {
         const size = `${term.options.fontSize}px`
         commandPin.style.fontSize = size
@@ -283,36 +292,45 @@ export const useCliTerminal = (
         if (promptPin.hidden) {
           host.style.flex = ''
           host.style.height = ''
+          host.style.maxHeight = ''
           commandPin.dataset.stuck = 'false'
           promptPin.style.marginTop = ''
           return
         }
         if (!rowHeight) return
-        const reserved =
-          (commandPin.dataset.collapsed === 'true'
-            ? 0
-            : commandPin.offsetHeight) + promptPin.offsetHeight
-        const max = Math.max(rowHeight, surface.clientHeight - reserved)
+        const box = window.getComputedStyle(surface)
+        const inner =
+          surface.clientHeight -
+          parseFloat(box.paddingTop) -
+          parseFloat(box.paddingBottom)
+        promptPin.style.marginTop = `${rowHeight}px`
         const used = contentRows() * rowHeight
+        const reserved =
+          (commandPin.dataset.collapsed === 'true' ? 0 : pinBlock(commandPin)) +
+          pinBlock(promptPin)
+        const max = Math.max(rowHeight, inner - reserved)
+        const maxRows = Math.max(1, Math.floor(max / rowHeight))
+        const usedRows = Math.max(1, Math.round(used / rowHeight))
+        const rows = Math.min(usedRows, maxRows)
+        const hostH = rows * rowHeight
         const stuck =
           commandPin.dataset.collapsed !== 'true' &&
-          (term.buffer.active.viewportY > 0 || used > max)
+          (term.buffer.active.viewportY > 0 || usedRows > maxRows)
         commandPin.dataset.stuck = stuck ? 'true' : 'false'
-        promptPin.style.marginTop = stuck ? '' : `${rowHeight}px`
-        host.style.flex = '0 0 auto'
-        host.style.height = `${Math.min(used, max)}px`
-        const needed = Math.max(1, Math.round(used / rowHeight))
-        if (used > max) {
-          const rows = Math.max(1, Math.round(max / rowHeight))
-          if (Math.abs(term.rows - rows) > 1) {
-            const keep = term.buffer.active.viewportY
-            fitTerm()
-            term.scrollToLine(keep)
-          } else fitCols()
-        } else if (term.rows < needed) {
+        host.style.flex = '0 1 auto'
+        host.style.height = `${hostH}px`
+        host.style.maxHeight = `${hostH}px`
+        const stayBottom =
+          term.buffer.active.viewportY >= term.buffer.active.baseY
+        if (term.rows !== rows) {
           const keep = term.buffer.active.viewportY
-          fitTerm()
-          term.scrollToLine(keep)
+          const cols = fitAddon.proposeDimensions()?.cols ?? term.cols
+          const nextCols = isCompactCli()
+            ? Math.max(cols, MIN_TERMINAL_COLS)
+            : cols
+          term.resize(nextCols, rows)
+          if (stayBottom) term.scrollToBottom()
+          else term.scrollToLine(keep)
         } else fitCols()
       }
       surface.append(commandPin, host, promptPin)

--- a/src/components/pages/cli/use-cli-terminal.js
+++ b/src/components/pages/cli/use-cli-terminal.js
@@ -252,7 +252,14 @@ export const useCliTerminal = (
       }
       const contentRows = () => {
         const buf = term.buffer.active
-        return Math.max(1, buf.baseY + buf.cursorY + 1)
+        let last = buf.baseY + buf.cursorY + 1
+        for (let i = buf.length - 1; i >= 0; i--) {
+          if (buf.getLine(i)?.translateToString(true).trim()) {
+            last = Math.max(last, i + 1)
+            break
+          }
+        }
+        return Math.max(1, last)
       }
       const fitTerm = () => {
         fitAddon.fit()

--- a/src/components/pages/cli/use-cli-terminal.js
+++ b/src/components/pages/cli/use-cli-terminal.js
@@ -252,10 +252,7 @@ export const useCliTerminal = (
       }
       const contentRows = () => {
         const buf = term.buffer.active
-        for (let i = buf.length - 1; i >= 0; i--) {
-          if (buf.getLine(i)?.translateToString(true).trim()) return i + 1
-        }
-        return 1
+        return Math.max(1, buf.baseY + buf.cursorY + 1)
       }
       const fitTerm = () => {
         fitAddon.fit()
@@ -321,6 +318,7 @@ export const useCliTerminal = (
         host.style.height = `${hostH}px`
         host.style.maxHeight = `${hostH}px`
         const stayBottom =
+          usedRows > maxRows &&
           term.buffer.active.viewportY >= term.buffer.active.baseY
         if (term.rows !== rows) {
           const keep = term.buffer.active.viewportY


### PR DESCRIPTION
## Summary
- After a command, keep the overlay prompt and blinking caret on screen (layout was using `clientHeight` and clipping the prompt below the fold).
- Scroll to the bottom of the output so SUCCESS/timing sit above the next prompt, instead of pinning the viewport to the first JSON line.
- Snap the host to whole terminal rows and leave a one-line gap so the last output line is not drawn under the caret.

## Test plan
- [ ] Open `/terminal`, run `metadata microlink.io`, confirm `microlink` + caret are visible and typing shows up.
- [ ] Confirm the viewport lands on SUCCESS, timing, cache, and a fully visible `id` line — not the start of the JSON.
- [ ] Scroll up through the output; command pin stays, prompt stays.
- [ ] Fresh `/terminal` (no `?q=`) still shows the in-terminal blinking cursor before the first command.
- [ ] Repeat on a short viewport / mobile width.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Terminal output remains pinned to the bottom of the scrollback after commands complete.
  - Terminal sizing now accounts for prompt and command areas, including spacing, padding, and visible content.
  - Resizing preserves the current scroll position and maintains a usable minimum width in compact layouts.
  - Delayed scrolling no longer affects terminal sessions after they are closed.
  - Terminal content sizing better reflects the last non-empty line, preventing truncated or excess terminal space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->