### PR TITLE
docs(function): raise heap limits to 32/64MB

### DIFF
--- a/src/components/pages/function/product-shared.js
+++ b/src/components/pages/function/product-shared.js
@@ -431,7 +431,7 @@ export const FAQ_ITEMS = [
   },
   {
     question: 'Is Function available on the free plan?',
-    text: 'Yes. Free runs get a 5-second timeout, 16 MB of memory, 1024 bytes of code, and one concurrent execution per IP. Pro plans extend the timeout up to 60 seconds, raise memory to 32 MB, and remove code-size and concurrency limits.'
+    text: 'Yes. Free runs get a 5-second timeout, 32 MB of memory, 1024 bytes of code, and one concurrent execution per IP. Pro plans extend the timeout up to 60 seconds, raise memory to 64 MB, and remove code-size and concurrency limits.'
   },
   {
     question: 'Does every call execute the function again?',

--- a/src/components/pages/function/shared.js
+++ b/src/components/pages/function/shared.js
@@ -146,7 +146,7 @@ export const FAQ_ITEMS = faqFromItems([
   },
   {
     question: 'Is function() available on the free plan?',
-    text: 'Yes. Free runs get a 5-second timeout, 16 MB of memory, and one concurrent execution per IP. Pro plans extend the timeout up to 60 seconds, raise memory to 32 MB, and remove code-size limits.'
+    text: 'Yes. Free runs get a 5-second timeout, 32 MB of memory, and one concurrent execution per IP. Pro plans extend the timeout up to 60 seconds, raise memory to 64 MB, and remove code-size limits.'
   },
   {
     question: 'When should I use function() instead of extract()?',

--- a/src/content/docs/api/parameters/function.md
+++ b/src/content/docs/api/parameters/function.md
@@ -139,7 +139,7 @@ The function parameter is available on both free and pro plans with different re
 |                      | Free             | Pro              |
 | -------------------- | ---------------- | ---------------- |
 | Timeout              | 5 seconds        | Up to 60 seconds |
-| Memory               | 16 MB            | 32 MB            |
+| Memory               | 32 MB            | 64 MB            |
 | Code size            | 1024 bytes       | Unlimited        |
 | Concurrency          | 1 in-flight per IP | Unlimited      |
 | Outgoing requests    | Same-origin only | Unrestricted     |

--- a/src/content/docs/guides/function/profiling-and-performance.md
+++ b/src/content/docs/guides/function/profiling-and-performance.md
@@ -49,7 +49,7 @@ The function parameter is available on both free and pro plans:
 |                   | Free             | Pro              |
 | ----------------- | ---------------- | ---------------- |
 | Timeout           | 5 seconds        | Up to 60 seconds |
-| Memory            | 16 MB            | 32 MB            |
+| Memory            | 32 MB            | 64 MB            |
 | Code size         | 1024 bytes       | Unlimited        |
 | Concurrency       | 1 in-flight per IP | Unlimited      |
 | Outgoing requests | Same-origin only | Unrestricted     |

--- a/src/content/docs/guides/function/troubleshooting.md
+++ b/src/content/docs/guides/function/troubleshooting.md
@@ -72,7 +72,7 @@ Each error message is plan-aware:
 2. Avoid CPU-intensive operations like large JSON parsing or complex regular expressions.
 3. Move heavy processing to your own server and use the function only for data extraction.
 
-**MemoryError** — the function exceeded its memory limit (16 MB free, 32 MB pro). The limit applies to the JavaScript heap, which is where objects, arrays, and strings live, and it is reported as `profiling.memory.heap`:
+**MemoryError** — the function exceeded its memory limit (32 MB free, 64 MB pro). The limit applies to the JavaScript heap, which is where objects, arrays, and strings live, and it is reported as `profiling.memory.heap`:
 
 1. Reduce the amount of data held in memory at once.
 2. Avoid loading entire pages into memory when you only need a small part.

--- a/src/content/docs/sdk/methods/function.md
+++ b/src/content/docs/sdk/methods/function.md
@@ -78,6 +78,6 @@ Large function bodies are compressed before they're sent, so the free plan's cod
 
 ## Limits
 
-The free plan allows 5 seconds, 16 MB of heap, 1024 bytes of code, one in-flight function per IP, and same-origin outgoing requests only; the pro plan lifts those to 60 seconds, 32 MB, unlimited code size and concurrency, and unrestricted requests. Exceeding a limit returns `isFulfilled: false` with a plan-aware error such as `TimeoutError`; see [plan limits](/docs/api/parameters/function#plan-limits) and [troubleshooting](/docs/guides/function/troubleshooting).
+The free plan allows 5 seconds, 32 MB of heap, 1024 bytes of code, one in-flight function per IP, and same-origin outgoing requests only; the pro plan lifts those to 60 seconds, 64 MB, unlimited code size and concurrency, and unrestricted requests. Exceeding a limit returns `isFulfilled: false` with a plan-aware error such as `TimeoutError`; see [plan limits](/docs/api/parameters/function#plan-limits) and [troubleshooting](/docs/guides/function/troubleshooting).
 
 See the [function guide](/docs/guides/function) for writing patterns, package dependencies, and profiling.


### PR DESCRIPTION
## Summary
- Document Function heap as **32 MB free / 64 MB pro** (was 16/32).
- Update plan-limit tables, troubleshooting, SDK limits, and the Function FAQ.

Pairs with the API MR that actually raises the isolate `--max-old-space-size`.

## Test plan
- [ ] Check `/docs/api/parameters/function#plan-limits`
- [ ] Check Function FAQ copy on `/function`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased function memory limits to 32 MB on the Free plan and 64 MB on the Pro plan.

- **Documentation**
  - Updated FAQs, API references, SDK documentation, performance guidance, and troubleshooting information to reflect the new memory limits.
  - Other function limits remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->