### PR TITLE
feat(editor): run TypeScript modules in the playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "styled-components": "~6.4.3",
     "styled-is": "~1.3.0",
     "styled-system": "~5.1.5",
+    "sucrase": "~3.35.1",
     "sugar-high": "~2.1.0",
     "swr": "~2.5.1",
     "tldts": "~7.4.9",

--- a/src/components/pages/editor/examples.js
+++ b/src/components/pages/editor/examples.js
@@ -91,6 +91,30 @@ export default microlink.function('https://example.com', scrape)
       'scrape.mjs': `export const scrape = ({ page }) => page.title()
 `
     }
+  },
+  {
+    id: 'typescript',
+    label: 'TypeScript function',
+    files: {
+      [ENTRY_FILE]: `import createClient from 'microlink.io'
+import { scrape } from './scrape.ts'
+
+const microlink = createClient()
+
+export default microlink.function('https://example.com', scrape)
+`,
+      'scrape.ts': `type Page = {
+  title: () => Promise<string>
+  $eval: <T>(selector: string, fn: (el: Element) => T) => Promise<T>
+}
+
+export const scrape = async ({ page }: { page: Page }) => {
+  const title = await page.title()
+  const heading = await page.$eval('h1', el => el.textContent)
+  return { title, heading }
+}
+`
+    }
   }
 ]
 

--- a/src/components/pages/editor/format.js
+++ b/src/components/pages/editor/format.js
@@ -1,3 +1,6 @@
 import { prettier } from 'helpers/prettier'
 
-export const formatSource = code => prettier(code, 'js')
+import { isTypeScriptFile } from './shared'
+
+export const formatSource = (code, file) =>
+  prettier(code, isTypeScriptFile(file) ? 'ts' : 'js')

--- a/src/components/pages/editor/index.js
+++ b/src/components/pages/editor/index.js
@@ -14,7 +14,12 @@ import Text from 'components/elements/Text'
 import { useLocalStorage } from 'components/hook/use-local-storage'
 
 import FileBar from './chrome'
-import { DEFAULT_EXAMPLE, DEFAULT_FILES, EXAMPLES } from './examples'
+import {
+  DEFAULT_EXAMPLE,
+  DEFAULT_FILES,
+  EXAMPLES,
+  exampleIdForFiles
+} from './examples'
 import { Pane, PaneBody, PaneFooter } from './pane'
 import Results from './results'
 import { ENTRY_FILE, nextFileName } from './shared'
@@ -114,6 +119,7 @@ const Editor = () => {
       if (!example) return
       templateRef.current = example.files
       replaceFiles({ ...example.files })
+      writeShareQuery(example.files)
     },
     [replaceFiles]
   )
