### PR TITLE
blog: isolated worlds hide headless work

### DIFF
--- a/data/git-timestamps-created.json
+++ b/data/git-timestamps-created.json
@@ -3,6 +3,7 @@
   "src/content/blog/antibot-at-scale.md": "2026-01-06T00:00:00.000Z",
   "src/content/blog/antibot-detection-at-scale.md": "2026-01-19T00:00:00.000Z",
   "src/content/blog/automate-open-graph-audit.md": "2026-01-22T00:00:00.000Z",
+  "src/content/blog/automation-leaks-are-not-just-the-webdriver-flag.md": "2026-09-13T00:00:00.000Z",
   "src/content/blog/brand-logos-are-hiding-in-dns.md": "2026-08-04T00:00:00.000Z",
   "src/content/blog/browser-automation.md": "2026-01-06T00:00:00.000Z",
   "src/content/blog/chrome-built-in-ai-from-nodejs.md": "2026-08-24T00:00:00.000Z",

--- a/data/git-timestamps-modified.json
+++ b/data/git-timestamps-modified.json
@@ -3,6 +3,7 @@
   "src/content/blog/antibot-at-scale.md": "2026-01-19T00:00:00.000Z",
   "src/content/blog/antibot-detection-at-scale.md": "2026-02-03T00:00:00.000Z",
   "src/content/blog/automate-open-graph-audit.md": "2026-07-05T00:00:00.000Z",
+  "src/content/blog/automation-leaks-are-not-just-the-webdriver-flag.md": "2026-09-13T00:00:00.000Z",
   "src/content/blog/brand-logos-are-hiding-in-dns.md": "2026-08-18T00:00:00.000Z",
   "src/content/blog/browser-automation.md": "2026-02-05T00:00:00.000Z",
   "src/content/blog/chrome-built-in-ai-from-nodejs.md": "2026-09-10T00:00:00.000Z",

