### PR TITLE
feat(tools): walk sitemaps with xml-urls

### DIFF
--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -5,7 +5,7 @@
   "src/content/blog/automate-open-graph-audit.md": "2026-07-05T00:00:00.000Z",
   "src/content/blog/brand-logos-are-hiding-in-dns.md": "2026-08-18T00:00:00.000Z",
   "src/content/blog/browser-automation.md": "2026-02-05T00:00:00.000Z",
-  "src/content/blog/chrome-built-in-ai-from-nodejs.md": "2026-08-24T00:00:00.000Z",
+  "src/content/blog/chrome-built-in-ai-from-nodejs.md": "2026-09-10T00:00:00.000Z",
   "src/content/blog/compress.md": "2026-02-04T00:00:00.000Z",
   "src/content/blog/custom-rules.md": "2026-01-10T00:00:00.000Z",
   "src/content/blog/documentation-as-markdown.md": "2026-02-11T00:00:00.000Z",

--- a/src/helpers/get-sitemap-urls.js
+++ b/src/helpers/get-sitemap-urls.js
@@ -4,9 +4,13 @@ import { mqlCode } from './mql-code'
 export const FREE_FUNCTION_CODE_LIMIT = 1024
 
 export const getSitemapUrls = `async ({ site }) => {
+  // Discover sitemap URLs from this origin's robots.txt
   const robotsUrl = new URL('/robots.txt', site).href
   const res = await fetch(robotsUrl)
-  const maps = require('robots-parser')(robotsUrl, res.ok ? await res.text() : '').getSitemaps()
+  const body = res.ok ? await res.text() : ''
+  const maps = require('robots-parser')(robotsUrl, body).getSitemaps()
+
+  // Walk nested sitemap indexes. \`fetcher\` is how each document is loaded.
   return require('xml-urls')(maps, { fetcher: fetch })
 }`
 

--- a/src/helpers/get-sitemap-urls.js
+++ b/src/helpers/get-sitemap-urls.js
@@ -4,31 +4,10 @@ import { mqlCode } from './mql-code'
 export const FREE_FUNCTION_CODE_LIMIT = 1024
 
 export const getSitemapUrls = `async ({ site }) => {
-  const o = new URL('/robots.txt', site).href
-  const r = await fetch(o)
-  const href = (x, b) => {
-    try {
-      const u = new URL(x.trim().replace(/&amp;/g, '&'), b)
-      return /^https?:$/.test(u.protocol) && u.href
-    } catch {}
-  }
-  const maps = [...new Set(require('robots-parser')(o, r.ok ? await r.text() : '').getSitemaps().map(l => href(l, o)).filter(Boolean))]
-  const seen = new Set(), urls = new Set()
-  const walk = async u => {
-    if (seen.has(u) || seen.size >= 1e3) return
-    seen.add(u)
-    try {
-      const res = await fetch(u)
-      if (!res.ok) return
-      let m, re = /<loc>([^<]+)<\\/loc>/gi, b = Buffer.from(await res.arrayBuffer()), xml = (b[0]==31&&b[1]==139?require('zlib').gunzipSync(b):b).toString()
-      while ((m = re.exec(xml))) {
-        const h = href(m[1], u)
-        h && (/\\.xml(\\.gz)?(\\?|#|$)/i.test(h) ? await walk(h) : urls.add(h))
-      }
-    } catch {}
-  }
-  for (const s of maps) await walk(s)
-  return [...urls]
+  const robotsUrl = new URL('/robots.txt', site).href
+  const res = await fetch(robotsUrl)
+  const maps = require('robots-parser')(robotsUrl, res.ok ? await res.text() : '').getSitemaps()
+  return require('xml-urls')(maps, { fetcher: fetch })
 }`
 
 const microlink = createClient()

--- a/src/helpers/get-sitemap-urls.js
+++ b/src/helpers/get-sitemap-urls.js
@@ -5,13 +5,14 @@ export const FREE_FUNCTION_CODE_LIMIT = 1024
 
 export const getSitemapUrls = `async ({ site }) => {
   // Discover sitemap URLs from this origin's robots.txt
-  const robotsUrl = new URL('/robots.txt', site).href
+  const { href: robotsUrl } = new URL('/robots.txt', site)
   const res = await fetch(robotsUrl)
   const body = res.ok ? await res.text() : ''
-  const maps = require('robots-parser')(robotsUrl, body).getSitemaps()
+  const robotsParser = require('robots-parser')
+  const sitemaps = robotsParser(robotsUrl, body).getSitemaps()
 
   // Walk nested sitemap indexes. \`fetcher\` is how each document is loaded.
-  return require('xml-urls')(maps, { fetcher: fetch })
+  return require('xml-urls')(sitemaps, { fetcher: fetch })
 }`
 
 const microlink = createClient()

--- a/src/pages/tools/sitemap.js
+++ b/src/pages/tools/sitemap.js
@@ -59,8 +59,9 @@ const TOP_FAQ_ITEMS = [
           <Link href='/docs/sdk/methods/function' logoIcon>
             microlink.function()
           </Link>
-          . The function does not start a browser — it reads robots.txt and
-          sitemap XML in the Node sandbox.
+          . The function does not start a browser — it reads <b>Sitemap:</b>{' '}
+          from robots.txt, then <b>xml-urls</b> walks nested indexes with
+          isolate <b>fetch</b>.
         </div>
         <CodeEditor language='javascript' autoHeight>
           {sitemapSdkSnippet('https://microlink.io')}

--- a/test/helpers/get-sitemap-urls.js
+++ b/test/helpers/get-sitemap-urls.js
@@ -16,11 +16,10 @@ test('does not reference page', () => {
   expect(getSitemapUrls).not.toMatch(/\bpage\b/)
 })
 
-test('walks gzipped sitemap indexes and isolates fetch errors', () => {
-  expect(getSitemapUrls).toMatch(/\\.xml(\\.gz)?/)
-  expect(getSitemapUrls).toMatch(/gunzipSync/)
-  expect(getSitemapUrls).toMatch(/catch/)
-  expect(getSitemapUrls).toMatch(/seen\.size >= 1e3/)
+test('walks sitemaps with xml-urls and isolate fetch', () => {
+  expect(getSitemapUrls).toMatch(/xml-urls/)
+  expect(getSitemapUrls).toMatch(/fetcher:\s*fetch/)
+  expect(getSitemapUrls).toMatch(/robots-parser/)
 })
 
 test('SDK snippet is JavaScript, not a query-string function', () => {


### PR DESCRIPTION
## Summary
- Replace the hand-rolled sitemap walker with `robots-parser` + `xml-urls` and isolate `fetch`.
- The sitemap tool and SDK example now share that shorter Function.
- Nested indexes, gzip, and `loc` parsing live in `xml-urls`.

Depends on [xml-urls#154](https://github.com/Kikobeats/xml-urls/pull/154). The live tool will fail to compile until that ships and Function compile can skip `re2`.

## Test plan
- [x] Function source stays under the free 1024-byte limit
- [x] Function does not reference `page`
- [ ] Confirm the FAQ SDK snippet on `/tools/sitemap` shows `xml-urls` + `{ fetcher: fetch }`
- [ ] After xml-urls is published, run the tool against a site with nested sitemaps


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Sitemap discovery now follows sitemap locations declared in `robots.txt`.
  - Nested sitemap indexes are traversed more reliably, including cases involving isolated fetch requests.
  - Sitemap processing now uses dedicated parsing and fetching tools for improved compatibility.

- **Documentation**
  - Updated the sitemap tool’s FAQ to explain how sitemap URLs are discovered and how nested indexes are processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->