### PR TITLE
fix(tools): swap sitemap example off stripe

### DIFF
--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -330,7 +330,7 @@
   "src/content/docs/sdk/parameters/size.md": "2026-01-10T00:00:00.000Z",
   "src/content/docs/sdk/parameters/url.md": "2026-01-10T00:00:00.000Z",
   "src/content/dpa.md": "2026-01-21T00:00:00.000Z",
-  "src/content/fragments/changelog.md": "2026-09-10T00:00:00.000Z",
+  "src/content/fragments/changelog.md": "2026-09-11T00:00:00.000Z",
   "src/content/fragments/enterprise.md": "2026-07-28T00:00:00.000Z",
   "src/content/privacy.md": "2026-08-20T00:00:00.000Z",
   "src/content/security.md": "2026-09-03T00:00:00.000Z",

--- a/src/components/pages/sitemap/hero/examples.js
+++ b/src/components/pages/sitemap/hero/examples.js
@@ -6,7 +6,7 @@ import { Link } from 'components/elements/Link'
 export const EXAMPLES = [
   { label: 'microlink.io', url: 'https://microlink.io' },
   { label: 'vercel.com', url: 'https://vercel.com' },
-  { label: 'stripe.com', url: 'https://stripe.com' }
+  { label: 'x.ai', url: 'https://x.ai' }
 ]
 
 export const ExampleLinks = ({ onPick }) => (


### PR DESCRIPTION
## Summary
- Replace the sitemap tool example `stripe.com` with `x.ai`.
- Stripe’s sitemap exceeds the free Function 32MB heap (9 large partitions + hreflang trees), so the chip OOMs for visitors.

## Test plan
- [ ] Open `/tools/sitemap` and confirm the third example is `x.ai`.
- [ ] Click `x.ai` and confirm the Function completes on the free plan.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Updated the sitemap examples to feature x.ai instead of stripe.com.
  - Refreshed the changelog’s recorded update date to reflect the latest content revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->