--- a/src/content/blog/automation-leaks-are-not-just-the-webdriver-flag.md
+++ b/src/content/blog/automation-leaks-are-not-just-the-webdriver-flag.md
@@ -1,0 +1,174 @@
+---
+title: 'Automation Leaks Are Not Just the WebDriver Flag'
+subtitle: 'Cutting page-visible automation calls by 99% with isolated worlds'
+description: 'Before taking a screenshot, browserless was running its own DOM work inside the page, where any site can watch it. Moving that work into isolated worlds cut page-visible automation calls from 1.7M to 14.6K across ten live sites. The measurements, the cost, and what still leaks.'
+authors:
+  - kiko
+date: '2026-09-13'
+---
+
+Every guide on undetectable headless browsing starts and ends with the same property:
+
+```js
+navigator.webdriver // false, and everyone knows how to hide it
+```
+
+We pass that check. We have passed it for years. Yet until last week, any site could install one line of JavaScript and watch us work:
+
+```js
+const original = document.querySelectorAll
+document.querySelectorAll = function () {
+  console.log(new Error().stack)
+  return original.apply(this, arguments)
+}
+```
+
+On [The Guardian](https://www.theguardian.com), a single viewport screenshot tripped that hook **14,537 times**, and the stack frames named us: `pptr:evaluate`, `extractFeatures`, `detectCmp`. Not one of those calls came from the page. They were ours.
+
+**TL;DR**
+
+- Nine PRs in [browserless](https://browserless.js.org) ([#920](https://github.com/microlinkhq/browserless/pull/920) through [#929](https://github.com/microlinkhq/browserless/pull/929), v13.9.15 to v13.9.21) moved our DOM work out of the page's JavaScript world.
+- Page-visible automation calls across ten live sites dropped from **1,716,830 to 14,658**, a 99.1% reduction. Five of ten sites now sit at exactly zero, one of them with a caveat I flag below.
+- Three of those PRs were not about hiding at all. They fixed emulation bugs so bad that the detectors' own fingerprinting scripts were crashing partway through.
+- Screenshots come out pixel-identical, wall clock is unchanged, and DevTools protocol traffic went down, not up.
+
+## Two worlds, one DOM
+
+Chrome gives every frame more than one JavaScript world. The **main world** is the page's own: its scripts, its globals, its prototypes. An **isolated world** shares the same DOM but gets a private globals object and a private stack.
+
+Same `document`. Different observers.
+
+Puppeteer exposes it as `isolatedRealm()`, and the switch is about that small:
+
+```js
+const isolatedRealm = page.mainFrame().isolatedRealm()
+await isolatedRealm.evaluate(() => {
+  /* the page cannot see this run */
+})
+```
+
+If the page patched `document.querySelectorAll`, the main world calls the patch. The isolated world calls the real one. The page never learns a thing.
+
+We were calling the patch. Everywhere.
+
+## Where we were standing in the page
+
+Six of the nine PRs are the same fix applied to a different caller. Each one was a helper that had a legitimate reason to touch the DOM and no reason at all to do it in public:
+
+| PR | What moved into an isolated world |
+| --- | --- |
+| [#920](https://github.com/microlinkhq/browserless/pull/920) | `browserless.text()` reading page text |
+| [#921](https://github.com/microlinkhq/browserless/pull/921) | shadow DOM flattening (`flattenShadowDOM`) |
+| [#924](https://github.com/microlinkhq/browserless/pull/924) | the `screenshot` page helpers |
+| [#925](https://github.com/microlinkhq/browserless/pull/925) | overlay dismissal |
+| [#926](https://github.com/microlinkhq/browserless/pull/926) | [autoconsent](https://github.com/duckduckgo/autoconsent) cookie-banner handling |
+| [#927](https://github.com/microlinkhq/browserless/pull/927) | Ghostery DOM scans (`extractFeatures`) |
+
+The cookie-banner one is the clearest case. Handling consent dialogs means querying, reading computed styles, and clicking, which is exactly the shape of activity a bot detector is looking for. In `packages/goto/src/adblock.js` it is now one flag:
+
+```js
+isMainWorld: false
+```
+
+## How we measured what a site can see
+
+Detector sites were no help here. On [bot-detector.rebrowser.net](https://bot-detector.rebrowser.net) the main-world check reports `not-triggered` both before and after our change, because it only fires when a client calls its trigger function. A passing grade there proves nothing about what a real page observes while we work.
+
+So we measured the page's point of view directly. Before navigation, a hook wraps the page's own DOM APIs (`querySelectorAll`, `getComputedStyle`, `getAttribute`, `classList`, `innerText`, `getBoundingClientRect` and friends). Each call walks `new Error().stack`. Frames pointing at an `http://` or `https://` source are the page's own work and get discarded. Everything else is us, attributed to a source by stack signature.
+
+Then we take an ordinary screenshot. Ten live sites (Guardian, El País, Bild, Le Monde, CNN, NYT, AliExpress, Booking, Stack Overflow, GitHub), viewport and fullPage, with identical Chrome 152.0.7977.75 and Puppeteer 25.10.0 on both sides.
+
+## The numbers
+
+| Automation calls the page could observe | v13.9.15 | v13.9.21 |
+| --- | --- | --- |
+| viewport screenshots | 288,659 | **7,082** |
+| fullPage screenshots | 1,428,171 | **7,576** |
+| total | 1,716,830 | **14,658** (−99.1%) |
+
+Le Monde's fullPage capture alone accounted for 299,113 of the old calls. It is now 0.
+
+One zero in that table has an asterisk. Stack Overflow's new fullPage navigation landed on a Cloudflare interstitial, 265 characters of "Just a moment" and 88&nbsp;KB, instead of the question list the old run captured at 1.8&nbsp;MB. There was hardly a page there to touch, so that particular 0 proves nothing. The viewport run is the honest comparison for that site: the real question list both times (9,622 and 9,662 characters, 604&nbsp;KB and 606&nbsp;KB), **29,562 calls before and 0 after**. Interstitials like that are order-dependent rather than version-dependent, and reversing the run order blocked both sides equally.
+
+By API, summed over every site and mode:
+
+| API | v13.9.15 | v13.9.21 |
+| --- | --- | --- |
+| `getComputedStyle` | 769,473 | **0** |
+| `getAttribute` | 554,655 | 2,908 |
+| `nodeName` | 202,117 | 11,113 |
+| `classList` | 184,427 | **0** |
+| `innerText` | 2,910 | **0** |
+| `querySelectorAll` | 2,116 | 608 |
+| `getBoundingClientRect` | 735 | **0** |
+
+`getComputedStyle` going from 769,473 to zero is the cookie-banner engine leaving the room.
+
+## What the remaining 14,658 are
+
+Almost none of it is helper code. 14,517 of the 14,658 classify as `adblock/scriptlet`: [uBlock-style scriptlets](https://github.com/gorhill/uBlock/wiki/Resources-Library) shipped inside the ad-block engine's `engine.bin`, injected as page scripts against specific domains.
+
+Those run in the main world on purpose. A scriptlet that neutralizes an anti-adblock check has to be *in* the page to do it, and it looks like the filter-list resource it is, not like automation. Bild and AliExpress are the heaviest filtered sites in the set, and they hold nearly all of the residue: 11,068 and 3,077 calls.
+
+The last 141 the harness could not attribute to anyone, so they stay in an `other` bucket rather than a flattering one. 139 of them are on AliExpress, and their stack frames name the page's own ad tracking (`spm_getParamForAD`) running from a script with no URL in its stack, which is exactly the case the "is this frame the page's own?" test cannot decide. The remaining two are a single `click` each on El País and the NYT. Read them at their worst and the bound still holds: 141 calls we have not proven innocent, against 1,716,830 before.
+
+## The bugs we found by looking
+
+Three PRs had nothing to do with isolated worlds. They surfaced because once we started reading detector output carefully, the output was obviously broken.
+
+**[#922](https://github.com/microlinkhq/browserless/pull/922) stopped disabling standard Web APIs.** Our launch flags carried `--disable-notifications`, `--disable-speech-api`, and the `PushMessaging` and `WebPayments` feature switches. Those delete `Notification`, `speechSynthesis`, `webkitSpeechRecognition`, `PushManager` and `PaymentRequest` from every page. Stock Chrome exposes all five. Worse, `permissions.query('notifications')` still answered `prompt`, so a page could read the contradiction: permission to send notifications, no API to send them with.
+
+That missing API was not a subtle signal, it was fatal to the detectors themselves. On [bot.sannysoft.com](https://bot.sannysoft.com), the `fp-collect` section never rendered: **0 checks completed** before, 20 after. On [bot.incolumitas.com](https://bot.incolumitas.com), `fpscanner` returned **0 keys** before and 21 after. Their scripts were throwing partway through on a missing global, and a fingerprinting script that dies is itself an anomaly. We were failing tests by being too strange to test.
+
+**[#923](https://github.com/microlinkhq/browserless/pull/923) emulated a screen consistent with the viewport.** `window.innerWidth` reported 1280, while `screen.width` reported Chrome's headless default of 800x600. No desktop exists where the window is wider than the screen. The consequence was not only a fingerprint:
+
+```js
+matchMedia('(max-device-width: 1024px)').matches
+// before: true   ← the site serves tablet CSS
+// after:  false
+```
+
+Desktop pages were getting their tablet layout. `screen` now reads 1440x900 for the default device, and the screenshots come back pixel-identical, so the fix changed what sites decide and not what we render.
+
+**[#929](https://github.com/microlinkhq/browserless/pull/929) sent UA Client Hints matching the user agent.** We set a Chrome user agent string and then sent no `Sec-CH-UA` headers at all, and `navigator.userAgentData` came back empty. Modern Chrome always sends them.
+
+| Signal | Before | After |
+| --- | --- | --- |
+| `Sec-CH-UA` request header | absent | `"Google Chrome";v="149", …` |
+| `Sec-CH-UA-Mobile` / `-Platform` | absent | `?0` / `"macOS"` |
+| `navigator.userAgentData` | empty | Google Chrome 149 |
+
+Measured across those detectors, 3 runs per side, 36 runs, zero errors:
+
+| Detector | v13.9.14 | v13.9.20 |
+| --- | --- | --- |
+| [fingerprint-scan.com](https://fingerprint-scan.com) bot score | 100/100 | **90/100** |
+| [CreepJS](https://abrahamjuliot.github.io/creepjs/) "like headless" | 38% | **31%** |
+| sannysoft `fp-collect` checks | 0 | 20 |
+| incolumitas `fpscanner` keys | 0 | 21 |
+
+## The cost
+
+Cheaper, which was not the plan. An element handle round trip is several protocol messages; one isolated-world `evaluate` is one. DevTools protocol commands per capture, median of five runs:
+
+| | viewport CDP commands | fullPage CDP commands |
+| --- | --- | --- |
+| theguardian.com | 645 → **162** (−74.9%) | 843 → 344 (−59.2%) |
+| cnn.com | 518 → **186** (−64.1%) | 1455 → 1299 (−10.7%) |
+| github.com | 322 → **209** (−35.1%) | 383 → 257 (−32.9%) |
+
+Wall clock did not move: every timing landed between −3.8% and +0.7%, inside run-to-run noise. Resident memory moved between −0.2% and +4.8%, the top of that range being GitHub's fullPage capture. Titles, extracted text and cookie-banner outcomes stayed equivalent site by site.
+
+## What still leaks
+
+Four things, none of them fixed by this work.
+
+**`Runtime.enable` is still detectable.** Rebrowser's check passes, but the general technique does not care: `Error.prepareStackTrace` and console timing still reveal that a debugger is attached. Closing that requires patching `puppeteer-core` itself, which was out of scope here.
+
+**Web Workers still say HeadlessChrome.** The page reports Chrome; spawn a worker and its `navigator.userAgent` reports `HeadlessChrome`. CreepJS flags exactly that, before and after. A fix is being investigated.
+
+**One real regression.** Re-enabling `Notification` in #922 means sites that gate a notification opt-in overlay on the API existing now render that overlay, and it lands in the screenshot. AliExpress does this. Being more honest about Chrome's API surface made us look more like Chrome and made one class of screenshot worse. A fix is in progress.
+
+**The scoreboard barely moved, and that is expected.** 100/100 to 90/100 on fingerprint-scan, 38% to 31% on CreepJS. These numbers are dominated by signals we are not pretending about: real headless Chrome, a datacenter IP, no GPU. What changed is not the score on a detector page, it is that a real site watching its own DOM sees 99% less of us.
+
+That is the part no detector site was ever going to tell us, which is why we had to hook ten real sites and count.

--- a/src/content/blog/automation-leaks-are-not-just-the-webdriver-flag.md
+++ b/src/content/blog/automation-leaks-are-not-just-the-webdriver-flag.md
@@ -27,9 +27,9 @@ On [The Guardian](https://www.theguardian.com), a single viewport screenshot tri
 
 **TL;DR**
 
-- Nine PRs in [browserless](https://browserless.js.org) ([#920](https://github.com/microlinkhq/browserless/pull/920) through [#929](https://github.com/microlinkhq/browserless/pull/929), v13.9.15 to v13.9.21) moved our DOM work out of the page's JavaScript world.
+- Across v13.9.15 to v13.9.21, [browserless](https://browserless.js.org) moved its own DOM work out of the page's JavaScript world.
 - Page-visible automation calls across ten live sites dropped from **1,716,830 to 14,658**, a 99.1% reduction. Five of ten sites now sit at exactly zero, one of them with a caveat I flag below.
-- Three of those PRs were not about hiding at all. They fixed emulation bugs so bad that the detectors' own fingerprinting scripts were crashing partway through.
+- Some of that work was not about hiding at all. It fixed emulation bugs so bad that the detectors' own fingerprinting scripts were crashing partway through.
 - Screenshots come out pixel-identical, wall clock is unchanged, and DevTools protocol traffic went down, not up.
 
 ## Two worlds, one DOM
@@ -51,24 +51,18 @@ If the page patched `document.querySelectorAll`, the main world calls the patch.
 
 We were calling the patch. Everywhere.
 
-## Where we were standing in the page
+## What we were doing inside the page
 
-Six of the nine PRs are the same fix applied to a different caller. Each one was a helper that had a legitimate reason to touch the DOM and no reason at all to do it in public:
+Taking a screenshot is never just a screenshot. Before the shutter, a handful of helpers walk the DOM, and every one of them was doing it in public:
 
-| PR | What moved into an isolated world |
-| --- | --- |
-| [#920](https://github.com/microlinkhq/browserless/pull/920) | `browserless.text()` reading page text |
-| [#921](https://github.com/microlinkhq/browserless/pull/921) | shadow DOM flattening (`flattenShadowDOM`) |
-| [#924](https://github.com/microlinkhq/browserless/pull/924) | the `screenshot` page helpers |
-| [#925](https://github.com/microlinkhq/browserless/pull/925) | overlay dismissal |
-| [#926](https://github.com/microlinkhq/browserless/pull/926) | [autoconsent](https://github.com/duckduckgo/autoconsent) cookie-banner handling |
-| [#927](https://github.com/microlinkhq/browserless/pull/927) | Ghostery DOM scans (`extractFeatures`) |
+- **Handling cookie banners.** The clearest case. Consent dialogs have to be found, measured and clicked, which is exactly the shape of activity a bot detector watches for. This one helper accounts for most of the old volume.
+- **Blocking ads.** The ad-block engine scans the document to decide what to hide.
+- **Dismissing overlays.** Newsletter modals and paywall interstitials get scanned and closed the same way.
+- **Reading a page's text.** The helper behind text extraction was querying the page's own DOM to do it.
+- **Flattening shadow DOM.** Components hidden inside shadow roots get inlined so a screenshot captures them.
+- **Positioning the shot.** The screenshot helpers themselves measured elements through page APIs.
 
-The cookie-banner one is the clearest case. Handling consent dialogs means querying, reading computed styles, and clicking, which is exactly the shape of activity a bot detector is looking for. In `packages/goto/src/adblock.js` it is now one flag:
-
-```js
-isMainWorld: false
-```
+Each one had a legitimate reason to touch the DOM and no reason at all to do it where the page could watch. So each moved into an isolated world, one at a time, with the cookie-banner engine reduced to a single flag telling it to stop running in the main world.
 
 ## How we measured what a site can see
 
@@ -106,7 +100,7 @@ By API, summed over every site and mode:
 
 ## What the remaining 14,658 are
 
-Almost none of it is helper code. 14,517 of the 14,658 classify as `adblock/scriptlet`: [uBlock-style scriptlets](https://github.com/gorhill/uBlock/wiki/Resources-Library) shipped inside the ad-block engine's `engine.bin`, injected as page scripts against specific domains.
+Almost none of it is helper code. 14,517 of the 14,658 are [uBlock-style scriptlets](https://github.com/gorhill/uBlock/wiki/Resources-Library) shipped inside the ad-block engine's filter lists and injected as page scripts against specific domains.
 
 Those run in the main world on purpose. A scriptlet that neutralizes an anti-adblock check has to be *in* the page to do it, and it looks like the filter-list resource it is, not like automation. Bild and AliExpress are the heaviest filtered sites in the set, and they hold nearly all of the residue: 11,068 and 3,077 calls.
 
@@ -114,13 +108,13 @@ The last 141 the harness could not attribute to anyone, so they stay in an `othe
 
 ## The bugs we found by looking
 
-Three PRs had nothing to do with isolated worlds. They surfaced because once we started reading detector output carefully, the output was obviously broken.
+Three of the fixes had nothing to do with isolated worlds. They surfaced because once we started reading detector output carefully, the output was obviously broken.
 
-**[#922](https://github.com/microlinkhq/browserless/pull/922) stopped disabling standard Web APIs.** Our launch flags carried `--disable-notifications`, `--disable-speech-api`, and the `PushMessaging` and `WebPayments` feature switches. Those delete `Notification`, `speechSynthesis`, `webkitSpeechRecognition`, `PushManager` and `PaymentRequest` from every page. Stock Chrome exposes all five. Worse, `permissions.query('notifications')` still answered `prompt`, so a page could read the contradiction: permission to send notifications, no API to send them with.
+**We were deleting standard Web APIs.** Our launch flags stripped `Notification`, `speechSynthesis`, `webkitSpeechRecognition`, `PushManager` and `PaymentRequest` from every page. Stock Chrome exposes all five. Worse, `permissions.query('notifications')` still answered `prompt`, so a page could read the contradiction: permission to send notifications, no API to send them with.
 
-That missing API was not a subtle signal, it was fatal to the detectors themselves. On [bot.sannysoft.com](https://bot.sannysoft.com), the `fp-collect` section never rendered: **0 checks completed** before, 20 after. On [bot.incolumitas.com](https://bot.incolumitas.com), `fpscanner` returned **0 keys** before and 21 after. Their scripts were throwing partway through on a missing global, and a fingerprinting script that dies is itself an anomaly. We were failing tests by being too strange to test.
+That was not a subtle signal, it was fatal to the detectors themselves. On [bot.sannysoft.com](https://bot.sannysoft.com), the `fp-collect` section never rendered: **0 checks completed** before, 20 after. On [bot.incolumitas.com](https://bot.incolumitas.com), `fpscanner` returned **0 keys** before and 21 after. Their scripts were throwing partway through on a missing global, and a fingerprinting script that dies is itself an anomaly. We were failing tests by being too strange to test.
 
-**[#923](https://github.com/microlinkhq/browserless/pull/923) emulated a screen consistent with the viewport.** `window.innerWidth` reported 1280, while `screen.width` reported Chrome's headless default of 800x600. No desktop exists where the window is wider than the screen. The consequence was not only a fingerprint:
+**The screen was smaller than the window.** `window.innerWidth` reported 1280, while `screen.width` reported Chrome's headless default of 800x600. No desktop exists where the window is wider than the screen. The consequence was not only a fingerprint:
 
 ```js
 matchMedia('(max-device-width: 1024px)').matches
@@ -130,13 +124,7 @@ matchMedia('(max-device-width: 1024px)').matches
 
 Desktop pages were getting their tablet layout. `screen` now reads 1440x900 for the default device, and the screenshots come back pixel-identical, so the fix changed what sites decide and not what we render.
 
-**[#929](https://github.com/microlinkhq/browserless/pull/929) sent UA Client Hints matching the user agent.** We set a Chrome user agent string and then sent no `Sec-CH-UA` headers at all, and `navigator.userAgentData` came back empty. Modern Chrome always sends them.
-
-| Signal | Before | After |
-| --- | --- | --- |
-| `Sec-CH-UA` request header | absent | `"Google Chrome";v="149", …` |
-| `Sec-CH-UA-Mobile` / `-Platform` | absent | `?0` / `"macOS"` |
-| `navigator.userAgentData` | empty | Google Chrome 149 |
+**Client Hints were missing.** We set a Chrome user agent string and then sent no `Sec-CH-UA` headers at all, and `navigator.userAgentData` came back empty. Modern Chrome always sends them, so the combination was self-contradicting. Both now match the user agent we claim.
 
 Measured across those detectors, 3 runs per side, 36 runs, zero errors:
 
@@ -149,25 +137,17 @@ Measured across those detectors, 3 runs per side, 36 runs, zero errors:
 
 ## The cost
 
-Cheaper, which was not the plan. An element handle round trip is several protocol messages; one isolated-world `evaluate` is one. DevTools protocol commands per capture, median of five runs:
-
-| | viewport CDP commands | fullPage CDP commands |
-| --- | --- | --- |
-| theguardian.com | 645 → **162** (−74.9%) | 843 → 344 (−59.2%) |
-| cnn.com | 518 → **186** (−64.1%) | 1455 → 1299 (−10.7%) |
-| github.com | 322 → **209** (−35.1%) | 383 → 257 (−32.9%) |
+Cheaper, which was not the plan. An element handle round trip is several protocol messages; one isolated-world `evaluate` is one. Viewport screenshots now issue 35% to 75% fewer DevTools protocol commands (The Guardian: 645 down to 162), and fullPage between 11% and 59% fewer.
 
 Wall clock did not move: every timing landed between −3.8% and +0.7%, inside run-to-run noise. Resident memory moved between −0.2% and +4.8%, the top of that range being GitHub's fullPage capture. Titles, extracted text and cookie-banner outcomes stayed equivalent site by site.
 
 ## What still leaks
 
-Four things, none of them fixed by this work.
+**`Runtime.enable` is still detectable.** Rebrowser's check passes, but the general technique does not care: `Error.prepareStackTrace` and console timing still reveal that a debugger is attached. Closing that means patching `puppeteer-core` itself.
 
-**`Runtime.enable` is still detectable.** Rebrowser's check passes, but the general technique does not care: `Error.prepareStackTrace` and console timing still reveal that a debugger is attached. Closing that requires patching `puppeteer-core` itself, which was out of scope here.
+**Web Workers still say HeadlessChrome.** The page reports Chrome; spawn a worker and its `navigator.userAgent` reports `HeadlessChrome`. CreepJS flags exactly that, before and after.
 
-**Web Workers still say HeadlessChrome.** The page reports Chrome; spawn a worker and its `navigator.userAgent` reports `HeadlessChrome`. CreepJS flags exactly that, before and after. A fix is being investigated.
-
-**One real regression.** Re-enabling `Notification` in #922 means sites that gate a notification opt-in overlay on the API existing now render that overlay, and it lands in the screenshot. AliExpress does this. Being more honest about Chrome's API surface made us look more like Chrome and made one class of screenshot worse. A fix is in progress.
+**Notification overlays now show up in screenshots.** Restoring the `Notification` API means sites that gate a notification opt-in prompt on the API existing now render it, and it lands in the capture. AliExpress does this. Denying the permission does not help: the site reads the permission, sees `denied`, and renders its overlay anyway. The overlay was absent before only because the API was missing entirely, so the site's feature detection never ran and it never got as far as asking. Exposing the API is the right call for detection, and this is its visible cost.
 
 **The scoreboard barely moved, and that is expected.** 100/100 to 90/100 on fingerprint-scan, 38% to 31% on CreepJS. These numbers are dominated by signals we are not pretending about: real headless Chrome, a datacenter IP, no GPU. What changed is not the score on a detector page, it is that a real site watching its own DOM sees 99% less of us.
 


### PR DESCRIPTION
## What

A blog post on the anti-detection work that landed in [browserless](https://github.com/microlinkhq/browserless) between v13.9.15 and v13.9.21: nine PRs that moved our own DOM work out of the page's JavaScript world, plus the emulation bugs found along the way.

`src/content/blog/automation-leaks-are-not-just-the-webdriver-flag.md`

## Why it is worth a post

The interesting part is not `navigator.webdriver`. Until last week any site could patch `document.querySelectorAll` and watch us work: a single Guardian viewport screenshot tripped that hook 14,537 times, with stack frames naming `pptr:evaluate`, `extractFeatures` and `detectCmp`. Separately, our launch flags deleted five standard Web APIs, which made the detectors' own fingerprinting scripts crash partway through.

## Numbers in the post, all measured A/B with identical Chrome and puppeteer

| | before | after |
|---|---|---|
| page-visible automation calls, 10 live sites | 1,716,830 | 14,658 (−99.1%) |
| `getComputedStyle` / `classList` | 769,473 / 184,427 | 0 / 0 |
| sannysoft `fp-collect` checks completed | 0 | 20 |
| incolumitas `fpscanner` keys | 0 | 21 |
| `screen` | 800x600 | 1440x900 |
| `Sec-CH-UA` request headers | absent | present |
| DevTools commands per viewport screenshot (Guardian) | 645 | 162 |

The post also states the cost and what still leaks: `Runtime.enable` remains detectable, Web Workers still report `HeadlessChrome`, memory is up to 4.8% higher, and re-enabling the Notification API means some sites now render their own opt-in overlay in screenshots.

## Verification

Every headline figure was recomputed from the raw measurement artifacts before publishing, which corrected three numbers taken from my own summary: five of ten sites at zero (not six), the DevTools reduction split per capture path rather than one range, and memory as −0.2% to +4.8%. Two claims are footnoted rather than smoothed over: 141 of the remaining calls are not provably ad-block scriptlets, and one Stack Overflow zero came from a Cloudflare interstitial rather than the real page.

## Notes

- No cover image. Two recent posts (`webgl-without-a-gpu`, `faster-webgl-screenshots`) also have none, so this renders fine as-is. If you want one, it needs an asset under `static/images/`; before/after screenshots exist in the measurement artifacts.
- Frontmatter follows the newest post's field order, author key `kiko`.
- The `data/git-timestamps-*.json` lines come from the repo's own pre-commit hook, matching three of the last four post commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116zka7w2WKPSi3kqHyVAET

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and timestamp metadata only; no product logic, auth, or deployment behavior changes.
> 
> **Overview**
> Adds a new blog article at `automation-leaks-are-not-just-the-webdriver-flag.md` (**Isolated Worlds Hide Headless Work**), dated 2026-09-13, documenting browserless anti-detection work: moving pre-screenshot DOM helpers into Puppeteer isolated worlds, A/B measurement results, and related emulation fixes.
> 
> The pre-commit hook also registers the new file in `data/git-timestamps-created.json` and `data/git-timestamps-modified.json`. No application or browserless runtime code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc40d433816c1fbe95c68a1faa126b06823f6385. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the blog article with the title “Isolated Worlds Hide Headless Work.”
  - Added an introductory overview and TL;DR summary.
  - Reorganized sections to clarify goals, findings, and limitations.
  - Condensed technical methodology, measurement details, and supporting examples for a more focused presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->