### PR TITLE
docs(function): raise free timeout to 10s

### DIFF
--- a/src/content/docs/api/parameters/function.md
+++ b/src/content/docs/api/parameters/function.md
@@ -138,7 +138,7 @@ The function parameter is available on both free and pro plans with different re
 
 |                      | Free             | Pro              |
 | -------------------- | ---------------- | ---------------- |
-| Timeout              | 5 seconds        | Up to 60 seconds |
+| Timeout              | 10 seconds       | Up to 60 seconds |
 | Memory               | 32 MB            | 64 MB            |
 | Code size            | 1024 bytes       | Unlimited        |
 | Concurrency          | 1 in-flight per IP | Unlimited      |
@@ -153,7 +153,7 @@ When a limit is exceeded, the function returns `isFulfilled: false` with a descr
       "isFulfilled": false,
       "value": {
         "name": "TimeoutError",
-        "message": "Function exceeded the 5s free plan timeout. Upgrade to pro for up to 60s."
+        "message": "Function exceeded the 10s free plan timeout. Upgrade to pro for up to 60s."
       },
       "profiling": {},
       "logging": {}

--- a/src/content/docs/guides/function/profiling-and-performance.md
+++ b/src/content/docs/guides/function/profiling-and-performance.md
@@ -48,7 +48,7 @@ The function parameter is available on both free and pro plans:
 
 |                   | Free             | Pro              |
 | ----------------- | ---------------- | ---------------- |
-| Timeout           | 5 seconds        | Up to 60 seconds |
+| Timeout           | 10 seconds       | Up to 60 seconds |
 | Memory            | 32 MB            | 64 MB            |
 | Code size         | 1024 bytes       | Unlimited        |
 | Concurrency       | 1 in-flight per IP | Unlimited      |

--- a/src/content/docs/guides/function/troubleshooting.md
+++ b/src/content/docs/guides/function/troubleshooting.md
@@ -47,7 +47,7 @@ Each error message is plan-aware:
   "isFulfilled": false,
   "value": {
     "name": "TimeoutError",
-    "message": "Function exceeded the 5s free plan timeout. Upgrade to pro for up to 60s."
+    "message": "Function exceeded the 10s free plan timeout. Upgrade to pro for up to 60s."
   }
 }
 ```
@@ -59,7 +59,7 @@ Each error message is plan-aware:
 
 ## Fixing resource limit errors
 
-**TimeoutError** — the function exceeded its plan timeout (5s free, ~60s pro):
+**TimeoutError** — the function exceeded its plan timeout (10s free, ~60s pro):
 
 1. Reduce the function to a trivial check such as `({ page }) => page.title()` to confirm the page itself loads in time.
 2. Set `meta: false` unless metadata is part of the requirement.

--- a/src/content/docs/sdk/methods/function.md
+++ b/src/content/docs/sdk/methods/function.md
@@ -78,6 +78,6 @@ Large function bodies are compressed before they're sent, so the free plan's cod
 
 ## Limits
 
-The free plan allows 5 seconds, 32 MB of heap, 1024 bytes of code, one in-flight function per IP, and same-origin outgoing requests only; the pro plan lifts those to 60 seconds, 64 MB, unlimited code size and concurrency, and unrestricted requests. Exceeding a limit returns `isFulfilled: false` with a plan-aware error such as `TimeoutError`; see [plan limits](/docs/api/parameters/function#plan-limits) and [troubleshooting](/docs/guides/function/troubleshooting).
+The free plan allows 10 seconds, 32 MB of heap, 1024 bytes of code, one in-flight function per IP, and same-origin outgoing requests only; the pro plan lifts those to 60 seconds, 64 MB, unlimited code size and concurrency, and unrestricted requests. Exceeding a limit returns `isFulfilled: false` with a plan-aware error such as `TimeoutError`; see [plan limits](/docs/api/parameters/function#plan-limits) and [troubleshooting](/docs/guides/function/troubleshooting).
 
 See the [function guide](/docs/guides/function) for writing patterns, package dependencies, and profiling.


### PR DESCRIPTION
## Summary
- Document the free-plan function timeout as 10 seconds (was 5s) across API, SDK, and guide pages.

## Test plan
- [ ] Confirm plan-limits tables and TimeoutError examples say 10s
- [ ] Confirm SDK methods/function limits paragraph matches


Made with [Cursor](https://cursor.com)