### PR TITLE
fix(tools): pin xml-urls@2.2.0 in the sitemap function

### DIFF
--- a/src/helpers/get-sitemap-urls.js
+++ b/src/helpers/get-sitemap-urls.js
@@ -5,14 +5,13 @@ export const FREE_FUNCTION_CODE_LIMIT = 1024
 
 export const getSitemapUrls = `async ({ site }) => {
   // Discover sitemap URLs from this origin's robots.txt
-  const { href: robotsUrl } = new URL('/robots.txt', site)
+  const robotsUrl = new URL('/robots.txt', site).href
   const res = await fetch(robotsUrl)
   const body = res.ok ? await res.text() : ''
-  const robotsParser = require('robots-parser')
-  const sitemaps = robotsParser(robotsUrl, body).getSitemaps()
+  const maps = require('robots-parser')(robotsUrl, body).getSitemaps()
 
   // Walk nested sitemap indexes. \`fetcher\` is how each document is loaded.
-  return require('xml-urls')(sitemaps, { fetcher: fetch })
+  return require('xml-urls@2.2.0')(maps, { fetcher: fetch })
 }`
 
 const microlink = createClient()

--- a/test/helpers/get-sitemap-urls.js
+++ b/test/helpers/get-sitemap-urls.js
@@ -17,7 +17,7 @@ test('does not reference page', () => {
 })
 
 test('walks sitemaps with xml-urls and isolate fetch', () => {
-  expect(getSitemapUrls).toMatch(/xml-urls/)
+  expect(getSitemapUrls).toMatch(/xml-urls@2\.2\.0/)
   expect(getSitemapUrls).toMatch(/fetcher:\s*fetch/)
   expect(getSitemapUrls).toMatch(/robots-parser/)
 })


### PR DESCRIPTION
## Summary
- Pin the sitemap Function to `xml-urls@2.2.0`.
- Unpinned `xml-urls` resolves to 2.1.84 under Function install (`minimumReleaseAge` + `--prefer-offline`) and falls back to `html-get`.

Follow-up to #2251.

## Test plan
- [x] Helper test expects `xml-urls@2.2.0`
- [ ] After API heap MR deploys, run `/tools/sitemap` against a nested-index site


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sitemap URL processing to use a pinned `xml-urls` version, improving consistency and reliability when discovering sitemap locations.
* **Tests**
  * Updated sitemap processing coverage to verify the pinned dependency is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->