### PR TITLE
chore(sitemap): replace x.ai example with stripe.com

### DIFF
--- a/src/components/pages/sitemap/hero/examples.js
+++ b/src/components/pages/sitemap/hero/examples.js
@@ -6,7 +6,7 @@ import { Link } from 'components/elements/Link'
 export const EXAMPLES = [
   { label: 'microlink.io', url: 'https://microlink.io' },
   { label: 'vercel.com', url: 'https://vercel.com' },
-  { label: 'x.ai', url: 'https://x.ai' }
+  { label: 'stripe.com', url: 'https://stripe.com' }
 ]
 
 export const ExampleLinks = ({ onPick }) => (


### PR DESCRIPTION
## Summary
- Swap the sitemap tool example from `x.ai` to `stripe.com`.
- `x.ai/robots.txt` lists a sitemap, but `sitemap.xml` is Cloudflare-blocked (403 HTML), so the example always showed zero URLs.

## Test plan
- [ ] Open `/tools/sitemap` and confirm examples are microlink.io · vercel.com · stripe.com
- [ ] Click stripe.com and confirm it lists URLs (robots.txt points at `https://stripe.com/sitemap/sitemap.xml`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Replaced the suggested `x.ai` example URL with `stripe.com` on the sitemap hero page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->