@@ -190,6 +196,7 @@ const Editor = () => {
         <PaneFooter>
           <Templates
             open={templatesOpen}
+            selectedId={exampleIdForFiles(files)}
             onToggle={setTemplatesOpen}
             onSelect={onTemplate}
           />

--- a/src/components/pages/editor/index.js
+++ b/src/components/pages/editor/index.js
@@ -41,6 +41,7 @@ const Editor = () => {
   const editorApi = useRef(null)
   const filesRef = useRef(DEFAULT_FILES)
   const templateRef = useRef(DEFAULT_EXAMPLE.files)
+  const shareEpochRef = useRef(0)
 
   const snapshot = useCallback(
     () => editorApi.current?.getFiles() || filesRef.current,
@@ -53,9 +54,17 @@ const Editor = () => {
     setActiveFile(nextActive)
   }, [])
 
-  const onSettled = useCallback(async nextFiles => {
-    await writeShareQuery(nextFiles)
+  const commitShare = useCallback(async files => {
+    const epoch = shareEpochRef.current
+    return writeShareQuery(files, () => epoch === shareEpochRef.current)
   }, [])
+
+  const onSettled = useCallback(
+    nextFiles => {
+      commitShare(nextFiles)
+    },
+    [commitShare]
+  )
 
   const { status, value, logs, http, elapsed, evaluate } = useEvaluate({
     apiKey,
@@ -117,11 +126,12 @@ const Editor = () => {
     id => {
       const example = EXAMPLES.find(item => item.id === id)
       if (!example) return
+      shareEpochRef.current += 1
       templateRef.current = example.files
       replaceFiles({ ...example.files })
-      writeShareQuery(example.files)
+      commitShare(example.files)
     },
-    [replaceFiles]
+    [commitShare, replaceFiles]
   )
 
   const onCopy = useCallback(async text => {

--- a/src/components/pages/editor/monaco-editor.js
+++ b/src/components/pages/editor/monaco-editor.js
@@ -3,6 +3,7 @@ import Monaco, { loader } from '@monaco-editor/react'
 
 import { formatSource } from './format'
 import { editorOptions, setupMonaco } from './monaco-setup'
+import { editorLanguage } from './shared'
 
 loader.config({
   paths: {
@@ -19,6 +20,7 @@ const MonacoEditor = ({
 }) => {
   const filesRef = useRef(files)
   const onEvaluateRef = useRef(onEvaluate)
+  const activeFileRef = useRef(activeFile)
 
   useEffect(() => {
     filesRef.current = files
@@ -28,10 +30,14 @@ const MonacoEditor = ({
     onEvaluateRef.current = onEvaluate
   }, [onEvaluate])
 
+  useEffect(() => {
+    activeFileRef.current = activeFile
+  }, [activeFile])
+
   return (
     <Monaco
       path={activeFile}
-      language='javascript'
+      language={editorLanguage(activeFile)}
       value={files[activeFile] || ''}
       theme='microlink'
       options={editorOptions}
@@ -53,7 +59,9 @@ const MonacoEditor = ({
           label: 'Format with Prettier',
           keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS],
           run: async current => {
-            current.setValue(await formatSource(current.getValue()))
+            current.setValue(
+              await formatSource(current.getValue(), activeFileRef.current)
+            )
           }
         })
         editor.addAction({

--- a/src/components/pages/editor/monaco-setup.js
+++ b/src/components/pages/editor/monaco-setup.js
@@ -73,18 +73,29 @@ declare module 'microlink.io' {
 
 export const setupMonaco = monaco => {
   monaco.editor.defineTheme('microlink', monacoTheme)
-  monaco.languages.typescript.javascriptDefaults.setDiagnosticsOptions({
-    noSemanticValidation: true,
-    noSyntaxValidation: false
-  })
-  monaco.languages.typescript.javascriptDefaults.setCompilerOptions({
+  const compilerOptions = {
     target: monaco.languages.typescript.ScriptTarget.ESNext,
     allowNonTsExtensions: true,
     esModuleInterop: true,
-    module: monaco.languages.typescript.ModuleKind.ESNext
-  })
-  monaco.languages.typescript.javascriptDefaults.addExtraLib(
-    MICROLINK_TYPES,
-    'ts:filename/microlink.io.d.ts'
-  )
+    module: monaco.languages.typescript.ModuleKind.ESNext,
+    lib: ['esnext', 'dom']
+  }
+  const extras = [
+    [MICROLINK_TYPES, 'ts:filename/microlink.io.d.ts'],
+    [
+      'declare const Buffer: { concat(chunks: Uint8Array[]): { toString(encoding: string): string } }',
+      'ts:filename/buffer.d.ts'
+    ]
+  ]
+  for (const defaults of [
+    monaco.languages.typescript.javascriptDefaults,
+    monaco.languages.typescript.typescriptDefaults
+  ]) {
+    defaults.setDiagnosticsOptions({
+      noSemanticValidation: true,
+      noSyntaxValidation: false
+    })
+    defaults.setCompilerOptions(compilerOptions)
+    for (const [source, path] of extras) defaults.addExtraLib(source, path)
+  }
 }

--- a/src/components/pages/editor/shared.js
+++ b/src/components/pages/editor/shared.js
@@ -50,12 +50,19 @@ export const toSdkSnippet = ({ url, fn, opts, log, method = 'function' }) => {
 
 export const filesFromEntry = code => ({ [ENTRY_FILE]: code })
 
+export const isTypeScriptFile = name => /\.[cm]?tsx?$/.test(name)
+
+export const editorLanguage = name =>
+  isTypeScriptFile(name) ? 'typescript' : 'javascript'
+
 export const nextFileName = files => {
   const used = new Set(Object.keys(files))
-  if (!used.has('helper.mjs')) return 'helper.mjs'
+  const ext = Object.keys(files).some(isTypeScriptFile) ? 'ts' : 'mjs'
+  const first = `helper.${ext}`
+  if (!used.has(first)) return first
   let index = 2
-  while (used.has(`helper-${index}.mjs`)) index += 1
-  return `helper-${index}.mjs`
+  while (used.has(`helper-${index}.${ext}`)) index += 1
+  return `helper-${index}.${ext}`
 }
 
 export const byteLength = value => {

--- a/src/components/pages/editor/templates.js
+++ b/src/components/pages/editor/templates.js
@@ -9,7 +9,7 @@ import { Link } from 'components/elements/Link'
 import { DOCS_HREF } from './shared'
 import { EXAMPLES } from './examples'
 
-const Templates = ({ open, onToggle, onSelect }) => {
+const Templates = ({ open, selectedId, onToggle, onSelect }) => {
   const panelRef = useRef(null)
 
   useEffect(() => {
@@ -84,6 +84,7 @@ const Templates = ({ open, onToggle, onSelect }) => {
               as='li'
               key={example.id}
               role='option'
+              aria-selected={example.id === selectedId}
               onMouseDown={event => event.preventDefault()}
               onClick={() => {
                 onSelect(example.id)

--- a/src/components/pages/editor/to-module-source.js
+++ b/src/components/pages/editor/to-module-source.js
@@ -1,0 +1,30 @@
+import { isTypeScriptFile } from './shared'
+
+const rewriteSpecifiers = source =>
+  source
+    .replace(/((?:from|import)\s*\(?\s*['"])\.\/([^'"]+)(['"])/g, '$1$2$3')
+    .replace(
+      /((?:from|import)\s*\(?\s*['"])https:\/\/esm\.sh\/microlink\.io(?:@[^'"]*)?(['"])/g,
+      '$1microlink.io$2'
+    )
+
+let transformTs
+
+const loadTransform = async () => {
+  if (!transformTs) {
+    const { transform } = await import('sucrase')
+    transformTs = source =>
+      transform(source, {
+        transforms: ['typescript'],
+        disableESTransforms: true
+      }).code
+  }
+  return transformTs
+}
+
+export const toModuleSource = async (name, source) => {
+  const rewritten = rewriteSpecifiers(source)
+  if (!isTypeScriptFile(name)) return rewritten
+  const transform = await loadTransform()
+  return transform(rewritten)
+}

--- a/src/components/pages/editor/use-share.js
+++ b/src/components/pages/editor/use-share.js
@@ -116,11 +116,14 @@ export const readSharedFiles = async () => {
   return example ? example.files : null
 }
 
-export const writeShareQuery = async files => {
+export const writeShareQuery = async (files, isCurrent) => {
   if (typeof window === 'undefined') return window.location.href
   const url = new URL(window.location.href)
   const templateId = exampleIdForFiles(files)
   const encoded = templateId === 'custom' ? await encodeShareCode(files) : ''
+  if (typeof isCurrent === 'function' && !isCurrent()) {
+    return window.location.href
+  }
   const next = applyEditorParams(url, { templateId, encoded })
   window.history.replaceState(null, '', next)
   return new URL(next, url.origin).href

--- a/src/components/pages/editor/use-share.js
+++ b/src/components/pages/editor/use-share.js
@@ -1,6 +1,8 @@
+import { EXAMPLES, exampleIdForFiles } from './examples'
 import { ENTRY_FILE, filesFromEntry } from './shared'
 
 export const SHARE_QUERY_KEY = 'q'
+export const TEMPLATE_QUERY_KEY = 'template'
 
 const API_KEY_LITERAL =
   /(?:['"]apiKey['"]|apiKey)\s*:\s*(['"`])(?:\\.|(?!\1).)*\1\s*,?/g
@@ -86,22 +88,42 @@ export const decodeShareCode = async query => {
   }
 }
 
+export const exampleFromSearch = search => {
+  const id = new URLSearchParams(search).get(TEMPLATE_QUERY_KEY)
+  return EXAMPLES.find(example => example.id === id) || null
+}
+
+export const applyEditorParams = (url, { templateId, encoded } = {}) => {
+  if (templateId && templateId !== 'custom') {
+    url.searchParams.set(TEMPLATE_QUERY_KEY, templateId)
+    url.searchParams.delete(SHARE_QUERY_KEY)
+  } else {
+    url.searchParams.delete(TEMPLATE_QUERY_KEY)
+    if (encoded) url.searchParams.set(SHARE_QUERY_KEY, encoded)
+    else url.searchParams.delete(SHARE_QUERY_KEY)
+  }
+  return `${url.pathname}${url.search}${url.hash}`
+}
+
 export const readSharedFiles = async () => {
   if (typeof window === 'undefined') return null
-  return decodeShareCode(
-    new URLSearchParams(window.location.search).get(SHARE_QUERY_KEY) || ''
+  const search = window.location.search
+  const shared = await decodeShareCode(
+    new URLSearchParams(search).get(SHARE_QUERY_KEY) || ''
   )
+  if (shared) return shared
+  const example = exampleFromSearch(search)
+  return example ? example.files : null
 }
 
 export const writeShareQuery = async files => {
   if (typeof window === 'undefined') return window.location.href
   const url = new URL(window.location.href)
-  const encoded = await encodeShareCode(files)
-  if (encoded) url.searchParams.set(SHARE_QUERY_KEY, encoded)
-  else url.searchParams.delete(SHARE_QUERY_KEY)
-  const next = `${url.pathname}${url.search}${url.hash}`
+  const templateId = exampleIdForFiles(files)
+  const encoded = templateId === 'custom' ? await encodeShareCode(files) : ''
+  const next = applyEditorParams(url, { templateId, encoded })
   window.history.replaceState(null, '', next)
-  return url.href
+  return new URL(next, url.origin).href
 }
 
 export const hasEntry = files => files && typeof files[ENTRY_FILE] === 'string'

--- a/src/components/pages/editor/with-script.js
+++ b/src/components/pages/editor/with-script.js
@@ -1,5 +1,7 @@
 import createClient from 'microlink.io'
 
+import { toModuleSource } from './to-module-source'
+
 const MICROLINK_HOSTS = new Set(['api.microlink.io', 'pro.microlink.io'])
 const CONSOLE_METHODS = ['log', 'debug', 'info', 'warn', 'error']
 
@@ -80,14 +82,6 @@ const wrapFetch =
       }
       return nativeFetch(new Request(nextUrl, input), { ...init, headers })
     }
-
-const rewriteSpecifiers = source =>
-  source
-    .replace(/((?:from|import)\s*\(?\s*['"])\.\/([^'"]+)(['"])/g, '$1$2$3')
-    .replace(
-      /((?:from|import)\s*\(?\s*['"])https:\/\/esm\.sh\/microlink\.io(?:@[^'"]*)?(['"])/g,
-      '$1microlink.io$2'
-    )
 
 const formatLogArg = arg => {
   if (typeof arg === 'string') return arg
@@ -207,7 +201,7 @@ const evalInFrame = async (iframe, files, { apiKey, entry }) => {
 
     for (const [name, source] of Object.entries(files)) {
       const url = URL.createObjectURL(
-        new Blob([`// ${Date.now()}\n${rewriteSpecifiers(source)}`], {
+        new Blob([`// ${Date.now()}\n${await toModuleSource(name, source)}`], {
           type: 'text/javascript'
         })
       )

--- a/src/helpers/prettier.js
+++ b/src/helpers/prettier.js
@@ -3,10 +3,12 @@ import { once } from './once'
 const loadPrettier = once(() =>
   Promise.all([
     import('prettier/standalone'),
-    import('prettier/parser-babel')
-  ]).then(([{ format }, babel]) => ({
+    import('prettier/parser-babel'),
+    import('prettier/parser-typescript')
+  ]).then(([{ format }, babel, typescript]) => ({
     format,
-    babel: babel.default || babel
+    babel: babel.default || babel,
+    typescript: typescript.default || typescript
   }))
 )
 
@@ -23,20 +25,26 @@ const PRETTIER_CONFIG = {
   trailingComma: 'none'
 }
 
-const jsFormatterOpts = babel => ({
+const jsFormatterOpts = ({ babel }) => ({
   parser: 'babel',
   plugins: [babel]
 })
 
-const jsonFormatterOpts = babel => ({
+const jsonFormatterOpts = ({ babel }) => ({
   parser: 'json',
   plugins: [babel]
+})
+
+const tsFormatterOpts = ({ typescript }) => ({
+  parser: 'typescript',
+  plugins: [typescript]
 })
 
 const getFormatterOpts = {
   js: jsFormatterOpts,
   jsx: jsFormatterOpts,
-  json: jsonFormatterOpts
+  json: jsonFormatterOpts,
+  ts: tsFormatterOpts
 }
 
 /**
@@ -118,10 +126,12 @@ export const prettier = async (code, language = 'js') => {
 
   const formatterOpts = getFormatterOpts[language] || getFormatterOpts.js
 
-  // For JS/JSON, use lazy-loaded prettier
   try {
-    const { format, babel } = await loadPrettier()
-    const opts = { ...PRETTIER_CONFIG, ...formatterOpts(babel) }
+    const { format, babel, typescript } = await loadPrettier()
+    const opts = {
+      ...PRETTIER_CONFIG,
+      ...formatterOpts({ babel, typescript })
+    }
     const formatted = format(code, opts)
     return formatted.replace(';<', '<')
   } catch (error) {

--- a/test/components/editor-share.js
+++ b/test/components/editor-share.js
@@ -1,6 +1,10 @@
 import { expect, test } from 'vitest'
 
-import { sanitizeShareCode } from '../../src/components/pages/editor/use-share'
+import {
+  applyEditorParams,
+  exampleFromSearch,
+  sanitizeShareCode
+} from '../../src/components/pages/editor/use-share'
 
 test('strips unquoted apiKey literals', () => {
   expect(sanitizeShareCode("createClient({ apiKey: 'secret' })")).not.toContain(
@@ -26,4 +30,30 @@ test('strips double-quoted apiKey keys', () => {
 test('leaves code without an apiKey unchanged', () => {
   const source = "createClient({ ttl: '1d' })"
   expect(sanitizeShareCode(source)).toBe(source)
+})
+
+test('writes the selected template into the query', () => {
+  const url = new URL('https://microlink.io/editor')
+  expect(applyEditorParams(url, { templateId: 'typescript' })).toBe(
+    '/editor?template=typescript'
+  )
+})
+
+test('replaces a share payload when a template is selected', () => {
+  const url = new URL('https://microlink.io/editor?q=abc')
+  expect(applyEditorParams(url, { templateId: 'eval' })).toBe(
+    '/editor?template=eval'
+  )
+})
+
+test('writes a share payload for custom files', () => {
+  const url = new URL('https://microlink.io/editor?template=eval')
+  expect(applyEditorParams(url, { templateId: 'custom', encoded: 'xyz' })).toBe(
+    '/editor?q=xyz'
+  )
+})
+
+test('resolves a known template from the query', () => {
+  expect(exampleFromSearch('?template=typescript')?.id).toBe('typescript')
+  expect(exampleFromSearch('?template=missing')).toBe(null)
 })

--- a/test/components/editor-typescript.js
+++ b/test/components/editor-typescript.js
@@ -1,0 +1,43 @@
+import { expect, test } from 'vitest'
+
+import { EXAMPLES } from '../../src/components/pages/editor/examples'
+import {
+  editorLanguage,
+  isTypeScriptFile,
+  nextFileName
+} from '../../src/components/pages/editor/shared'
+import { toModuleSource } from '../../src/components/pages/editor/to-module-source'
+
+const typescriptExample = EXAMPLES.find(example => example.id === 'typescript')
+
+test('detects TypeScript files', () => {
+  expect(isTypeScriptFile('scrape.ts')).toBe(true)
+  expect(isTypeScriptFile('helper.tsx')).toBe(true)
+  expect(isTypeScriptFile('main.mjs')).toBe(false)
+  expect(editorLanguage('scrape.ts')).toBe('typescript')
+  expect(editorLanguage('main.mjs')).toBe('javascript')
+})
+
+test('names new helpers with the project extension', () => {
+  expect(nextFileName({ 'main.mjs': '' })).toBe('helper.mjs')
+  expect(nextFileName({ 'main.mjs': '', 'scrape.ts': '' })).toBe('helper.ts')
+})
+
+test('strips types from a TypeScript module', async () => {
+  const source = `export const scrape = ({ page }: { page: { title: () => Promise<string> } }) =>
+  page.title()
+`
+  const code = await toModuleSource('scrape.ts', source)
+  expect(code).toContain('export const scrape')
+  expect(code).not.toContain(': { page:')
+})
+
+test('transpiles the TypeScript template', async () => {
+  const code = await toModuleSource(
+    'scrape.ts',
+    typescriptExample.files['scrape.ts']
+  )
+  expect(code).toContain('export const scrape')
+  expect(code).not.toContain('type Page')
+  expect(code).not.toContain('$eval: <T>')
+})


### PR DESCRIPTION
## Summary
- Accept `.ts` / `.tsx` files in the editor: Monaco uses TypeScript mode, Prettier formats them, and sucrase strips types before the iframe run so `microlink.function` still receives plain JS.
- Add a small **TypeScript function** template (`main.mjs` + typed `scrape.ts`) that runs on the free plan.

## Test plan
- Open `/editor` → View templates → **TypeScript function**
- Confirm tabs `main.mjs` and `scrape.ts`; `scrape.ts` highlights as TypeScript
- Run: Output is `{ title, heading }` from example.com (`isFulfilled: true`)
- Add a file from that project: new tab is `helper.ts`
- ⌘/Ctrl+S on `scrape.ts` formats with the TypeScript parser
- Paste a custom `.ts` helper and import it from `main.mjs`; types must not appear in a thrown syntax error


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added TypeScript support in the code editor, including syntax highlighting, formatting, type-aware file naming, and execution.
  - Added a TypeScript example demonstrating typed scraping code.
  - Improved handling of imports and module references across editor files.
  - Added template-aware sharing, URL loading, and selection state for editor examples.

- **Bug Fixes**
  - Improved editor support for browser and runtime APIs used in examples.

- **Tests**
  - Added coverage for TypeScript editing, transpilation, file naming, sharing, and template selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->