### PR TITLE
chore: keep authored title casing on the blog

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -29,7 +29,6 @@ const { buildLlmsTxt } = require('./src/helpers/llms-txt')
 const {
   parseLatestChangelogEntry
 } = require('./src/helpers/parse-latest-changelog-entry')
-const { title: formatTitle } = require('./src/helpers/title')
 const { generate: generateOgCards, slug, imagePath } = require('@microlink/og')
 
 const RECIPES_BY_FEATURES_KEYS = Object.keys(
@@ -460,14 +459,10 @@ const createMarkdownPages = async ({ graphql, createPage }) => {
     const slug = node.fields.slug.replace(/\/+$/, '')
     const contentFilePath = node.internal.contentFilePath
     const lastEdited = await getLastModifiedDate(contentFilePath)
-    const isBlogPage = node.fields.slug.startsWith('/blog/')
     const isSkillPage = node.fields.slug.startsWith('/skills/')
     const skillSlug = isSkillPage
       ? node.fields.slug.split('/').filter(Boolean).pop()
       : null
-    const frontmatter = isBlogPage
-      ? { ...node.frontmatter, title: formatTitle(node.frontmatter.title) }
-      : node.frontmatter
     const templatePath = isSkillPage
       ? path.resolve('./src/templates/skill.js')
       : path.resolve('./src/templates/index.js')
@@ -490,7 +485,7 @@ const createMarkdownPages = async ({ graphql, createPage }) => {
       context: {
         id: node.id,
         description: node.frontmatter.description || node.description,
-        frontmatter,
+        frontmatter: node.frontmatter,
         githubUrl: await githubUrl(contentFilePath),
         lastEdited,
         isBlogPage: node.fields.slug.startsWith('/blog/'),

--- a/src/components/markdown/Context.js
+++ b/src/components/markdown/Context.js
@@ -2,5 +2,6 @@ import { createContext } from 'react'
 
 export const MarkdownContext = createContext({
   isBlogPage: false,
-  isGuidesPage: false
+  isGuidesPage: false,
+  titleize: true
 })

--- a/src/components/markdown/index.js
+++ b/src/components/markdown/index.js
@@ -339,10 +339,16 @@ const ScopedComponents = {
 
 const components = { ...mdComponents, ...ScopedComponents }
 
-const Markdown = ({ children, isBlogPage, isGuidesPage, ...props }) => {
+const Markdown = ({
+  children,
+  isBlogPage,
+  isGuidesPage,
+  titleize = true,
+  ...props
+}) => {
   const contextValue = useMemo(
-    () => ({ isBlogPage, isGuidesPage }),
-    [isBlogPage, isGuidesPage]
+    () => ({ isBlogPage, isGuidesPage, titleize }),
+    [isBlogPage, isGuidesPage, titleize]
   )
 
   return (

--- a/src/components/pages/blog/blog-posts.js
+++ b/src/components/pages/blog/blog-posts.js
@@ -1,7 +1,6 @@
 import { textGradient, theme, transition, breakpoints } from 'theme'
 import { Link } from 'components/elements/Link'
 import { formatDate } from 'helpers/format-date'
-import { title as titleize } from 'helpers/title'
 import { H2 } from 'components/markdown'
 import Flex from 'components/elements/Flex'
 import Text from 'components/elements/Text'
@@ -70,6 +69,7 @@ export const BlogPostList = ({
         >
           <H2
             slug={false}
+            titleize={false}
             css={theme({
               mt: 0,
               mb: 0,
@@ -77,7 +77,7 @@ export const BlogPostList = ({
               display: 'inline-block'
             })}
           >
-            {titleize(title)}
+            {title}
           </H2>
           <Flex
             css={theme({

--- a/src/helpers/feed.js
+++ b/src/helpers/feed.js
@@ -1,11 +1,9 @@
-import { title as formatTitle } from './title.js'
-
 export const serializeBlogFeed = ({ siteUrl, nodes }) =>
   nodes.map(node => {
     const slug = node.fields.slug.replace(/\/+$/, '')
     const url = new URL(slug, siteUrl).toString()
     return {
-      title: formatTitle(node.frontmatter.title),
+      title: node.frontmatter.title,
       description: node.frontmatter.description || node.excerpt,
       date: node.frontmatter.date,
       url,

--- a/src/helpers/hoc/with-title.js
+++ b/src/helpers/hoc/with-title.js
@@ -1,9 +1,13 @@
-import { createElement } from 'react'
+import { createElement, useContext } from 'react'
+import { MarkdownContext } from 'components/markdown/Context'
 import { title as titleizeFn } from 'helpers/title'
 
 export const withTitle = Component => {
   const TitleWrapper = ({ titleize, omitTitleize, ...props }) => {
-    if (typeof props.children !== 'string' || titleize === false) {
+    const { titleize: titleizeByDefault } = useContext(MarkdownContext)
+    const shouldTitleize = titleize ?? titleizeByDefault
+
+    if (typeof props.children !== 'string' || !shouldTitleize) {
       return createElement(Component, props)
     }
 

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -11,7 +11,6 @@ import Layout from 'components/patterns/Layout'
 import Markdown, { H1, H2 } from 'components/markdown'
 import { textGradient, layout, theme } from 'theme'
 import { formatDate } from 'helpers/format-date'
-import { title as titleize } from 'helpers/title'
 import TimeAgo from 'react-timeago'
 import React from 'react'
 
@@ -62,7 +61,7 @@ const PageTemplate = ({
                     mt: 0
                   })}
                 >
-                  <PostTitle>{titleize(subtitle)}</PostTitle>
+                  <PostTitle>{subtitle}</PostTitle>
                 </H2>
               )}
               <PostAuthor authorIds={authorList} />
@@ -96,11 +95,13 @@ const PageTemplate = ({
       </Text>
 
       <Box css={theme({ pt: [3, null, 4] })}>
-        <Markdown isBlogPage>{content}</Markdown>
+        <Markdown isBlogPage titleize={!isBlogPage}>
+          {content}
+        </Markdown>
       </Box>
 
       {isBlogPage && (
-        <Markdown isBlogPage={isBlogPage}>
+        <Markdown isBlogPage={isBlogPage} titleize={false}>
           <PostFooter />
         </Markdown>
       )}

--- a/test/helpers/feed.js
+++ b/test/helpers/feed.js
@@ -1,7 +1,6 @@
 import { test, expect } from 'vitest'
 
 import { serializeBlogFeed } from '../../src/helpers/feed'
-import { title as formatTitle } from '../../src/helpers/title'
 
 const siteUrl = 'https://microlink.io'
 
@@ -29,21 +28,20 @@ test('builds absolute url and stable guid from slug', () => {
   expect(item.date).toBe('2026-01-15')
 })
 
-test('formats titles with the shared title helper', () => {
+test('keeps the authored title casing', () => {
   const [item] = serializeBlogFeed({
     siteUrl,
     nodes: [
       node({
         slug: '/blog/example',
-        title: 'what is a headless browser?',
+        title: 'What Is a Headless Browser? Puppeteer vs Playwright',
         description: 'A description.',
         date: '2026-01-15'
       })
     ]
   })
 
-  expect(item.title).toBe(formatTitle('what is a headless browser?'))
-  expect(item.title).not.toBe('what is a headless browser?')
+  expect(item.title).toBe('What Is a Headless Browser? Puppeteer vs Playwright')
 })
 
 test('falls back to excerpt when description is missing', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Preserved authored title casing in blog post listings and feed entries.
  * Subtitles and selected page content now display as written instead of being automatically reformatted.
  * Added controls for enabling or disabling automatic title capitalization across Markdown-rendered content.
  * Blog pages and post footers now apply title formatting rules more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->